### PR TITLE
SPV_AMD_shader_ballot: Extension spec update

### DIFF
--- a/extensions/AMD/SPV_AMD_shader_ballot.asciidoc
+++ b/extensions/AMD/SPV_AMD_shader_ballot.asciidoc
@@ -1,4 +1,4 @@
-SPIR-V Extension SPV_AMD_shader_ballot
+﻿SPIR-V Extension SPV_AMD_shader_ballot
 ======================================
 
 Name Strings
@@ -42,7 +42,7 @@ Revision:      6
 Dependencies
 ------------
 
-This extension is written against Revision 1 of the version 1.1 of the
+This extension is written against Revision 1 of the version 1.10 of the
 SPIR-V Specification.
 
 The extension is written against Revision 1 of the OpenGL extension
@@ -92,9 +92,17 @@ WriteInvocationAMD = 3
 MbcntAMD = 4
 ----
 
-To use the new core and extended instructions, declare:
+To use the new core instructions, declare:
 
 ---------------------------------------------------------------
+OpCapability Groups
+OpExtension "SPV_AMD_shader_ballot"
+---------------------------------------------------------------
+
+To use the new extended instructions, declare:
+
+---------------------------------------------------------------
+OpExtension "SPV_AMD_shader_ballot"
 OpExtInstImport %ext "SPV_AMD_shader_ballot"
 ---------------------------------------------------------------
 
@@ -465,11 +473,11 @@ MbcntAMD
 Returns the bit count of SubgroupLtMaskARB with <mask> as described below:
 
 ----
-%X = OpBitwiseAnd u64 %SubgroupLtMaskARB %mask
-<Result> = OpBitCount u64 %X
+%X = OpBitwiseAnd u32 %SubgroupLtMaskARB %mask
+<Result> = OpBitCount u32 %X
 ----
 
-Result Type and mask must be 64-bit unsigned integers.
+Result Type and mask must be 32-bit unsigned integers.
 
 ----
 4 | <id> mask
@@ -507,4 +515,5 @@ Revision History
 |4|August 11, 2016|Rex Xu|Add new core instructions to handle group operations placed with non-uniform control flow.
 |5|October 13, 2016|Dominik Witczak|Added missing numerical value assignments, removed extension number
 |6|March 28, 2018|Dominik Witczak|Generalized type restrictions for result types of group operation instructions to integer types. Added issue#1.
+|7|May 16, 2019|Dominik Witczak|Fixed an issue in the section describing how to use the new functionality. Fixed MbcntAMD's return type.
 |========================================

--- a/extensions/AMD/SPV_AMD_shader_ballot.html
+++ b/extensions/AMD/SPV_AMD_shader_ballot.html
@@ -809,7 +809,7 @@ Revision:      6</p></div>
 <div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension is written against Revision 1 of the version 1.1 of the
+<div class="paragraph"><p>This extension is written against Revision 1 of the version 1.10 of the
 SPIR-V Specification.</p></div>
 <div class="paragraph"><p>The extension is written against Revision 1 of the OpenGL extension
 AMD_shader_ballot.</p></div>
@@ -859,10 +859,17 @@ SwizzleInvocationsMaskedAMD = 2
 WriteInvocationAMD = 3
 MbcntAMD = 4</code></pre>
 </div></div>
-<div class="paragraph"><p>To use the new core and extended instructions, declare:</p></div>
+<div class="paragraph"><p>To use the new core instructions, declare:</p></div>
 <div class="listingblock">
 <div class="content">
-<pre><code>OpExtInstImport %ext "SPV_AMD_shader_ballot"</code></pre>
+<pre><code>OpCapability Groups
+OpExtension "SPV_AMD_shader_ballot"</code></pre>
+</div></div>
+<div class="paragraph"><p>To use the new extended instructions, declare:</p></div>
+<div class="listingblock">
+<div class="content">
+<pre><code>OpExtension "SPV_AMD_shader_ballot"
+OpExtInstImport %ext "SPV_AMD_shader_ballot"</code></pre>
 </div></div>
 </div>
 </div>
@@ -1147,10 +1154,10 @@ otherwise the result of the operation is undefined.</p></div>
 <div class="paragraph"><p>Returns the bit count of SubgroupLtMaskARB with &lt;mask&gt; as described below:</p></div>
 <div class="listingblock">
 <div class="content">
-<pre><code>%X = OpBitwiseAnd u64 %SubgroupLtMaskARB %mask
-&lt;Result&gt; = OpBitCount u64 %X</code></pre>
+<pre><code>%X = OpBitwiseAnd u32 %SubgroupLtMaskARB %mask
+&lt;Result&gt; = OpBitCount u32 %X</code></pre>
 </div></div>
-<div class="paragraph"><p>Result Type and mask must be 64-bit unsigned integers.</p></div>
+<div class="paragraph"><p>Result Type and mask must be 32-bit unsigned integers.</p></div>
 <div class="listingblock">
 <div class="content">
 <pre><code>4 | &lt;id&gt; mask</code></pre>
@@ -1233,6 +1240,12 @@ cellspacing="0" cellpadding="4">
 <td align="left" valign="top"><p class="table">Dominik Witczak</p></td>
 <td align="left" valign="top"><p class="table">Generalized type restrictions for result types of group operation instructions to integer types. Added issue#1.</p></td>
 </tr>
+<tr>
+<td align="left" valign="top"><p class="table">7</p></td>
+<td align="left" valign="top"><p class="table">May 16, 2019</p></td>
+<td align="left" valign="top"><p class="table">Dominik Witczak</p></td>
+<td align="left" valign="top"><p class="table">Fixed an issue in the section describing how to use the new functionality. Fixed MbcntAMD&#8217;s return type.</p></td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -1242,7 +1255,7 @@ cellspacing="0" cellpadding="4">
 <div id="footnotes"><hr /></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2018-03-29 11:35:30 Central European Daylight Time
+Last updated 2019-05-16 17:12:16 Central European Daylight Time
 </div>
 </div>
 </body>


### PR DESCRIPTION
Fixed an issue in the section describing how to use the new functionality. Fixed MbcntAMD's return type.