### PR TITLE
Add new execution mode to SPV_INTEL_kernel_attributes

### DIFF
--- a/extensions/INTEL/SPV_INTEL_kernel_attributes.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_kernel_attributes.asciidoc
@@ -60,7 +60,7 @@ This extension introduces new capabilities:
 ----
 KernelAttributesINTEL
 FPGAKernelAttributesINTEL
-FPGAKernelAttributesINTELv2
+FPGAKernelAttributesv2INTEL
 ----
 
 == New Execution Modes
@@ -88,7 +88,7 @@ RegisterMapInterfaceINTEL
 |NoGlobalOffsetINTEL          |5895
 |NumSIMDWorkitemsINTEL        |5896
 |FPGAKernelAttributesINTEL    |5897
-|FPGAKernelAttributesINTELv2  |6161
+|FPGAKernelAttributesv2INTEL  |6161
 |SchedulerTargetFmaxMhzINTEL  |5903
 |StreamingInterfaceINTEL      |6154
 |RegisterMapInterfaceINTEL    |6160
@@ -158,7 +158,7 @@ _AcceptDownstreamStall_ is a boolean type scalar.
 If _AcceptDownstreamStall_ is `true`, it indicates that the kernel interface will contain a stall register that can be used to back-pressure the kernel, while if it is `false`, it indicates that it will not.
 3+^| Literal +
 _AcceptDownstreamStall_
-| *FPGAKernelAttributesINTELv2*
+| *FPGAKernelAttributesv2INTEL*
 
 |====
 --
@@ -172,7 +172,7 @@ Modify Section 3.31, Capability, adding the following rows to the Capability tab
 2+^| Capability ^| Implicitly Declares
 | 5892 | KernelAttributesINTEL |
 | 5897 | FPGAKernelAttributesINTEL |
-| 6161 | FPGAKernelAttributesINTELv2 | FPGAKernelAttributesINTEL
+| 6161 | FPGAKernelAttributesv2INTEL | FPGAKernelAttributesINTEL
 |====
 --
 

--- a/extensions/INTEL/SPV_INTEL_kernel_attributes.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_kernel_attributes.asciidoc
@@ -18,10 +18,11 @@ https://github.com/KhronosGroup/SPIRV-Registry
 - Ajaykumar Kannan, Intel
 - Michael Kinsner, Intel
 - Ryan Murray, Intel
+- Abhishek Tiwari, Intel
 
 == Notice
 
-Copyright (c) 2019-2021 Intel Corporation.  All rights reserved.
+Copyright (c) 2019-2022 Intel Corporation.  All rights reserved.
 
 == Status
 
@@ -31,14 +32,14 @@ Final Draft
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2021-09-14
-| Revision           | 3
+| Last Modified Date | 2022-12-05
+| Revision           | 4
 |========================================
 
 == Dependencies
 
 This extension is written against the SPIR-V Specification,
-Version 1.5 Revision 5.
+Version 1.6 Revision 2.
 
 This extension requires SPIR-V 1.0.
 
@@ -59,6 +60,7 @@ This extension introduces new capabilities:
 ----
 KernelAttributesINTEL
 FPGAKernelAttributesINTEL
+FPGAKernelAttributesINTELv2
 ----
 
 == New Execution Modes
@@ -70,6 +72,7 @@ NoGlobalOffsetINTEL
 NumSIMDWorkitemsINTEL
 SchedulerTargetFmaxMhzINTEL
 StreamingInterfaceINTEL
+RegisterMapInterfaceINTEL
 ----
 
 == Token Number Assignments
@@ -85,12 +88,14 @@ StreamingInterfaceINTEL
 |NoGlobalOffsetINTEL          |5895
 |NumSIMDWorkitemsINTEL        |5896
 |FPGAKernelAttributesINTEL    |5897
+|FPGAKernelAttributesINTELv2  |6161
 |SchedulerTargetFmaxMhzINTEL  |5903
 |StreamingInterfaceINTEL      |6154
-|==== 
+|RegisterMapInterfaceINTEL    |6160
+|====
 --
 
-== Modifications to the SPIR-V Specification, Version 1.5
+== Modifications to the SPIR-V Specification, Version 1.6
 
 === Execution Mode
 
@@ -147,6 +152,14 @@ If _StallFreeReturn_ is equal to zero, it indicates that the return interface of
 _StallFreeReturn_
 | *FPGAKernelAttributesINTEL*
 
+| 6160 | *RegisterMapInterfaceINTEL* +
+Indicates that the kernel has a single register based interface that is shared across all kernel control signals and kernel arguments.
+_AcceptDownstreamStall_ is a boolean type scalar.
+If _AcceptDownstreamStall_ is `true`, it indicates that the kernel interface will contain a stall register that can be used to back-pressure the kernel, while if it is `false`, it indicates that it will not.
+3+^| Literal +
+_AcceptDownstreamStall_
+| *FPGAKernelAttributesINTELv2*
+
 |====
 --
 
@@ -159,8 +172,13 @@ Modify Section 3.31, Capability, adding the following rows to the Capability tab
 2+^| Capability ^| Implicitly Declares
 | 5892 | KernelAttributesINTEL |
 | 5897 | FPGAKernelAttributesINTEL |
+| 6161 | FPGAKernelAttributesINTELv2 | FPGAKernelAttributesINTEL
 |====
 --
+
+=== Validation Rules
+
+It is illegal to specify both *StreamingInterfaceINTEL* and *RegisterMapInterfaceINTEL* modes on the same entry point.
 
 == Issues
 
@@ -176,5 +194,6 @@ None.
 |1|2019-12-18|Joe Garvey|*Initial public release*
 |2|2020-04-22|Jessica Davies|Added one new execution mode, SchedulerTargetFmaxMhzINTEL.
 |3|2021-09-14|Ajaykumar Kannan|Added one new execution mode, StreamingInterfaceINTEL.
-|======================================== 
+|4|2022-12-05|Abhishek Tiwari|Added one new execution mode, RegisterMapInterfaceINTEL, under a new compatibility.
+|========================================
 

--- a/extensions/INTEL/SPV_INTEL_kernel_attributes.html
+++ b/extensions/INTEL/SPV_INTEL_kernel_attributes.html
@@ -567,7 +567,7 @@ Version 1.6 Revision 2.</p>
 <div class="content">
 <pre>KernelAttributesINTEL
 FPGAKernelAttributesINTEL
-FPGAKernelAttributesINTELv2</pre>
+FPGAKernelAttributesv2INTEL</pre>
 </div>
 </div>
 </div>
@@ -624,7 +624,7 @@ RegisterMapInterfaceINTEL</pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">5897</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">FPGAKernelAttributesINTELv2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">FPGAKernelAttributesv2INTEL</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">6161</p></td>
 </tr>
 <tr>
@@ -738,7 +738,7 @@ Indicates that the kernel has a single register based interface that is shared a
 If <em>AcceptDownstreamStall</em> is <code>true</code>, it indicates that the kernel interface will contain a stall register that can be used to back-pressure the kernel, while if it is <code>false</code>, it indicates that it will not.</p></td>
 <td class="tableblock halign-center valign-top" colspan="3"><p class="tableblock">Literal<br>
 <em>AcceptDownstreamStall</em></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>FPGAKernelAttributesINTELv2</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>FPGAKernelAttributesv2INTEL</strong></p></td>
 </tr>
 </tbody>
 </table>
@@ -777,7 +777,7 @@ If <em>AcceptDownstreamStall</em> is <code>true</code>, it indicates that the ke
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">6161</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">FPGAKernelAttributesINTELv2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">FPGAKernelAttributesv2INTEL</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">FPGAKernelAttributesINTEL</p></td>
 </tr>
 </tbody>

--- a/extensions/INTEL/SPV_INTEL_kernel_attributes.html
+++ b/extensions/INTEL/SPV_INTEL_kernel_attributes.html
@@ -4,25 +4,23 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.10">
+<meta name="generator" content="Asciidoctor 2.0.17">
 <title>SPV_INTEL_kernel_attributes</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
-/* Uncomment @import statement to use as custom stylesheet */
-/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
-article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}
-audio,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment the following line when using as a custom stylesheet */
+/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
+html{font-family:sans-serif;-webkit-text-size-adjust:100%}
 a{background:none}
 a:focus{outline:thin dotted}
 a:active,a:hover{outline:0}
 h1{font-size:2em;margin:.67em 0}
-abbr[title]{border-bottom:1px dotted}
 b,strong{font-weight:bold}
+abbr{font-size:.9em}
+abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
 dfn{font-style:italic}
-hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+hr{height:0}
 mark{background:#ff0;color:#000}
 code,kbd,pre,samp{font-family:monospace;font-size:1em}
 pre{white-space:pre-wrap}
@@ -34,20 +32,22 @@ sub{bottom:-.25em}
 img{border:0}
 svg:not(:root){overflow:hidden}
 figure{margin:0}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
 fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
 legend{border:0;padding:0}
 button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
 button,input{line-height:normal}
 button,select{text-transform:none}
-button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
 button[disabled],html input[disabled]{cursor:default}
-input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
+input[type=checkbox],input[type=radio]{padding:0}
 button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
 textarea{overflow:auto;vertical-align:top}
 table{border-collapse:collapse;border-spacing:0}
-*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
+*,::before,::after{box-sizing:border-box}
 html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
 a:hover{cursor:pointer}
 img,object,embed{max-width:100%;height:auto}
 object,embed{height:100%}
@@ -62,14 +62,12 @@ img{-ms-interpolation-mode:bicubic}
 img,object,svg{display:inline-block;vertical-align:middle}
 textarea{height:auto;min-height:50px}
 select{width:100%}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
 .subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
 a{color:#2156a5;text-decoration:underline;line-height:inherit}
 a:hover,a:focus{color:#1d4b8f}
 a img{border:0}
-p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
 p aside{font-size:.875em;line-height:1.35;font-style:italic}
 h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
 h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
@@ -78,14 +76,14 @@ h2{font-size:1.6875em}
 h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
 h4,h5{font-size:1.125em}
 h6{font-size:1em}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
 em,i{font-style:italic;line-height:inherit}
 strong,b{font-weight:bold;line-height:inherit}
 small{font-size:60%;line-height:inherit}
 code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
 ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
 ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
 ul.square{list-style-type:square}
 ul.circle{list-style-type:circle}
@@ -93,31 +91,29 @@ ul.disc{list-style-type:disc}
 ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
 dl dt{margin-bottom:.3125em;font-weight:bold}
 dl dd{margin-bottom:1.25em}
-abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
-abbr{text-transform:none}
 blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
-blockquote cite::before{content:"\2014 \0020"}
-blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
 blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
 @media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
 h1{font-size:2.75em}
 h2{font-size:2.3125em}
 h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
 h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
 table thead,table tfoot{background:#f7f8f7}
 table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
 table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
 table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
 h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
 h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
 .clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
 .clearfix::after,.float-group::after{clear:both}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
-:not(pre)>code.nobreak{word-wrap:normal}
-:not(pre)>code.nowrap{white-space:nowrap}
+:not(pre).nobreak{word-wrap:normal}
+:not(pre).nowrap{white-space:nowrap}
+:not(pre).pre-wrap{white-space:pre-wrap}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
 pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
 pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
 pre>code{display:block}
@@ -125,7 +121,7 @@ pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
 em em{font-style:normal}
 strong strong{font-weight:400}
 .keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
 .keyseq kbd:first-child{margin-left:0}
 .keyseq kbd:last-child{margin-right:0}
 .menuseq,.menuref{color:#000}
@@ -137,7 +133,7 @@ b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
 b.button::before{content:"[";padding:0 3px 0 2px}
 b.button::after{content:"]";padding:0 2px 0 3px}
 p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
 #header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
 #header::after,#content::after,#footnotes::after,#footer::after{clear:both}
 #content{margin-top:1.25em}
@@ -145,7 +141,7 @@ p a>code:hover{color:rgba(0,0,0,.9)}
 #header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
 #header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
 #header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
 #header .details span:first-child{margin-left:-.125em}
 #header .details span.email a{color:rgba(0,0,0,.85)}
 #header .details br{display:none}
@@ -179,11 +175,11 @@ body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9
 #toc.toc2>ul{font-size:.95em}
 #toc.toc2 ul ul{padding-left:1.25em}
 body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
 #content #toc>:first-child{margin-top:0}
 #content #toc>:last-child{margin-bottom:0}
-#footer{max-width:100%;background:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
+#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
 #content{margin-bottom:.625em}
 .sect1{padding-bottom:.625em}
 @media screen and (min-width:768px){#content{margin-bottom:1.25em}
@@ -196,29 +192,33 @@ body.toc2.toc-right{padding-left:0;padding-right:20em}}
 #content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
 #content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
 details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details>summary:first-of-type{cursor:pointer;display:list-item;outline:none;margin-bottom:.75em}
+details{margin-left:1.25rem}
+details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
+details>summary::-webkit-details-marker{display:none}
+details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
+details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
+details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
 .admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
 table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:inherit}
+.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
 .admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
 .admonitionblock>table td.icon{text-align:center;width:80px}
 .admonitionblock>table td.icon img{max-width:none}
 .admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
 .admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
+.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
 .exampleblock>.content>:first-child{margin-top:0}
 .exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border-style:solid;border-width:1px;border-color:#dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;-webkit-border-radius:4px;border-radius:4px}
+.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
 .sidebarblock>:first-child{margin-top:0}
 .sidebarblock>:last-child{margin-bottom:0}
 .sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
 .exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
+.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
 @media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
 @media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
-.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
 .literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
 .listingblock>.content{position:relative}
 .listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
@@ -226,7 +226,7 @@ table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font
 .listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
 .listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
 .listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
+.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
 .listingblock pre.prettyprint{border-width:0}
 .prettyprint{background:#f7f7f8}
 pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
@@ -236,9 +236,8 @@ pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
 table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
 table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
 table.linenotable td.code{padding-left:.75em}
-table.linenotable td.linenos{border-right:1px solid currentColor;opacity:.35;padding-right:.5em}
-pre.pygments .lineno{border-right:1px solid currentColor;opacity:.35;display:inline-block;margin-right:.75em}
-pre.pygments .lineno::before{content:"";margin-right:-.125em}
+table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
+pre.pygments span.linenos{display:inline-block;margin-right:.75em}
 .quoteblock{margin:0 1em 1.25em 1.5em;display:table}
 .quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
 .quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
@@ -247,7 +246,7 @@ pre.pygments .lineno::before{content:"";margin-right:-.125em}
 .quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
 .quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
 .verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
 .verseblock pre strong{font-weight:400}
 .verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
 .quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
@@ -260,23 +259,22 @@ pre.pygments .lineno::before{content:"";margin-right:-.125em}
 .quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
 .quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
 .quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
-table.tableblock{max-width:100%;border-collapse:separate}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
 p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
 td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-td.tableblock>.content>:last-child.sidebarblock{margin-bottom:0}
 table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
-table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
-table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
-table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
-table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
-table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
-table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
+table.grid-all>*>tr>*{border-width:1px}
+table.grid-cols>*>tr>*{border-width:0 1px}
+table.grid-rows>*>tr>*{border-width:1px 0}
 table.frame-all{border-width:1px}
+table.frame-ends{border-width:1px 0}
 table.frame-sides{border-width:0 1px}
-table.frame-topbot,table.frame-ends{border-width:1px 0}
-table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
+table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
+table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
+table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
 th.halign-left,td.halign-left{text-align:left}
 th.halign-right,td.halign-right{text-align:right}
 th.halign-center,td.halign-center{text-align:center}
@@ -284,7 +282,7 @@ th.valign-top,td.valign-top{vertical-align:top}
 th.valign-bottom,td.valign-bottom{vertical-align:bottom}
 th.valign-middle,td.valign-middle{vertical-align:middle}
 table thead th,table tfoot th{font-weight:bold}
-tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th{background:#f7f8f7}
 tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
 p.tableblock>code:only-child{background:none;padding:0}
 p.tableblock{font-size:1em}
@@ -292,14 +290,15 @@ ol{margin-left:1.75em}
 ul li ol{margin-left:1.5em}
 dl dd{margin-left:1.125em}
 dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
 ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
 ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
 ul.unstyled,ol.unstyled{margin-left:0}
-ul.checklist{margin-left:.625em}
-ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
-ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+li>p:empty:only-child::before{content:"";display:inline-block}
+ul.checklist>li>p:first-child{margin-left:-1em}
+ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
+ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
 ul.inline>li{margin-left:1.25em}
 .unstyled dl dt{font-weight:400;font-style:normal}
 ol.arabic{list-style-type:decimal}
@@ -313,11 +312,12 @@ ol.lowergreek{list-style-type:lower-greek}
 .hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
 td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
 td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+td.hdlist2{word-wrap:anywhere}
 .literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
 .colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
 .colist td:not([class]):first-child img{max-width:none}
 .colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
+.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
 .imageblock.left{margin:.25em .625em 1.25em 0}
 .imageblock.right{margin:.25em 0 1.25em .625em}
 .imageblock>.title{margin-bottom:0}
@@ -337,8 +337,6 @@ sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
 #footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
 #footnotes .footnote:last-of-type{margin-bottom:0}
 #content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
-.gist .file-data>table td.line-data{width:99%}
 div.unbreakable{page-break-inside:avoid}
 .big{font-size:larger}
 .small{font-size:smaller}
@@ -385,7 +383,7 @@ a span.icon>.fa{cursor:inherit}
 .admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
 .admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
 .admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
 .conum[data-value] *{color:#fff!important}
 .conum[data-value]+b{display:none}
 .conum[data-value]::after{content:attr(data-value)}
@@ -393,25 +391,27 @@ pre .conum[data-value]{position:relative;top:-.125em}
 b.conum *{color:inherit!important}
 .conum:not([data-value]):empty{display:none}
 dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
+h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
 p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
+p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
 p{margin-bottom:1.25rem}
 .sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
 .print-only{display:none!important}
 @page{margin:1.25cm .75cm}
-@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
+@media print{*{box-shadow:none!important;text-shadow:none!important}
 html{font-size:80%}
 a{color:inherit!important;text-decoration:underline!important}
 a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
 a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]{border-bottom:1px dotted}
 abbr[title]::after{content:" (" attr(title) ")"}
 pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
 thead{display:table-header-group}
 svg{max-width:100%}
 p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
 h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#header,#content,#footnotes,#footer{max-width:none}
 #toc,.sidebarblock,.exampleblock>.content{background:none!important}
 #toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
 body.book #header{text-align:center}
@@ -428,7 +428,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 .print-only{display:block!important}
 .hide-for-print{display:none!important}
 .show-for-print{display:inherit!important}}
-@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
+@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
 .sect1{padding:0!important}
 .sect1+.sect1{border:0}
 #footer{background:none}
@@ -436,74 +436,77 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 @media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
 </style>
 </head>
-<body class="article">
+<body class="article data-line-1">
 <div id="header">
 <h1>SPV_INTEL_kernel_attributes</h1>
 </div>
 <div id="content">
-<div class="sect1">
+<div class="sect1 data-line-4">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph">
+<div class="paragraph data-line-6">
 <p>SPV_INTEL_kernel_attributes</p>
 </div>
 </div>
 </div>
-<div class="sect1">
+<div class="sect1 data-line-8">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph">
+<div class="paragraph data-line-10">
 <p>To report problems with this extension, please open a new issue at:</p>
 </div>
-<div class="paragraph">
-<p><a href="https://github.com/KhronosGroup/SPIRV-Registry" class="bare">https://github.com/KhronosGroup/SPIRV-Registry</a></p>
+<div class="paragraph data-line-12">
+<p><a href="https://github.com/KhronosGroup/SPIRV-Registry" class="undefined" data-href="https://github.com/KhronosGroup/SPIRV-Registry">https://github.com/KhronosGroup/SPIRV-Registry</a></p>
 </div>
 </div>
 </div>
-<div class="sect1">
+<div class="sect1 data-line-14">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="ulist">
+<div class="ulist data-line-16">
 <ul>
-<li>
+<li class="data-line-16">
 <p>Jessica Davies, Intel</p>
 </li>
-<li>
+<li class="data-line-17">
 <p>Joseph Garvey, Intel</p>
 </li>
-<li>
+<li class="data-line-18">
 <p>Ajaykumar Kannan, Intel</p>
 </li>
-<li>
+<li class="data-line-19">
 <p>Michael Kinsner, Intel</p>
 </li>
-<li>
+<li class="data-line-20">
 <p>Ryan Murray, Intel</p>
+</li>
+<li class="data-line-21">
+<p>Abhishek Tiwari, Intel</p>
 </li>
 </ul>
 </div>
 </div>
 </div>
-<div class="sect1">
+<div class="sect1 data-line-23">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph">
-<p>Copyright (c) 2019-2021 Intel Corporation.  All rights reserved.</p>
+<div class="paragraph data-line-25">
+<p>Copyright (c) 2019-2022 Intel Corporation.  All rights reserved.</p>
 </div>
 </div>
 </div>
-<div class="sect1">
+<div class="sect1 data-line-27">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="paragraph">
+<div class="paragraph data-line-29">
 <p>Final Draft</p>
 </div>
 </div>
 </div>
-<div class="sect1">
+<div class="sect1 data-line-31">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all data-line-34" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -511,84 +514,86 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2021-09-14</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2022-12-05</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 </div>
-<div class="sect1">
+<div class="sect1 data-line-39">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph">
+<div class="paragraph data-line-41">
 <p>This extension is written against the SPIR-V Specification,
-Version 1.5 Revision 5.</p>
+Version 1.6 Revision 2.</p>
 </div>
-<div class="paragraph">
+<div class="paragraph data-line-44">
 <p>This extension requires SPIR-V 1.0.</p>
 </div>
 </div>
 </div>
-<div class="sect1">
+<div class="sect1 data-line-46">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph">
+<div class="paragraph data-line-48">
 <p>This extension adds a variety of new execution modes, both general and target-specific. The target-specific execution modes are guarded by separate capabilities.</p>
 </div>
 </div>
 </div>
-<div class="sect1">
+<div class="sect1 data-line-50">
 <h2 id="_extension_name">Extension Name</h2>
 <div class="sectionbody">
-<div class="paragraph">
+<div class="paragraph data-line-51">
 <p>To use this extension within a SPIR-V module, the following <strong>OpExtension</strong> must be present in the module:</p>
 </div>
-<div class="listingblock">
+<div class="listingblock data-line-53">
 <div class="content">
 <pre>OpExtension "SPV_INTEL_kernel_attributes"</pre>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1">
+<div class="sect1 data-line-57">
 <h2 id="_new_capabilities">New Capabilities</h2>
 <div class="sectionbody">
-<div class="paragraph">
+<div class="paragraph data-line-58">
 <p>This extension introduces new capabilities:</p>
 </div>
-<div class="listingblock">
+<div class="listingblock data-line-60">
 <div class="content">
 <pre>KernelAttributesINTEL
-FPGAKernelAttributesINTEL</pre>
+FPGAKernelAttributesINTEL
+FPGAKernelAttributesINTELv2</pre>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1">
+<div class="sect1 data-line-66">
 <h2 id="_new_execution_modes">New Execution Modes</h2>
 <div class="sectionbody">
-<div class="listingblock">
+<div class="listingblock data-line-68">
 <div class="content">
 <pre>MaxWorkgroupSizeINTEL
 MaxWorkDimINTEL
 NoGlobalOffsetINTEL
 NumSIMDWorkitemsINTEL
 SchedulerTargetFmaxMhzINTEL
-StreamingInterfaceINTEL</pre>
+StreamingInterfaceINTEL
+RegisterMapInterfaceINTEL</pre>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1">
+<div class="sect1 data-line-78">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<div class="openblock">
+<div class="openblock data-line-80">
 <div class="content">
-<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<table class="tableblock frame-all grid-rows data-line-84" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -619,6 +624,10 @@ StreamingInterfaceINTEL</pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">5897</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">FPGAKernelAttributesINTELv2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6161</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">SchedulerTargetFmaxMhzINTEL</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">5903</p></td>
 </tr>
@@ -626,23 +635,27 @@ StreamingInterfaceINTEL</pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">StreamingInterfaceINTEL</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">6154</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">RegisterMapInterfaceINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6160</p></td>
+</tr>
 </tbody>
 </table>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1">
-<h2 id="_modifications_to_the_spir_v_specification_version_1_5">Modifications to the SPIR-V Specification, Version 1.5</h2>
+<div class="sect1 data-line-98">
+<h2 id="_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification, Version 1.6</h2>
 <div class="sectionbody">
-<div class="sect2">
+<div class="sect2 data-line-100">
 <h3 id="_execution_mode">Execution Mode</h3>
-<div class="paragraph">
+<div class="paragraph data-line-102">
 <p>Modify Section 3.6, Execution Mode, adding these rows to the Execution Mode table:</p>
 </div>
-<div class="openblock">
+<div class="openblock data-line-104">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stretch data-line-106">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -717,19 +730,29 @@ If <em>StallFreeReturn</em> is equal to zero, it indicates that the return inter
 <em>StallFreeReturn</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>FPGAKernelAttributesINTEL</strong></p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6160</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>RegisterMapInterfaceINTEL</strong><br>
+Indicates that the kernel has a single register based interface that is shared across all kernel control signals and kernel arguments.
+<em>AcceptDownstreamStall</em> is a boolean type scalar.
+If <em>AcceptDownstreamStall</em> is <code>true</code>, it indicates that the kernel interface will contain a stall register that can be used to back-pressure the kernel, while if it is <code>false</code>, it indicates that it will not.</p></td>
+<td class="tableblock halign-center valign-top" colspan="3"><p class="tableblock">Literal<br>
+<em>AcceptDownstreamStall</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>FPGAKernelAttributesINTELv2</strong></p></td>
+</tr>
 </tbody>
 </table>
 </div>
 </div>
 </div>
-<div class="sect2">
+<div class="sect2 data-line-166">
 <h3 id="_capability">Capability</h3>
-<div class="paragraph">
+<div class="paragraph data-line-168">
 <p>Modify Section 3.31, Capability, adding the following rows to the Capability table:</p>
 </div>
-<div class="openblock">
+<div class="openblock data-line-169">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stretch data-line-171">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -752,25 +775,36 @@ If <em>StallFreeReturn</em> is equal to zero, it indicates that the return inter
 <td class="tableblock halign-left valign-top"><p class="tableblock">FPGAKernelAttributesINTEL</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6161</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">FPGAKernelAttributesINTELv2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">FPGAKernelAttributesINTEL</p></td>
+</tr>
 </tbody>
 </table>
 </div>
 </div>
 </div>
+<div class="sect2 data-line-179">
+<h3 id="_validation_rules">Validation Rules</h3>
+<div class="paragraph data-line-181">
+<p>It is illegal to specify both <strong>StreamingInterfaceINTEL</strong> and <strong>RegisterMapInterfaceINTEL</strong> modes on the same entry point.</p>
 </div>
 </div>
-<div class="sect1">
+</div>
+</div>
+<div class="sect1 data-line-183">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph">
+<div class="paragraph data-line-185">
 <p>None.</p>
 </div>
 </div>
 </div>
-<div class="sect1">
+<div class="sect1 data-line-187">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stretch data-line-192">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">
@@ -804,6 +838,12 @@ If <em>StallFreeReturn</em> is equal to zero, it indicates that the return inter
 <td class="tableblock halign-left valign-top"><p class="tableblock">Ajaykumar Kannan</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Added one new execution mode, StreamingInterfaceINTEL.</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2022-12-05</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Abhishek Tiwari</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Added one new execution mode, RegisterMapInterfaceINTEL, under a new compatibility.</p></td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -811,7 +851,7 @@ If <em>StallFreeReturn</em> is equal to zero, it indicates that the return inter
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2021-09-21 12:25:23 -0300
+Last updated 2022-12-08 08:30:43 -0800
 </div>
 </div>
 </body>


### PR DESCRIPTION
FPGA kernels can have two types of interfaces - streaming based or register based. This PR adds a new execution mode (`RegisterMapInterfaceINTEL`) which specifies a 'register' based interface. 

`RegisterMapInterfaceINTEL` is being added to the existing `SPV_INTEL_kernel_attributes` extension as this extension already has the other execution mode (`StreamingInterfaceINTEL`) that represents the streaming based interface. We want to keep these two related modes together in one extension document.

To allow backwards compatibility, the new mode is guarded by a new capability `FPGAKernelAttributesv2INTEL`.