### PR TITLE
Update Intel FPGA memory attribute extension to rev D

### DIFF
--- a/extensions/INTEL/SPV_INTEL_fpga_memory_attributes.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_fpga_memory_attributes.asciidoc
@@ -30,7 +30,7 @@ Final draft
 [width="40%",cols="25,25"]
 |========================================
 | Last Modified Date | {docdate}
-| Revision           | C
+| Revision           | D
 |========================================
 
 == Dependencies
@@ -67,7 +67,7 @@ RegisterINTEL
 MemoryINTEL
 NumbanksINTEL
 BankwidthINTEL
-MaxconcurrencyINTEL
+MaxPrivateCopiesINTEL
 SinglepumpINTEL
 DoublepumpINTEL
 ----
@@ -84,7 +84,7 @@ DoublepumpINTEL
 |MemoryINTEL              |5826
 |NumbanksINTEL            |5827
 |BankwidthINTEL           |5828
-|MaxconcurrencyINTEL      |5829
+|MaxPrivateCopiesINTEL    |5829
 |SinglepumpINTEL          |5830
 |DoublepumpINTEL          |5831
 |==== 
@@ -115,10 +115,10 @@ _Banks_
 Apply to a variable or a structure-type member. Request, to the extent possible, that the variable or structure member should be implemented in a memory whose banks have the specified width in bytes.
 | *FPGAMemoryAttributesINTEL* | Literal Number +
 _Bank Width_
-| 5829 | *MaxconcurrencyINTEL* +
-Apply to a variable or a structure-type member. Request, to the extent possible, that the implementation allow no more than the specified number of threads or loop iterations to access the variable or structure-type member concurrently.  
+| 5829 | *MaxPrivateCopiesINTEL* +
+Apply to a variable or a structure-type member. Request, to the extent possible, that the memory synthesized for the variable or structure member should be copied no more than the specified number of times to enable concurrent thread or loop iteration accesses.
 | *FPGAMemoryAttributesINTEL* | Literal Number +
-_Maximum Concurrency_
+_Maximum Copies_
 | 5830 | *SinglepumpINTEL* +
 Apply to a variable or a structure-type member. Request, to the extent possible, that the variable or structure member should be implemented in a memory that is clocked at the same rate as accesses to it.
 | *FPGAMemoryAttributesINTEL* |
@@ -135,10 +135,7 @@ Modify Section 3.31, Capability, adding a row to the Capability table:
 [options="header"]
 |====
 2+^| Capability ^| Implicitly Declares
-| 5824 | FPGAMemoryAttributesINTEL | Reserved. +
-
-Also see extension: + 
-*SPV_INTEL_fpga_memory_attributes*
+| 5824 | FPGAMemoryAttributesINTEL |
 |====
 --
 
@@ -166,4 +163,5 @@ None.
 |A|2019-02-27|Joe Garvey|*Initial public release*
 |B|2019-03-18|Joe Garvey|Added MaxconcurrencyINTEL decoration.  Fixed NumbanksINTEL capitalization
 |C|2019-04-23|Joe Garvey|Added SinglepumpINTEL and DoublepumpINTEL decorations
+|D|2019-06-06|Joe Garvey|Changed the name of MaxconcurrencyINTEL to MaxPrivateCopiesINTEL
 |======================================== 

--- a/extensions/INTEL/SPV_INTEL_fpga_memory_attributes.html
+++ b/extensions/INTEL/SPV_INTEL_fpga_memory_attributes.html
@@ -499,11 +499,11 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2019-04-23</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2019-06-06</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">C</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">D</p></td>
 </tr>
 </tbody>
 </table>
@@ -567,7 +567,7 @@ Version 1.3 Revision 6.</p>
 MemoryINTEL
 NumbanksINTEL
 BankwidthINTEL
-MaxconcurrencyINTEL
+MaxPrivateCopiesINTEL
 SinglepumpINTEL
 DoublepumpINTEL</pre>
 </div>
@@ -606,7 +606,7 @@ DoublepumpINTEL</pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">5828</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">MaxconcurrencyINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">MaxPrivateCopiesINTEL</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">5829</p></td>
 </tr>
 <tr>
@@ -681,11 +681,11 @@ Apply to a variable or a structure-type member. Request, to the extent possible,
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">5829</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>MaxconcurrencyINTEL</strong><br>
-Apply to a variable or a structure-type member. Request, to the extent possible, that the implementation allow no more than the specified number of threads or loop iterations to access the variable or structure-type member concurrently.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>MaxPrivateCopiesINTEL</strong><br>
+Apply to a variable or a structure-type member. Request, to the extent possible, that the memory synthesized for the variable or structure member should be copied no more than the specified number of times to enable concurrent thread or loop iteration accesses.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>FPGAMemoryAttributesINTEL</strong></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Literal Number<br>
-<em>Maximum Concurrency</em></p></td>
+<em>Maximum Copies</em></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">5830</p></td>
@@ -729,9 +729,7 @@ Apply to a variable or a structure-type member. Request, to the extent possible,
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">5824</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">FPGAMemoryAttributesINTEL</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Reserved.<br></p>
-<p class="tableblock">Also see extension:<br>
-<strong>SPV_INTEL_fpga_memory_attributes</strong></p></td>
+<td class="tableblock halign-left valign-top"></td>
 </tr>
 </tbody>
 </table>
@@ -791,6 +789,12 @@ Apply to a variable or a structure-type member. Request, to the extent possible,
 <td class="tableblock halign-left valign-top"><p class="tableblock">Joe Garvey</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Added SinglepumpINTEL and DoublepumpINTEL decorations</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">D</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2019-06-06</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Joe Garvey</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Changed the name of MaxconcurrencyINTEL to MaxPrivateCopiesINTEL</p></td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -798,7 +802,7 @@ Apply to a variable or a structure-type member. Request, to the extent possible,
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-04-23 09:56:31 EDT
+Last updated 2019-06-06 13:31:00 EDT
 </div>
 </div>
 </body>


### PR DESCRIPTION
Update Intel FPGA memory attribute extension to rev D, updating a token name to match implementation.