### PR TITLE
add a Makefile to compile asciidoc files to HTML

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -8,7 +8,7 @@ Khronos recommends using [Asciidoc](https://asciidoc-py.github.io/index.html) to
 Asciidoc is a text-based document format that is easy to store and manage in a version control system, like this GitHub repo.
 For information about the Asciidoc format, please refer to the online documentation.
 
-For most SPIR-V specifications it is usually easiest to copy and modify an existing SPIR-V extension specification, to ensure there are no missing sections and to have a consistent look-and-feel.
+For most SPIR-V specifications it is easiest to copy and modify an existing SPIR-V extension specification, to ensure there are no missing sections and to have a consistent look-and-feel.
 
 ## Converting from Asciidoc to HTML
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,27 @@
+# Building HTML Specifications
+
+This document describes how to create HTML specifications for this repo.
+
+## Asciidoc Specification Source
+
+Khronos recommends using [Asciidoc](https://asciidoc-py.github.io/index.html) to author SPIR-V extensions.
+Asciidoc is a text-based document format that is easy to store and manage in a version control system, like this GitHub repo.
+For information about the Asciidoc format, please refer to the online documentation.
+
+For most SPIR-V specifications it is usually easiest to copy and modify an existing SPIR-V extension specification, to ensure there are no missing sections and to have a consistent look-and-feel.
+
+## Converting from Asciidoc to HTML
+
+The Asciidoc toolchain supports many output formats.
+To publish an extension in this repo, generate an HTML specification.
+
+Most specifications in this repo are built with the older Asciidoc toolchain.
+Please refer to the online documentation to install the Asciidoc toolchain.
+
+A recommended command line to build an HTML specification from Asciidoc source is:
+
+```sh
+$ asciidoc -b html5 -a icons -a toc2 -a toclevels=1 -o SPV_my_extension.html SPV_my_extension.asciidoc
+```
+
+The included Makefile in this repo can also be used to generate an HTML specification from Asciidoc source.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+# Copyright (c) 2023 The Khronos Group Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ASCIIDOC ?= asciidoc
+DOS2UNIX ?= dos2unix
+
+SRC_ASCIIDOC = $(wildcard extensions/*/*.asciidoc)
+DST_HTML = $(SRC_ASCIIDOC:.asciidoc=.html)
+
+all: $(DST_HTML)
+
+%.html: %.asciidoc
+	$(ASCIIDOC) -b html5 -a icons -a toc2 -a toclevels=1 -o $@ $<
+	$(DOS2UNIX) $@

--- a/README.md
+++ b/README.md
@@ -124,3 +124,7 @@ Khronos SPIR-V Registry](https://www.khronos.org/registry/spir-v/).
 1. [NonSemantic.ClspvReflection]( http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/nonsemantic/NonSemantic.ClspvReflection.html)
 1. [NonSemantic.Shader.DebugInfo.100]( http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/nonsemantic/NonSemantic.Shader.DebugInfo.100.html)
 1. [NonSemantic.DebugBreak]( http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/nonsemantic/NonSemantic.DebugBreak.html)
+
+## Building HTML Specifications
+
+Please see [BUILD.md](BUILD.md) for instructions to create an HTML specification for this repo.


### PR DESCRIPTION
Possible fix for #181 

This PR adds a Makefile to create an HTML spec from asciidoc spec source in the extensions directory.

I haven't updated the README with these instructions but perhaps the Makefile is good enough?  Or should we include best practices in a separate document?  The README is primarily an index with links to HTML specs right now.

Note also this is still using the older asciidoc toolchain but we can shift to asciidoctor if we'd like, we just need to figure out which command line to use.