### PR TITLE
update the HTML spec for SPV_KHR_uniform_group_instructions

### DIFF
--- a/extensions/KHR/SPV_KHR_uniform_group_instructions.html
+++ b/extensions/KHR/SPV_KHR_uniform_group_instructions.html
@@ -1,87 +1,864 @@
-<html><head><link rel="stylesheet" id="asciidoctor-browser-font-awesome-style" href="chrome-extension://iaalpfgpbocpdfblpnhhgllgbdbchmia/css/font-awesome.min.css"><link rel="stylesheet" id="asciidoctor-browser-style" href="chrome-extension://iaalpfgpbocpdfblpnhhgllgbdbchmia/css/themes/asciidoctor.css"><link rel="stylesheet" id="asciidoctor-browser-github-highlight-style" href="chrome-extension://iaalpfgpbocpdfblpnhhgllgbdbchmia/css/highlight/github.css"><link rel="stylesheet" id="asciidoctor-browser-chartist-style" href="chrome-extension://iaalpfgpbocpdfblpnhhgllgbdbchmia/css/chartist.min.css"><style type="text/css" id="asciidoctor-browser-chartist-default-style">.ct-chart .ct-series.ct-series-a .ct-line {stroke:#8EB33B} .ct-chart .ct-series.ct-series-b .ct-line {stroke:#72B3CC} .ct-chart .ct-series.ct-series-a .ct-point {stroke:#8EB33B} .ct-chart .ct-series.ct-series-b .ct-point {stroke:#72B3CC}</style><title>SPV_KHR_uniform_group_instructions</title><meta name="viewport" content="width=device-width, initial-scale=1.0"></head><body class="article"><div id="content"><h1>SPV_KHR_uniform_group_instructions</h1>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta name="generator" content="AsciiDoc 9.0.0rc1">
+<title>SPV_KHR_uniform_group_instructions</title>
+<style type="text/css">
+/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
+
+/* Default font. */
+body {
+  font-family: Georgia,serif;
+}
+
+/* Title font. */
+h1, h2, h3, h4, h5, h6,
+div.title, caption.title,
+thead, p.table.header,
+#toctitle,
+#author, #revnumber, #revdate, #revremark,
+#footer {
+  font-family: Arial,Helvetica,sans-serif;
+}
+
+body {
+  margin: 1em 5% 1em 5%;
+}
+
+a {
+  color: blue;
+  text-decoration: underline;
+}
+a:visited {
+  color: fuchsia;
+}
+
+em {
+  font-style: italic;
+  color: navy;
+}
+
+strong {
+  font-weight: bold;
+  color: #083194;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #527bbd;
+  margin-top: 1.2em;
+  margin-bottom: 0.5em;
+  line-height: 1.3;
+}
+
+h1, h2, h3 {
+  border-bottom: 2px solid silver;
+}
+h2 {
+  padding-top: 0.5em;
+}
+h3 {
+  float: left;
+}
+h3 + * {
+  clear: left;
+}
+h5 {
+  font-size: 1.0em;
+}
+
+div.sectionbody {
+  margin-left: 0;
+}
+
+hr {
+  border: 1px solid silver;
+}
+
+p {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+ul, ol, li > p {
+  margin-top: 0;
+}
+ul > li     { color: #aaa; }
+ul > li > * { color: black; }
+
+.monospaced, code, pre {
+  font-family: "Courier New", Courier, monospace;
+  font-size: inherit;
+  color: navy;
+  padding: 0;
+  margin: 0;
+}
+pre {
+  white-space: pre-wrap;
+}
+
+#author {
+  color: #527bbd;
+  font-weight: bold;
+  font-size: 1.1em;
+}
+#email {
+}
+#revnumber, #revdate, #revremark {
+}
+
+#footer {
+  font-size: small;
+  border-top: 2px solid silver;
+  padding-top: 0.5em;
+  margin-top: 4.0em;
+}
+#footer-text {
+  float: left;
+  padding-bottom: 0.5em;
+}
+#footer-badges {
+  float: right;
+  padding-bottom: 0.5em;
+}
+
+#preamble {
+  margin-top: 1.5em;
+  margin-bottom: 1.5em;
+}
+div.imageblock, div.exampleblock, div.verseblock,
+div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
+div.admonitionblock {
+  margin-top: 1.0em;
+  margin-bottom: 1.5em;
+}
+div.admonitionblock {
+  margin-top: 2.0em;
+  margin-bottom: 2.0em;
+  margin-right: 10%;
+  color: #606060;
+}
+
+div.content { /* Block element content. */
+  padding: 0;
+}
+
+/* Block element titles. */
+div.title, caption.title {
+  color: #527bbd;
+  font-weight: bold;
+  text-align: left;
+  margin-top: 1.0em;
+  margin-bottom: 0.5em;
+}
+div.title + * {
+  margin-top: 0;
+}
+
+td div.title:first-child {
+  margin-top: 0.0em;
+}
+div.content div.title:first-child {
+  margin-top: 0.0em;
+}
+div.content + div.title {
+  margin-top: 0.0em;
+}
+
+div.sidebarblock > div.content {
+  background: #ffffee;
+  border: 1px solid #dddddd;
+  border-left: 4px solid #f0f0f0;
+  padding: 0.5em;
+}
+
+div.listingblock > div.content {
+  border: 1px solid #dddddd;
+  border-left: 5px solid #f0f0f0;
+  background: #f8f8f8;
+  padding: 0.5em;
+}
+
+div.quoteblock, div.verseblock {
+  padding-left: 1.0em;
+  margin-left: 1.0em;
+  margin-right: 10%;
+  border-left: 5px solid #f0f0f0;
+  color: #888;
+}
+
+div.quoteblock > div.attribution {
+  padding-top: 0.5em;
+  text-align: right;
+}
+
+div.verseblock > pre.content {
+  font-family: inherit;
+  font-size: inherit;
+}
+div.verseblock > div.attribution {
+  padding-top: 0.75em;
+  text-align: left;
+}
+/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
+div.verseblock + div.attribution {
+  text-align: left;
+}
+
+div.admonitionblock .icon {
+  vertical-align: top;
+  font-size: 1.1em;
+  font-weight: bold;
+  text-decoration: underline;
+  color: #527bbd;
+  padding-right: 0.5em;
+}
+div.admonitionblock td.content {
+  padding-left: 0.5em;
+  border-left: 3px solid #dddddd;
+}
+
+div.exampleblock > div.content {
+  border-left: 3px solid #dddddd;
+  padding-left: 0.5em;
+}
+
+div.imageblock div.content { padding-left: 0; }
+span.image img { border-style: none; vertical-align: text-bottom; }
+a.image:visited { color: white; }
+
+dl {
+  margin-top: 0.8em;
+  margin-bottom: 0.8em;
+}
+dt {
+  margin-top: 0.5em;
+  margin-bottom: 0;
+  font-style: normal;
+  color: navy;
+}
+dd > *:first-child {
+  margin-top: 0.1em;
+}
+
+ul, ol {
+    list-style-position: outside;
+}
+ol.arabic {
+  list-style-type: decimal;
+}
+ol.loweralpha {
+  list-style-type: lower-alpha;
+}
+ol.upperalpha {
+  list-style-type: upper-alpha;
+}
+ol.lowerroman {
+  list-style-type: lower-roman;
+}
+ol.upperroman {
+  list-style-type: upper-roman;
+}
+
+div.compact ul, div.compact ol,
+div.compact p, div.compact p,
+div.compact div, div.compact div {
+  margin-top: 0.1em;
+  margin-bottom: 0.1em;
+}
+
+tfoot {
+  font-weight: bold;
+}
+td > div.verse {
+  white-space: pre;
+}
+
+div.hdlist {
+  margin-top: 0.8em;
+  margin-bottom: 0.8em;
+}
+div.hdlist tr {
+  padding-bottom: 15px;
+}
+dt.hdlist1.strong, td.hdlist1.strong {
+  font-weight: bold;
+}
+td.hdlist1 {
+  vertical-align: top;
+  font-style: normal;
+  padding-right: 0.8em;
+  color: navy;
+}
+td.hdlist2 {
+  vertical-align: top;
+}
+div.hdlist.compact tr {
+  margin: 0;
+  padding-bottom: 0;
+}
+
+.comment {
+  background: yellow;
+}
+
+.footnote, .footnoteref {
+  font-size: 0.8em;
+}
+
+span.footnote, span.footnoteref {
+  vertical-align: super;
+}
+
+#footnotes {
+  margin: 20px 0 20px 0;
+  padding: 7px 0 0 0;
+}
+
+#footnotes div.footnote {
+  margin: 0 0 5px 0;
+}
+
+#footnotes hr {
+  border: none;
+  border-top: 1px solid silver;
+  height: 1px;
+  text-align: left;
+  margin-left: 0;
+  width: 20%;
+  min-width: 100px;
+}
+
+div.colist td {
+  padding-right: 0.5em;
+  padding-bottom: 0.3em;
+  vertical-align: top;
+}
+div.colist td img {
+  margin-top: 0.3em;
+}
+
+@media print {
+  #footer-badges { display: none; }
+}
+
+#toc {
+  margin-bottom: 2.5em;
+}
+
+#toctitle {
+  color: #527bbd;
+  font-size: 1.1em;
+  font-weight: bold;
+  margin-top: 1.0em;
+  margin-bottom: 0.1em;
+}
+
+div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+div.toclevel2 {
+  margin-left: 2em;
+  font-size: 0.9em;
+}
+div.toclevel3 {
+  margin-left: 4em;
+  font-size: 0.9em;
+}
+div.toclevel4 {
+  margin-left: 6em;
+  font-size: 0.9em;
+}
+
+span.aqua { color: aqua; }
+span.black { color: black; }
+span.blue { color: blue; }
+span.fuchsia { color: fuchsia; }
+span.gray { color: gray; }
+span.green { color: green; }
+span.lime { color: lime; }
+span.maroon { color: maroon; }
+span.navy { color: navy; }
+span.olive { color: olive; }
+span.purple { color: purple; }
+span.red { color: red; }
+span.silver { color: silver; }
+span.teal { color: teal; }
+span.white { color: white; }
+span.yellow { color: yellow; }
+
+span.aqua-background { background: aqua; }
+span.black-background { background: black; }
+span.blue-background { background: blue; }
+span.fuchsia-background { background: fuchsia; }
+span.gray-background { background: gray; }
+span.green-background { background: green; }
+span.lime-background { background: lime; }
+span.maroon-background { background: maroon; }
+span.navy-background { background: navy; }
+span.olive-background { background: olive; }
+span.purple-background { background: purple; }
+span.red-background { background: red; }
+span.silver-background { background: silver; }
+span.teal-background { background: teal; }
+span.white-background { background: white; }
+span.yellow-background { background: yellow; }
+
+span.big { font-size: 2em; }
+span.small { font-size: 0.6em; }
+
+span.underline { text-decoration: underline; }
+span.overline { text-decoration: overline; }
+span.line-through { text-decoration: line-through; }
+
+div.unbreakable { page-break-inside: avoid; }
+
+
+/*
+ * xhtml11 specific
+ *
+ * */
+
+div.tableblock {
+  margin-top: 1.0em;
+  margin-bottom: 1.5em;
+}
+div.tableblock > table {
+  border: 3px solid #527bbd;
+}
+thead, p.table.header {
+  font-weight: bold;
+  color: #527bbd;
+}
+p.table {
+  margin-top: 0;
+}
+/* Because the table frame attribute is overridden by CSS in most browsers. */
+div.tableblock > table[frame="void"] {
+  border-style: none;
+}
+div.tableblock > table[frame="hsides"] {
+  border-left-style: none;
+  border-right-style: none;
+}
+div.tableblock > table[frame="vsides"] {
+  border-top-style: none;
+  border-bottom-style: none;
+}
+
+
+/*
+ * html5 specific
+ *
+ * */
+
+table.tableblock {
+  margin-top: 1.0em;
+  margin-bottom: 1.5em;
+}
+thead, p.tableblock.header {
+  font-weight: bold;
+  color: #527bbd;
+}
+p.tableblock {
+  margin-top: 0;
+}
+table.tableblock {
+  border-width: 3px;
+  border-spacing: 0px;
+  border-style: solid;
+  border-color: #527bbd;
+  border-collapse: collapse;
+}
+th.tableblock, td.tableblock {
+  border-width: 1px;
+  padding: 4px;
+  border-style: solid;
+  border-color: #527bbd;
+}
+
+table.tableblock.frame-topbot {
+  border-left-style: hidden;
+  border-right-style: hidden;
+}
+table.tableblock.frame-sides {
+  border-top-style: hidden;
+  border-bottom-style: hidden;
+}
+table.tableblock.frame-none {
+  border-style: hidden;
+}
+
+th.tableblock.halign-left, td.tableblock.halign-left {
+  text-align: left;
+}
+th.tableblock.halign-center, td.tableblock.halign-center {
+  text-align: center;
+}
+th.tableblock.halign-right, td.tableblock.halign-right {
+  text-align: right;
+}
+
+th.tableblock.valign-top, td.tableblock.valign-top {
+  vertical-align: top;
+}
+th.tableblock.valign-middle, td.tableblock.valign-middle {
+  vertical-align: middle;
+}
+th.tableblock.valign-bottom, td.tableblock.valign-bottom {
+  vertical-align: bottom;
+}
+
+
+/*
+ * manpage specific
+ *
+ * */
+
+body.manpage h1 {
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+  border-top: 2px solid silver;
+  border-bottom: 2px solid silver;
+}
+body.manpage h2 {
+  border-style: none;
+}
+body.manpage div.sectionbody {
+  margin-left: 3em;
+}
+
+@media print {
+  body.manpage div#toc { display: none; }
+}
+
+
+@media screen {
+  body {
+    max-width: 50em; /* approximately 80 characters wide */
+    margin-left: 16em;
+  }
+
+  #toc {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 13em;
+    padding: 0.5em;
+    padding-bottom: 1.5em;
+    margin: 0;
+    overflow: auto;
+    border-right: 3px solid #f8f8f8;
+    background-color: white;
+  }
+
+  #toc .toclevel1 {
+    margin-top: 0.5em;
+  }
+
+  #toc .toclevel2 {
+    margin-top: 0.25em;
+    display: list-item;
+    color: #aaaaaa;
+  }
+
+  #toctitle {
+    margin-top: 0.5em;
+  }
+}
+</style>
+<script type="text/javascript">
+/*<![CDATA[*/
+var asciidoc = {  // Namespace.
+
+/////////////////////////////////////////////////////////////////////
+// Table Of Contents generator
+/////////////////////////////////////////////////////////////////////
+
+/* Author: Mihai Bazon, September 2002
+ * http://students.infoiasi.ro/~mishoo
+ *
+ * Table Of Content generator
+ * Version: 0.4
+ *
+ * Feel free to use this script under the terms of the GNU General Public
+ * License, as long as you do not remove or alter this notice.
+ */
+
+ /* modified by Troy D. Hanson, September 2006. License: GPL */
+ /* modified by Stuart Rackham, 2006, 2009. License: GPL */
+
+// toclevels = 1..4.
+toc: function (toclevels) {
+
+  function getText(el) {
+    var text = "";
+    for (var i = el.firstChild; i != null; i = i.nextSibling) {
+      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
+        text += i.data;
+      else if (i.firstChild != null)
+        text += getText(i);
+    }
+    return text;
+  }
+
+  function TocEntry(el, text, toclevel) {
+    this.element = el;
+    this.text = text;
+    this.toclevel = toclevel;
+  }
+
+  function tocEntries(el, toclevels) {
+    var result = new Array;
+    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
+    // Function that scans the DOM tree for header elements (the DOM2
+    // nodeIterator API would be a better technique but not supported by all
+    // browsers).
+    var iterate = function (el) {
+      for (var i = el.firstChild; i != null; i = i.nextSibling) {
+        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
+          var mo = re.exec(i.tagName);
+          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
+            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
+          }
+          iterate(i);
+        }
+      }
+    }
+    iterate(el);
+    return result;
+  }
+
+  var toc = document.getElementById("toc");
+  if (!toc) {
+    return;
+  }
+
+  // Delete existing TOC entries in case we're reloading the TOC.
+  var tocEntriesToRemove = [];
+  var i;
+  for (i = 0; i < toc.childNodes.length; i++) {
+    var entry = toc.childNodes[i];
+    if (entry.nodeName.toLowerCase() == 'div'
+     && entry.getAttribute("class")
+     && entry.getAttribute("class").match(/^toclevel/))
+      tocEntriesToRemove.push(entry);
+  }
+  for (i = 0; i < tocEntriesToRemove.length; i++) {
+    toc.removeChild(tocEntriesToRemove[i]);
+  }
+
+  // Rebuild TOC entries.
+  var entries = tocEntries(document.getElementById("content"), toclevels);
+  for (var i = 0; i < entries.length; ++i) {
+    var entry = entries[i];
+    if (entry.element.id == "")
+      entry.element.id = "_toc_" + i;
+    var a = document.createElement("a");
+    a.href = "#" + entry.element.id;
+    a.appendChild(document.createTextNode(entry.text));
+    var div = document.createElement("div");
+    div.appendChild(a);
+    div.className = "toclevel" + entry.toclevel;
+    toc.appendChild(div);
+  }
+  if (entries.length == 0)
+    toc.parentNode.removeChild(toc);
+},
+
+
+/////////////////////////////////////////////////////////////////////
+// Footnotes generator
+/////////////////////////////////////////////////////////////////////
+
+/* Based on footnote generation code from:
+ * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
+ */
+
+footnotes: function () {
+  // Delete existing footnote entries in case we're reloading the footnodes.
+  var i;
+  var noteholder = document.getElementById("footnotes");
+  if (!noteholder) {
+    return;
+  }
+  var entriesToRemove = [];
+  for (i = 0; i < noteholder.childNodes.length; i++) {
+    var entry = noteholder.childNodes[i];
+    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
+      entriesToRemove.push(entry);
+  }
+  for (i = 0; i < entriesToRemove.length; i++) {
+    noteholder.removeChild(entriesToRemove[i]);
+  }
+
+  // Rebuild footnote entries.
+  var cont = document.getElementById("content");
+  var spans = cont.getElementsByTagName("span");
+  var refs = {};
+  var n = 0;
+  for (i=0; i<spans.length; i++) {
+    if (spans[i].className == "footnote") {
+      n++;
+      var note = spans[i].getAttribute("data-note");
+      if (!note) {
+        // Use [\s\S] in place of . so multi-line matches work.
+        // Because JavaScript has no s (dotall) regex flag.
+        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
+        spans[i].innerHTML =
+          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
+          "' title='View footnote' class='footnote'>" + n + "</a>]";
+        spans[i].setAttribute("data-note", note);
+      }
+      noteholder.innerHTML +=
+        "<div class='footnote' id='_footnote_" + n + "'>" +
+        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
+        n + "</a>. " + note + "</div>";
+      var id =spans[i].getAttribute("id");
+      if (id != null) refs["#"+id] = n;
+    }
+  }
+  if (n == 0)
+    noteholder.parentNode.removeChild(noteholder);
+  else {
+    // Process footnoterefs.
+    for (i=0; i<spans.length; i++) {
+      if (spans[i].className == "footnoteref") {
+        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
+        href = href.match(/#.*/)[0];  // Because IE return full URL.
+        n = refs[href];
+        spans[i].innerHTML =
+          "[<a href='#_footnote_" + n +
+          "' title='View footnote' class='footnote'>" + n + "</a>]";
+      }
+    }
+  }
+},
+
+install: function(toclevels) {
+  var timerId;
+
+  function reinstall() {
+    asciidoc.footnotes();
+    if (toclevels) {
+      asciidoc.toc(toclevels);
+    }
+  }
+
+  function reinstallAndRemoveTimer() {
+    clearInterval(timerId);
+    reinstall();
+  }
+
+  timerId = setInterval(reinstall, 500);
+  if (document.addEventListener)
+    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
+  else
+    window.onload = reinstallAndRemoveTimer;
+}
+
+}
+asciidoc.install(1);
+/*]]>*/
+</script>
+</head>
+<body class="article">
+<div id="header">
+<h1>SPV_KHR_uniform_group_instructions</h1>
+<div id="toc">
+  <div id="toctitle">Table of Contents</div>
+  <noscript><p><b>JavaScript must be enabled in your browser to display the table of contents.</b></p></noscript>
+</div>
+</div>
+<div id="content">
 <div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph">
-<p>SPV_KHR_uniform_group_instructions</p>
-</div>
+<div class="paragraph"><p>SPV_KHR_uniform_group_instructions</p></div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph">
-<p>To report problems with this extension, please open a new issue at:</p>
-</div>
-<div class="paragraph">
-<p><a href="https://github.com/KhronosGroup/SPIRV-Registry" class="bare">https://github.com/KhronosGroup/SPIRV-Registry</a></p>
-</div>
+<div class="paragraph"><p>To report problems with this extension, please open a new issue at:</p></div>
+<div class="paragraph"><p><a href="https://github.com/KhronosGroup/SPIRV-Registry">https://github.com/KhronosGroup/SPIRV-Registry</a></p></div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="ulist">
-<ul>
+<div class="ulist"><ul>
 <li>
-<p>Dmitry Sidorov, Intel<br></p>
+<p>
+Dmitry Sidorov, Intel<br>
+</p>
 </li>
 <li>
-<p>Alexey Sotkin, Intel<br></p>
+<p>
+Alexey Sotkin, Intel<br>
+</p>
 </li>
 <li>
-<p>John Pennycook, Intel<br></p>
+<p>
+John Pennycook, Intel<br>
+</p>
 </li>
 <li>
-<p>Ben Ashbaugh, Intel<br></p>
+<p>
+Ben Ashbaugh, Intel<br>
+</p>
 </li>
-</ul>
-</div>
+</ul></div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph">
-<p>Copyright (c) 2021 The Khronos Group Inc. Copyright terms at
-<a href="http://www.khronos.org/registry/speccopyright.html" class="bare">http://www.khronos.org/registry/speccopyright.html</a></p>
-</div>
+<div class="paragraph"><p>Copyright (c) 2022 The Khronos Group Inc. Copyright terms at
+<a href="http://www.khronos.org/registry/speccopyright.html">http://www.khronos.org/registry/speccopyright.html</a></p></div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="ulist">
-<ul>
+<div class="ulist"><ul>
 <li>
-<p>Working Draft</p>
+<p>
+Complete
+</p>
 </li>
 <li>
-<p>Not Yet Approved by the SPIR-V Working Group: (To become approved, with an approval date here, e.g. 2018-01-30)</p>
+<p>
+Approved by the SPIR-V Working Group: 2021-12-08
+</p>
 </li>
 <li>
-<p>Not Yet Approved by the Khronos Board of Promoters: (To become approved, with an approval date, e.g. 2018-01-30)</p>
+<p>
+Approved by the Khronos Board of Promoters: 2022-01-21
+</p>
 </li>
-</ul>
-</div>
+</ul></div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
+<table class="tableblock frame-all grid-all"
+style="
+width:40%;
+">
+<col style="width:50%;">
+<col style="width:50%;">
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2021-12-08</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Last Modified Date</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2022-05-03</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">B</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Revision</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
 </tr>
 </tbody>
 </table>
@@ -90,36 +867,27 @@
 <div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph">
-<p>This extension is written against the SPIR-V Specification,
-Version 1.5, Revision 5, Unified.</p>
-</div>
-<div class="paragraph">
-<p>This extension requires SPIR-V 1.0.</p>
-</div>
+<div class="paragraph"><p>This extension is written against the SPIR-V Specification,
+Version 1.5, Revision 5, Unified.</p></div>
+<div class="paragraph"><p>This extension requires SPIR-V 1.0.</p></div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph">
-<p>This extension adds new instructions to SPIR-V to support additional group operations within uniform control flow.
-Some SPIR-V consumers may only be able to support these operations within uniform control flow for some <em>Execution</em> <em>Scopes</em>, and some SPIR-V consumers may be able to generate more efficient code when control flow is known to be uniform.</p>
-</div>
+<div class="paragraph"><p>This extension adds new instructions to SPIR-V to support additional group operations within uniform control flow.
+Some SPIR-V consumers may only be able to support these operations within uniform control flow for some <em>Execution</em> <em>Scopes</em>, and some SPIR-V consumers may be able to generate more efficient code when control flow is known to be uniform.</p></div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_extension_name">Extension Name</h2>
 <div class="sectionbody">
-<div class="paragraph">
-<p>To use this extension within a SPIR-V module, the following
-<strong>OpExtension</strong> must be present in the module:</p>
-</div>
+<div class="paragraph"><p>To use this extension within a SPIR-V module, the following
+<strong>OpExtension</strong> must be present in the module:</p></div>
 <div class="listingblock">
-<div class="content">
+<div class="content monospaced">
 <pre>OpExtension "SPV_KHR_uniform_group_instructions"</pre>
-</div>
-</div>
+</div></div>
 </div>
 </div>
 <div class="sect1">
@@ -127,465 +895,472 @@ Some SPIR-V consumers may only be able to support these operations within unifor
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_capabilities">Capabilities</h3>
-<div class="paragraph">
-<p>Modify Section 3.31, Capability, adding rows to the Capability table:</p>
-</div>
+<div class="paragraph"><p>Modify Section 3.31, Capability, adding rows to the Capability table:</p></div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
+<table class="tableblock frame-all grid-all"
+style="
+width:100%;
+">
+<col style="width:33%;">
+<col style="width:33%;">
+<col style="width:33%;">
 <thead>
 <tr>
-<th class="tableblock halign-center valign-top" colspan="2">Capability</th>
-<th class="tableblock halign-center valign-top">Implicitly Declares</th>
+<th class="tableblock halign-center valign-top" colspan="2" > Capability </th>
+<th class="tableblock halign-center valign-top" > Implicitly Declares</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">6400</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>GroupUniformArithmeticKHR</strong><br>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6400</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>GroupUniformArithmeticKHR</strong><br>
 Uses additional group uniform arithmetic instructions.</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Groups</strong></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>Groups</strong></p></td>
 </tr>
 </tbody>
 </table>
-</div>
-</div>
+</div></div>
 </div>
 <div class="sect2">
 <h3 id="_instructions">Instructions</h3>
-<div class="paragraph">
-<p>Add new instructions to Section 3.37.21, Group and Subgroup Instructions:</p>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 5.8823%;">
-<col style="width: 5.8823%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.6474%;">
-</colgroup>
+<div class="paragraph"><p>Add new instructions to Section 3.37.21, Group and Subgroup Instructions:</p></div>
+<table class="tableblock frame-all grid-all"
+style="
+width:100%;
+">
+<col style="width:5%;">
+<col style="width:5%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpGroupIMulKHR"></a><strong>OpGroupIMulKHR</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpGroupIMulKHR"></a><strong>OpGroupIMulKHR</strong><br>
 <br>
-An integer multiplication <a href="#group operation">group operation</a> specified for all values of 'X'
+An integer multiplication <a href="#group operation">group operation</a> specified for all values of <em>X</em>
 specified by <a href="#invocations">invocations</a> in the group.<br>
 <br>
-Behavior is undefined if not all <a href="#invocations">invocations</a> of this module within 'Execution'
+Behavior is undefined if not all <a href="#invocations">invocations</a> of this module within <em>Execution</em>
 reach this point of execution.<br>
 <br>
-Behavior is undefined unless all invocations within 'Execution' execute the
+Behavior is undefined unless all invocations within <em>Execution</em> execute the
 same dynamic instance of this instruction.<br>
 <br>
-'Result Type' must be a scalar or vector of <a href="#integer type">integer type</a>.<br>
+<em>Result Type</em> must be a scalar or vector of <a href="#integer type">integer type</a>.<br>
 <br>
-'Execution' is a <a href="#Scope">Scope</a>. It must be either <strong>Workgroup</strong> or <strong>Subgroup</strong>.<br>
+<em>Execution</em> is a <a href="#Scope">Scope</a>. It must be either <strong>Workgroup</strong> or <strong>Subgroup</strong>.<br>
 <br>
-The identity <em>I</em> for 'Operation' is 1.<br>
+The identity <em>I</em> for <em>Operation</em> is 1.<br>
 <br>
-The type of 'X' must be the same as 'Result Type'.<br></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
+The type of <em>X</em> must be the same as <em>Result Type</em>.<br></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
 <strong>GroupUniformArithmeticKHR</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">6</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">6401</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;id&gt;'<br>
-'Result Type'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'Result &lt;id&gt;'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'Scope &lt;id&gt;'<br>
-'Execution'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;Group Operation&gt;'<br>
-'Operation'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;id&gt;'<br>
-'X'</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6401</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>Result Type</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Scope &lt;id&gt;</em><br>
+<em>Execution</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;Group Operation&gt;</em><br>
+<em>Operation</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>X</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 5.8823%;">
-<col style="width: 5.8823%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.6474%;">
-</colgroup>
+<table class="tableblock frame-all grid-all"
+style="
+width:100%;
+">
+<col style="width:5%;">
+<col style="width:5%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpGroupFMulKHR"></a><strong>OpGroupFMulKHR</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpGroupFMulKHR"></a><strong>OpGroupFMulKHR</strong><br>
 <br>
-A floating-point multiplication <a href="#group operation">group operation</a> specified for all values of 'X'
+A floating-point multiplication <a href="#group operation">group operation</a> specified for all values of <em>X</em>
 specified by <a href="#invocations">invocations</a> in the group.<br>
 <br>
-Behavior is undefined if not all <a href="#invocations">invocations</a> of this module within 'Execution'
+Behavior is undefined if not all <a href="#invocations">invocations</a> of this module within <em>Execution</em>
 reach this point of execution.<br>
 <br>
-Behavior is undefined unless all invocations within 'Execution' execute the
+Behavior is undefined unless all invocations within <em>Execution</em> execute the
 same dynamic instance of this instruction.<br>
 <br>
-'Result Type' must be a scalar or vector of <a href="#floating-point type">floating-point type</a>.<br>
+<em>Result Type</em> must be a scalar or vector of <a href="#floating-point type">floating-point type</a>.<br>
 <br>
-'Execution' is a <a href="#Scope">Scope</a>. It must be either <strong>Workgroup</strong> or <strong>Subgroup</strong>.<br>
+<em>Execution</em> is a <a href="#Scope">Scope</a>. It must be either <strong>Workgroup</strong> or <strong>Subgroup</strong>.<br>
 <br>
-The identity <em>I</em> for 'Operation' is 1.<br>
+The identity <em>I</em> for <em>Operation</em> is 1.<br>
 <br>
-The type of 'X' must be the same as 'Result Type'.<br></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
+The type of <em>X</em> must be the same as <em>Result Type</em>.<br></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
 <strong>GroupUniformArithmeticKHR</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">6</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">6402</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;id&gt;'<br>
-'Result Type'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'Result &lt;id&gt;'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'Scope &lt;id&gt;'<br>
-'Execution'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;Group Operation&gt;'<br>
-'Operation'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;id&gt;'<br>
-'X'</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6402</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>Result Type</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Scope &lt;id&gt;</em><br>
+<em>Execution</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;Group Operation&gt;</em><br>
+<em>Operation</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>X</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 5.8823%;">
-<col style="width: 5.8823%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.6474%;">
-</colgroup>
+<table class="tableblock frame-all grid-all"
+style="
+width:100%;
+">
+<col style="width:5%;">
+<col style="width:5%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpGroupBitwiseAndKHR"></a><strong>OpGroupBitwiseAndKHR</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpGroupBitwiseAndKHR"></a><strong>OpGroupBitwiseAndKHR</strong><br>
 <br>
-A bitwise 'And' <a href="#group operation">group operation</a> specified for all values of 'X'
+A bitwise <em>And</em> <a href="#group operation">group operation</a> specified for all values of <em>X</em>
 specified by <a href="#invocations">invocations</a> in the group.<br>
 <br>
-Behavior is undefined if not all <a href="#invocations">invocations</a> of this module within 'Execution'
+Behavior is undefined if not all <a href="#invocations">invocations</a> of this module within <em>Execution</em>
 reach this point of execution.<br>
 <br>
-Behavior is undefined unless all invocations within 'Execution' execute the
+Behavior is undefined unless all invocations within <em>Execution</em> execute the
 same dynamic instance of this instruction.<br>
 <br>
-'Result Type' must be a scalar or vector of <a href="#integer type">integer type</a>.<br>
+<em>Result Type</em> must be a scalar or vector of <a href="#integer type">integer type</a>.<br>
 <br>
-'Execution' is a <a href="#Scope">Scope</a>. It must be either <strong>Workgroup</strong> or <strong>Subgroup</strong>.<br>
+<em>Execution</em> is a <a href="#Scope">Scope</a>. It must be either <strong>Workgroup</strong> or <strong>Subgroup</strong>.<br>
 <br>
-The identity <em>I</em> for 'Operation' is ~0.<br>
+The identity <em>I</em> for <em>Operation</em> is ~0.<br>
 <br>
-The type of 'X' must be the same as 'Result Type'.<br></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
+The type of <em>X</em> must be the same as <em>Result Type</em>.<br></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
 <strong>GroupUniformArithmeticKHR</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">6</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">6403</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;id&gt;'<br>
-'Result Type'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'Result &lt;id&gt;'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'Scope &lt;id&gt;'<br>
-'Execution'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;Group Operation&gt;'<br>
-'Operation'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;id&gt;'<br>
-'X'</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6403</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>Result Type</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Scope &lt;id&gt;</em><br>
+<em>Execution</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;Group Operation&gt;</em><br>
+<em>Operation</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>X</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 5.8823%;">
-<col style="width: 5.8823%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.6474%;">
-</colgroup>
+<table class="tableblock frame-all grid-all"
+style="
+width:100%;
+">
+<col style="width:5%;">
+<col style="width:5%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpGroupBitwiseOrKHR"></a><strong>OpGroupBitwiseOrKHR</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpGroupBitwiseOrKHR"></a><strong>OpGroupBitwiseOrKHR</strong><br>
 <br>
-A bitwise 'Or' <a href="#group operation">group operation</a> specified for all values of 'X'
+A bitwise <em>Or</em> <a href="#group operation">group operation</a> specified for all values of <em>X</em>
 specified by <a href="#invocations">invocations</a> in the group.<br>
 <br>
-Behavior is undefined if not all <a href="#invocations">invocations</a> of this module within 'Execution'
+Behavior is undefined if not all <a href="#invocations">invocations</a> of this module within <em>Execution</em>
 reach this point of execution.<br>
 <br>
-Behavior is undefined unless all invocations within 'Execution' execute the
+Behavior is undefined unless all invocations within <em>Execution</em> execute the
 same dynamic instance of this instruction.<br>
 <br>
-'Result Type' must be a scalar or vector of <a href="#integer type">integer type</a>.<br>
+<em>Result Type</em> must be a scalar or vector of <a href="#integer type">integer type</a>.<br>
 <br>
-'Execution' is a <a href="#Scope">Scope</a>. It must be either <strong>Workgroup</strong> or <strong>Subgroup</strong>.<br>
+<em>Execution</em> is a <a href="#Scope">Scope</a>. It must be either <strong>Workgroup</strong> or <strong>Subgroup</strong>.<br>
 <br>
-The identity <em>I</em> for 'Operation' is 0.<br>
+The identity <em>I</em> for <em>Operation</em> is 0.<br>
 <br>
-The type of 'X' must be the same as 'Result Type'.<br></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
+The type of <em>X</em> must be the same as <em>Result Type</em>.<br></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
 <strong>GroupUniformArithmeticKHR</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">6</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">6404</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;id&gt;'<br>
-'Result Type'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'Result &lt;id&gt;'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'Scope &lt;id&gt;'<br>
-'Execution'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;Group Operation&gt;'<br>
-'Operation'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;id&gt;'<br>
-'X'</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6404</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>Result Type</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Scope &lt;id&gt;</em><br>
+<em>Execution</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;Group Operation&gt;</em><br>
+<em>Operation</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>X</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 5.8823%;">
-<col style="width: 5.8823%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.6474%;">
-</colgroup>
+<table class="tableblock frame-all grid-all"
+style="
+width:100%;
+">
+<col style="width:5%;">
+<col style="width:5%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpGroupBitwiseXorKHR"></a><strong>OpGroupBitwiseXorKHR</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpGroupBitwiseXorKHR"></a><strong>OpGroupBitwiseXorKHR</strong><br>
 <br>
-A bitwise 'Xor' <a href="#group operation">group operation</a> specified for all values of 'X'
+A bitwise <em>Xor</em> <a href="#group operation">group operation</a> specified for all values of <em>X</em>
 specified by <a href="#invocations">invocations</a> in the group.<br>
 <br>
-Behavior is undefined if not all <a href="#invocations">invocations</a> of this module within 'Execution'
+Behavior is undefined if not all <a href="#invocations">invocations</a> of this module within <em>Execution</em>
 reach this point of execution.<br>
 <br>
-Behavior is undefined unless all invocations within 'Execution' execute the
+Behavior is undefined unless all invocations within <em>Execution</em> execute the
 same dynamic instance of this instruction.<br>
 <br>
-'Result Type' must be a scalar or vector of <a href="#integer type">integer type</a>.<br>
+<em>Result Type</em> must be a scalar or vector of <a href="#integer type">integer type</a>.<br>
 <br>
-'Execution' is a <a href="#Scope">Scope</a>. It must be either <strong>Workgroup</strong> or <strong>Subgroup</strong>.<br>
+<em>Execution</em> is a <a href="#Scope">Scope</a>. It must be either <strong>Workgroup</strong> or <strong>Subgroup</strong>.<br>
 <br>
-The identity <em>I</em> for 'Operation' is 0.<br>
+The identity <em>I</em> for <em>Operation</em> is 0.<br>
 <br>
-The type of 'X' must be the same as 'Result Type'.<br></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
+The type of <em>X</em> must be the same as <em>Result Type</em>.<br></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
 <strong>GroupUniformArithmeticKHR</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">6</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">6405</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;id&gt;'<br>
-'Result Type'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'Result &lt;id&gt;'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'Scope &lt;id&gt;'<br>
-'Execution'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;Group Operation&gt;'<br>
-'Operation'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;id&gt;'<br>
-'X'</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6405</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>Result Type</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Scope &lt;id&gt;</em><br>
+<em>Execution</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;Group Operation&gt;</em><br>
+<em>Operation</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>X</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 5.8823%;">
-<col style="width: 5.8823%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.6474%;">
-</colgroup>
+<table class="tableblock frame-all grid-all"
+style="
+width:100%;
+">
+<col style="width:5%;">
+<col style="width:5%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpGroupBitwiseLogicalAndKHR"></a><strong>OpGroupLogicalAndKHR</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpGroupBitwiseLogicalAndKHR"></a><strong>OpGroupLogicalAndKHR</strong><br>
 <br>
-A logical 'And' <a href="#group operation">group operation</a> specified for all values of 'X'
+A logical <em>And</em> <a href="#group operation">group operation</a> specified for all values of <em>X</em>
 specified by <a href="#invocations">invocations</a> in the group.<br>
 <br>
-Behavior is undefined if not all <a href="#invocations">invocations</a> of this module within 'Execution'
+Behavior is undefined if not all <a href="#invocations">invocations</a> of this module within <em>Execution</em>
 reach this point of execution.<br>
 <br>
-Behavior is undefined unless all invocations within 'Execution' execute the
+Behavior is undefined unless all invocations within <em>Execution</em> execute the
 same dynamic instance of this instruction.<br>
 <br>
-'Result Type' must be a scalar or vector of <a href="#Boolean type">Boolean type</a>.<br>
+<em>Result Type</em> must be a scalar or vector of <a href="#Boolean type">Boolean type</a>.<br>
 <br>
-'Execution' is a <a href="#Scope">Scope</a>. It must be either <strong>Workgroup</strong> or <strong>Subgroup</strong>.<br>
+<em>Execution</em> is a <a href="#Scope">Scope</a>. It must be either <strong>Workgroup</strong> or <strong>Subgroup</strong>.<br>
 <br>
-The identity <em>I</em> for 'Operation' is ~0.<br>
+The identity <em>I</em> for <em>Operation</em> is ~0.<br>
 <br>
-The type of 'X' must be the same as 'Result Type'.<br></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
+The type of <em>X</em> must be the same as <em>Result Type</em>.<br></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
 <strong>GroupUniformArithmeticKHR</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">6</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">6406</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;id&gt;'<br>
-'Result Type'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'Result &lt;id&gt;'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'Scope &lt;id&gt;'<br>
-'Execution'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;Group Operation&gt;'<br>
-'Operation'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;id&gt;'<br>
-'X'</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6406</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>Result Type</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Scope &lt;id&gt;</em><br>
+<em>Execution</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;Group Operation&gt;</em><br>
+<em>Operation</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>X</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 5.8823%;">
-<col style="width: 5.8823%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.6474%;">
-</colgroup>
+<table class="tableblock frame-all grid-all"
+style="
+width:100%;
+">
+<col style="width:5%;">
+<col style="width:5%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpGroupLogicalOrKHR"></a><strong>OpGroupLogicalOrKHR</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpGroupLogicalOrKHR"></a><strong>OpGroupLogicalOrKHR</strong><br>
 <br>
-A logical 'Or' <a href="#group operation">group operation</a> specified for all values of 'X'
+A logical <em>Or</em> <a href="#group operation">group operation</a> specified for all values of <em>X</em>
 specified by <a href="#invocations">invocations</a> in the group.<br>
 <br>
-Behavior is undefined if not all <a href="#invocations">invocations</a> of this module within 'Execution'
+Behavior is undefined if not all <a href="#invocations">invocations</a> of this module within <em>Execution</em>
 reach this point of execution.<br>
 <br>
-Behavior is undefined unless all invocations within 'Execution' execute the
+Behavior is undefined unless all invocations within <em>Execution</em> execute the
 same dynamic instance of this instruction.<br>
 <br>
-'Result Type' must be a scalar or vector of <a href="#Boolean type">Boolean type</a>.<br>
+<em>Result Type</em> must be a scalar or vector of <a href="#Boolean type">Boolean type</a>.<br>
 <br>
-'Execution' is a <a href="#Scope">Scope</a>. It must be either <strong>Workgroup</strong> or <strong>Subgroup</strong>.<br>
+<em>Execution</em> is a <a href="#Scope">Scope</a>. It must be either <strong>Workgroup</strong> or <strong>Subgroup</strong>.<br>
 <br>
-The identity <em>I</em> for 'Operation' is 0.<br>
+The identity <em>I</em> for <em>Operation</em> is 0.<br>
 <br>
-The type of 'X' must be the same as 'Result Type'.<br></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
+The type of <em>X</em> must be the same as <em>Result Type</em>.<br></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
 <strong>GroupUniformArithmeticKHR</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">6</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">6407</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;id&gt;'<br>
-'Result Type'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'Result &lt;id&gt;'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'Scope &lt;id&gt;'<br>
-'Execution'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;Group Operation&gt;'<br>
-'Operation'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;id&gt;'<br>
-'X'</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6407</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>Result Type</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Scope &lt;id&gt;</em><br>
+<em>Execution</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;Group Operation&gt;</em><br>
+<em>Operation</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>X</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 5.8823%;">
-<col style="width: 5.8823%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.647%;">
-<col style="width: 17.6474%;">
-</colgroup>
+<table class="tableblock frame-all grid-all"
+style="
+width:100%;
+">
+<col style="width:5%;">
+<col style="width:5%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
+<col style="width:17%;">
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpGroupLogicalXorKHR"></a><strong>OpGroupLogicalXorKHR</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpGroupLogicalXorKHR"></a><strong>OpGroupLogicalXorKHR</strong><br>
 <br>
-A logical 'Xor' <a href="#group operation">group operation</a> specified for all values of 'X'
+A logical <em>Xor</em> <a href="#group operation">group operation</a> specified for all values of <em>X</em>
 specified by <a href="#invocations">invocations</a> in the group.<br>
 <br>
-Behavior is undefined if not all <a href="#invocations">invocations</a> of this module within 'Execution'
+Behavior is undefined if not all <a href="#invocations">invocations</a> of this module within <em>Execution</em>
 reach this point of execution.<br>
 <br>
-Behavior is undefined unless all invocations within 'Execution' execute the
+Behavior is undefined unless all invocations within <em>Execution</em> execute the
 same dynamic instance of this instruction.<br>
 <br>
-'Result Type' must be a scalar or vector of <a href="#Boolean type">Boolean type</a>.<br>
+<em>Result Type</em> must be a scalar or vector of <a href="#Boolean type">Boolean type</a>.<br>
 <br>
-'Execution' is a <a href="#Scope">Scope</a>. It must be either <strong>Workgroup</strong> or <strong>Subgroup</strong>.<br>
+<em>Execution</em> is a <a href="#Scope">Scope</a>. It must be either <strong>Workgroup</strong> or <strong>Subgroup</strong>.<br>
 <br>
-The identity <em>I</em> for 'Operation' is 0.<br>
+The identity <em>I</em> for <em>Operation</em> is 0.<br>
 <br>
-The type of 'X' must be the same as 'Result Type'.<br></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
+The type of <em>X</em> must be the same as <em>Result Type</em>.<br></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
 <strong>GroupUniformArithmeticKHR</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">6</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">6408</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;id&gt;'<br>
-'Result Type'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'Result &lt;id&gt;'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'Scope &lt;id&gt;'<br>
-'Execution'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;Group Operation&gt;'<br>
-'Operation'</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">'&lt;id&gt;'<br>
-'X'</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6408</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>Result Type</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Scope &lt;id&gt;</em><br>
+<em>Execution</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;Group Operation&gt;</em><br>
+<em>Operation</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>X</em></p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect2">
 <h3 id="_issues">Issues</h3>
-<div class="paragraph">
-<p>None</p>
-</div>
+<div class="paragraph"><p>None</p></div>
 </div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
-<colgroup>
-<col style="width: 4.7619%;">
-<col style="width: 14.2857%;">
-<col style="width: 14.2857%;">
-<col style="width: 66.6667%;">
-</colgroup>
+<table class="tableblock frame-all grid-rows"
+style="
+width:100%;
+">
+<col style="width:4%;">
+<col style="width:14%;">
+<col style="width:14%;">
+<col style="width:66%;">
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top">Rev</th>
-<th class="tableblock halign-left valign-top">Date</th>
-<th class="tableblock halign-left valign-top">Author</th>
-<th class="tableblock halign-left valign-top">Changes</th>
+<th class="tableblock halign-left valign-top" >Rev</th>
+<th class="tableblock halign-left valign-top" >Date</th>
+<th class="tableblock halign-left valign-top" >Author</th>
+<th class="tableblock halign-left valign-top" >Changes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">A</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2021-09-16</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Dmitry Sidorov</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Initial revision</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">B</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2021-11-08</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Converted to a KHR extension.</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2021-11-08</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Converted to a KHR extension.</p></td>
 </tr>
 </tbody>
 </table>
 </div>
-</div></div></body></html>
+</div>
+</div>
+<div id="footnotes"><hr></div>
+<div id="footer">
+<div id="footer-text">
+Last updated
+ 2022-05-03 08:06:32 PDT
+</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
It looks like the HTML spec for SPV_KHR_uniform_group_instructions was built from an older asciidoc spec source and using different asciidoc style sheet.  This PR rebuilds the HTML spec with the latest asciidoc spec source in this repo and using the standard SPIR-V style sheet.