### PR TITLE
SPV_EXT_shader_atomic_float_add clarify result type is scalar

### DIFF
--- a/extensions/EXT/SPV_EXT_shader_atomic_float_add.asciidoc
+++ b/extensions/EXT/SPV_EXT_shader_atomic_float_add.asciidoc
@@ -36,8 +36,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2020-07-15
-| Revision           | 1
+| Last Modified Date | 2021-03-17
+| Revision           | 2
 |========================================
 
 Dependencies
@@ -106,7 +106,7 @@ Perform the following steps atomically with respect to any other atomic accesses
 
 The instruction's result is the _Original Value_. +
 
-_Result Type_ must be a _floating-point type_. +
+_Result Type_ must be a _floating-point type_ scalar. +
 
 The type of _Value_ must be the same as _Result Type_. The type of the value pointed to by _Pointer_ must be the same as _Result Type_. +
 
@@ -156,5 +156,6 @@ Revision History
 |========================================
 |Rev|Date|Author|Changes
 |1 |2020-07-15 |Vikram Kushwaha|Internal revisions
+|2 |2021-03-17 |Spencer Fricke |Clarify result type is scalar
 |========================================
 

--- a/extensions/EXT/SPV_EXT_shader_atomic_float_add.html
+++ b/extensions/EXT/SPV_EXT_shader_atomic_float_add.html
@@ -862,11 +862,11 @@ width:40%;
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2020-07-15</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2021-03-17</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
 </tr>
 </tbody>
 </table>
@@ -964,7 +964,7 @@ Perform the following steps atomically with respect to any other atomic accesses
 <p class="tableblock">2) get a <em>New Value</em> by float addition of <em>Original Value</em> and <em>Value</em>, and<br></p>
 <p class="tableblock">3) store the <em>New Value</em> back through <em>Pointer</em>.<br></p>
 <p class="tableblock">The instruction&#8217;s result is the <em>Original Value</em>.<br></p>
-<p class="tableblock"><em>Result Type</em> must be a <em>floating-point type</em>.<br></p>
+<p class="tableblock"><em>Result Type</em> must be a <em>floating-point type</em> scalar.<br></p>
 <p class="tableblock">The type of <em>Value</em> must be the same as <em>Result Type</em>. The type of the value pointed to by <em>Pointer</em> must be the same as <em>Result Type</em>.<br></p>
 <p class="tableblock"><em>Memory</em> must be a valid memory <em>Scope</em>.</p></td>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
@@ -1056,6 +1056,12 @@ width:100%;
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Vikram Kushwaha</p></td>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Internal revisions</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2021-03-17</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Spencer Fricke</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Clarify result type is scalar</p></td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -1064,7 +1070,7 @@ width:100%;
 <div id="footnotes"><hr></div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2020-07-20 08:36:19 PDT
+Last updated 2021-03-17 12:00:00 PDT
 </div>
 </div>
 </body>


### PR DESCRIPTION
This assumption was made in `spirv-val` and wanted to clarify
https://github.com/KhronosGroup/SPIRV-Tools/commit/f2a19b0150b987618dc5d3326ddb8854d7451137#diff-38fd3032d90cb56b9e25b2b4141235b736de1ad8efc70d02dabf2be8adaf0117R144