### PR TITLE
Fix scope description

### DIFF
--- a/extensions/KHR/SPV_KHR_shader_clock.asciidoc
+++ b/extensions/KHR/SPV_KHR_shader_clock.asciidoc
@@ -33,8 +33,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2019-10-29
-| Revision           | 2
+| Last Modified Date | 2019-10-30
+| Revision           | 3
 |========================================
 
 Dependencies
@@ -134,11 +134,11 @@ two-components of 32-bit unsigned integer type with the first component
 containing the 32 least significant bits and the second component containing
 the 32 most significant bits.
 
-All invocations within the 'Execution' read from the same source clock.
-_Execution_ must be a valid execution scope.
+All invocations within the 'Scope' read from the same source clock.
+_Scope_ must be a valid _Scope <id>_ (Section 3.27).
 1+|Capability: +
 *ShaderClockKHR*
-| 4 | 5055 | '<id>' 'Result Type' | '<id>' 'Result' | 'Scope <id>' 'Execution'
+| 4 | 5055 | '<id>' 'Result Type' | '<id>' 'Result' | 'Scope <id>' 'Scope'
 |=====
 
 --
@@ -157,6 +157,9 @@ legal use of this extension:
 ----
 OpExtension "SPV_KHR_shader_clock"
 ----
+
+The 'Scope' operand of the *OpReadClockKHR* instruction must be a valid
+_Scope <id>_.
 
 Issues
 ------
@@ -186,4 +189,5 @@ Revision History
 |Rev|Date|Author|Changes
 |1 |2019-02-22 |Aaron Hagan|*Initial draft*
 |2 |2019-10-29 |Daniel Koch|Add Op prefix to new instruction, add links to GLSL specs
+|3 |2019-10-30 |Daniel Koch|SPIR-V/issues/511 (gitlab) - stop calling the scope "Execution Scope"
 |========================================

--- a/extensions/KHR/SPV_KHR_shader_clock.html
+++ b/extensions/KHR/SPV_KHR_shader_clock.html
@@ -852,11 +852,11 @@ width:40%;
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2019-10-29</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2019-10-30</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">3</p></td>
 </tr>
 </tbody>
 </table>
@@ -996,8 +996,8 @@ sampled values wrap around zero.</p>
 two-components of 32-bit unsigned integer type with the first component
 containing the 32 least significant bits and the second component containing
 the 32 most significant bits.</p>
-<p class="tableblock">All invocations within the <em>Execution</em> read from the same source clock.
-<em>Execution</em> must be a valid execution scope.</p></td>
+<p class="tableblock">All invocations within the <em>Scope</em> read from the same source clock.
+<em>Scope</em> must be a valid <em>Scope &lt;id&gt;</em> (Section 3.27).</p></td>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
 <strong>ShaderClockKHR</strong></p></td>
 </tr>
@@ -1006,7 +1006,7 @@ the 32 most significant bits.</p>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">5055</p></td>
 <td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Result Type</em></p></td>
 <td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Result</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Scope &lt;id&gt;</em> <em>Execution</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Scope &lt;id&gt;</em> <em>Scope</em></p></td>
 </tr>
 </tbody>
 </table>
@@ -1034,6 +1034,8 @@ legal use of this extension:</p></div>
 <div class="content monospaced">
 <pre>OpExtension "SPV_KHR_shader_clock"</pre>
 </div></div>
+<div class="paragraph"><p>The <em>Scope</em> operand of the <strong>OpReadClockKHR</strong> instruction must be a valid
+<em>Scope &lt;id&gt;</em>.</p></div>
 </div>
 </div>
 <div class="sect1">
@@ -1096,6 +1098,12 @@ width:100%;
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Daniel Koch</p></td>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Add Op prefix to new instruction, add links to GLSL specs</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">3</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2019-10-30</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Daniel Koch</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">SPIR-V/issues/511 (gitlab) - stop calling the scope "Execution Scope"</p></td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -1104,7 +1112,7 @@ width:100%;
 <div id="footnotes"><hr></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2019-10-29 15:16:06 EDT
+Last updated 2019-10-30 13:04:31 EDT
 </div>
 </div>
 </body>


### PR DESCRIPTION
spir-v issue 511 (gitlab)

Stop referring to it as an execution scope, since 'Device' 
scope is not actually an execution scope.