### PR TITLE
Update Execution Mode argument name to match name in the SYCL extension

### DIFF
--- a/extensions/INTEL/SPV_INTEL_kernel_attributes.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_kernel_attributes.asciidoc
@@ -154,10 +154,10 @@ _StallFreeReturn_
 
 | 6160 | *RegisterMapInterfaceINTEL* +
 Indicates that the kernel has a single register based interface that is shared across all kernel control signals and kernel arguments.
-_wait_for_done_write_ is a boolean type scalar.
-If _wait_for_done_write_ is `true`, it indicates that the kernel interface will contain a stall register that can be used to back-pressure the kernel, while if it is `false`, it indicates that it will not.
+_WaitForDoneWrite_ is a boolean type scalar.
+If _WaitForDoneWrite_ is `true`, it indicates that the kernel interface will contain a stall register that can be used to back-pressure the kernel, while if it is `false`, it indicates that it will not.
 3+^| Literal +
-_wait_for_done_write_
+_WaitForDoneWrite_
 | *FPGAKernelAttributesv2INTEL*
 
 |====

--- a/extensions/INTEL/SPV_INTEL_kernel_attributes.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_kernel_attributes.asciidoc
@@ -154,10 +154,10 @@ _StallFreeReturn_
 
 | 6160 | *RegisterMapInterfaceINTEL* +
 Indicates that the kernel has a single register based interface that is shared across all kernel control signals and kernel arguments.
-_AcceptDownstreamStall_ is a boolean type scalar.
-If _AcceptDownstreamStall_ is `true`, it indicates that the kernel interface will contain a stall register that can be used to back-pressure the kernel, while if it is `false`, it indicates that it will not.
+_wait_for_done_write_ is a boolean type scalar.
+If _wait_for_done_write_ is `true`, it indicates that the kernel interface will contain a stall register that can be used to back-pressure the kernel, while if it is `false`, it indicates that it will not.
 3+^| Literal +
-_AcceptDownstreamStall_
+_wait_for_done_write_
 | *FPGAKernelAttributesv2INTEL*
 
 |====

--- a/extensions/INTEL/SPV_INTEL_kernel_attributes.html
+++ b/extensions/INTEL/SPV_INTEL_kernel_attributes.html
@@ -734,10 +734,10 @@ If <em>StallFreeReturn</em> is equal to zero, it indicates that the return inter
 <td class="tableblock halign-left valign-top"><p class="tableblock">6160</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>RegisterMapInterfaceINTEL</strong><br>
 Indicates that the kernel has a single register based interface that is shared across all kernel control signals and kernel arguments.
-<em>AcceptDownstreamStall</em> is a boolean type scalar.
-If <em>AcceptDownstreamStall</em> is <code>true</code>, it indicates that the kernel interface will contain a stall register that can be used to back-pressure the kernel, while if it is <code>false</code>, it indicates that it will not.</p></td>
+<em>WaitForDoneWrite</em> is a boolean type scalar.
+If <em>WaitForDoneWrite</em> is <code>true</code>, it indicates that the kernel interface will contain a stall register that can be used to back-pressure the kernel, while if it is <code>false</code>, it indicates that it will not.</p></td>
 <td class="tableblock halign-center valign-top" colspan="3"><p class="tableblock">Literal<br>
-<em>AcceptDownstreamStall</em></p></td>
+<em>WaitForDoneWrite</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>FPGAKernelAttributesv2INTEL</strong></p></td>
 </tr>
 </tbody>


### PR DESCRIPTION
The argument name for the mode `RegisterMapInterfaceINTEL` in the SPIRV spec does not match the name in the [SYCL extension](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_intel_fpga_kernel_interface_properties.asciidoc) 
 (see property `register_map_interface`). This PR updates the SPIRV extension to align the names.