### PR TITLE
Allow at most one task payload variable per TaskEXT entry point

### DIFF
--- a/extensions/EXT/SPV_EXT_mesh_shader.asciidoc
+++ b/extensions/EXT/SPV_EXT_mesh_shader.asciidoc
@@ -35,8 +35,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2022-09-06
-| Revision           | 6
+| Last Modified Date | 2022-09-16
+| Revision           | 7
 |========================================
 
 Dependencies
@@ -179,8 +179,8 @@ pointers taken by atomic operation instructions can point to.
   *OutputTrianglesEXT* Execution Modes.
 * Each *OpEntryPoint* with the *MeshEXT* Execution Model must specify both the
   *OutputPrimitivesEXT* and *OutputVertices* Execution Modes.
-* Each *OpEntryPoint* with the *MeshEXT* Execution Model can have at most one
-  global OpVariable of storage class *TaskPayloadWorkgroupEXT*.
+* Each *OpEntryPoint* with the *MeshEXT* or *TaskEXT* Execution Models can have
+  at most one global OpVariable of storage class *TaskPayloadWorkgroupEXT*.
 * OpSetMeshOutputsEXT is only valid in MeshEXT execution model.
 * OpEmitMeshTasksEXT is only valid in TaskEXT Execution model.
 
@@ -587,4 +587,5 @@ Revision History
 |4  |2022-04-11 |Pankaj Mistry|Require SPIR-V 1.4 and add validation rules for TaskPayloadWorkgroupEXT
 |5  |2022-08-31 |Pankaj Mistry|Added validation rules for OpSetMeshOutputsEXT and OpEmitMeshTasksEXT
 |6  |2022-09-06 |Pankaj Mistry|Added OpEmitMeshTasksEXT as a termination instruction and added atomic access validation rule for TaskPayloadWorkgroupEXT
+|7  |2022-09-16 |Ricardo Garcia|Forbid more than one TaskPayloadWorkgroupEXT variable in each TaskEXT entry point
 |========================================

--- a/extensions/EXT/SPV_EXT_mesh_shader.html
+++ b/extensions/EXT/SPV_EXT_mesh_shader.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta name="generator" content="AsciiDoc 10.1.2">
+<meta name="generator" content="AsciiDoc 10.2.0">
 <title>SPV_EXT_mesh_shader</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -862,11 +862,11 @@ width:40%;
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2022-09-06</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2022-09-16</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">7</p></td>
 </tr>
 </tbody>
 </table>
@@ -1061,8 +1061,8 @@ Each <strong>OpEntryPoint</strong> with the <strong>MeshEXT</strong> Execution M
 </li>
 <li>
 <p>
-Each <strong>OpEntryPoint</strong> with the <strong>MeshEXT</strong> Execution Model can have at most one
-  global OpVariable of storage class <strong>TaskPayloadWorkgroupEXT</strong>.
+Each <strong>OpEntryPoint</strong> with the <strong>MeshEXT</strong> or <strong>TaskEXT</strong> Execution Models can have
+  at most one global OpVariable of storage class <strong>TaskPayloadWorkgroupEXT</strong>.
 </p>
 </li>
 <li>
@@ -1860,6 +1860,12 @@ width:100%;
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Pankaj Mistry</p></td>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Added OpEmitMeshTasksEXT as a termination instruction and added atomic access validation rule for TaskPayloadWorkgroupEXT</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">7</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2022-09-16</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Ricardo Garcia</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Forbid more than one TaskPayloadWorkgroupEXT variable in each TaskEXT entry point</p></td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -1869,7 +1875,7 @@ width:100%;
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2022-09-06 11:55:45 PDT
+ 2022-09-16 16:44:54 CEST
 </div>
 </div>
 </body>


### PR DESCRIPTION
This appears to be the desired behavior and matches the language in the issues section, which explains that there can be only one task payload variable per entry point, without specifying TaskEXT or MeshEXT.

/cc @pmistryNV @dgkoch @HansKristian-Work 