### PR TITLE
Update DebugEntryPoint to refer to a DebugFunction

### DIFF
--- a/nonsemantic/NonSemantic.Shader.DebugInfo.100.asciidoc
+++ b/nonsemantic/NonSemantic.Shader.DebugInfo.100.asciidoc
@@ -54,8 +54,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2021-07-27
-| Revision           | 8
+| Last Modified Date | 2022-02-28
+| Revision           | 9
 |========================================
 
 Dependencies
@@ -547,7 +547,10 @@ Compilation Unit
  +
  {result_type} +
  +
- 'Entry Point' is the '<id>' of the *OpEntryPoint* being described. +
+ 'Entry Point' is the '<id>' of the <<DebugFunction,*DebugFunction*>> corresponding
+  to the *OpFunction* referenced in the *OpEntryPoint*. This function must also have
+  a <<DebugFunctionDefinition,*DebugFunctionDefinition*>> in the first basic block
+  of that *OpFunction*. +
  +
  'Compilation Unit' is the '<id>' of the <<DebugCompilationUnit,*DebugCompilationUnit*>>
   that produced the entry point. +
@@ -1833,5 +1836,7 @@ Revision History
 |1.00 Rev 7  |2021-07-01|Baldur Karlsson    |Clarify runtime array sizing.
 |1.00 Rev 8  |2021-07-27|Baldur Karlsson    |Clarify that *DebugFunctionDefinition* can be in +
                                              basic blocks.
+|1.00 Rev 9  |2022-02-28|Baldur Karlsson    |Clarify that *DebugEntryPoint* refers to a
+                                             *DebugFunction*, not an *OpEntryPoint*.
 |========================================================
 

--- a/nonsemantic/NonSemantic.Shader.DebugInfo.100.html
+++ b/nonsemantic/NonSemantic.Shader.DebugInfo.100.html
@@ -897,11 +897,11 @@ width:40%;
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2021-07-27</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2022-02-28</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">8</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">9</p></td>
 </tr>
 </tbody>
 </table>
@@ -1939,7 +1939,10 @@ width:100%;
 <br>
  <em>Result Type</em> must be <strong>OpTypeVoid</strong>.<br>
 <br>
- <em>Entry Point</em> is the <em>&lt;id&gt;</em> of the <strong>OpEntryPoint</strong> being described.<br>
+ <em>Entry Point</em> is the <em>&lt;id&gt;</em> of the <a href="#DebugFunction"><strong>DebugFunction</strong></a> corresponding
+  to the <strong>OpFunction</strong> referenced in the <strong>OpEntryPoint</strong>. This function must also have
+  a <a href="#DebugFunctionDefinition"><strong>DebugFunctionDefinition</strong></a> in the first basic block
+  of that <strong>OpFunction</strong>.<br>
 <br>
  <em>Compilation Unit</em> is the <em>&lt;id&gt;</em> of the <a href="#DebugCompilationUnit"><strong>DebugCompilationUnit</strong></a>
   that produced the entry point.<br>
@@ -4057,6 +4060,13 @@ width:100%;
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Clarify that <strong>DebugFunctionDefinition</strong> can be in<br>
                                              basic blocks.</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">1.00 Rev 9</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2022-02-28</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Baldur Karlsson</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Clarify that <strong>DebugEntryPoint</strong> refers to a
+                                             <strong>DebugFunction</strong>, not an <strong>OpEntryPoint</strong>.</p></td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -4066,7 +4076,7 @@ width:100%;
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2021-07-27 15:41:09 GMT
+ 2022-02-28 12:41:22 IST
 </div>
 </div>
 </body>


### PR DESCRIPTION
Since `OpEntryPoint` has no result ID, `DebugEntryPoint` can't refer to it that way.

This commit updates the text to instead require that the function referenced in `OpEntryPoint` has a corresponding `DebugFunction` (with matching `DebugFunctionDefinition` in the function's first basic block) and reference it that way. That way the `DebugEntryPoint` for an `OpEntryPoint` can still be found via the referenced `OpFunction`.

This commit closes KhronosGroup/SPIRV-Registry#133.