### PR TITLE
Clarifications to SPV_KHR_cooperative_matrix

### DIFF
--- a/extensions/KHR/SPV_KHR_cooperative_matrix.asciidoc
+++ b/extensions/KHR/SPV_KHR_cooperative_matrix.asciidoc
@@ -55,8 +55,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2023-07-26
-| Revision           | 4
+| Last Modified Date | 2023-12-06
+| Revision           | 5
 |========================================
 
 Dependencies
@@ -268,6 +268,10 @@ where all invocations in 'Scope' cooperate to compute and store the matrix. +
 'Use' must be a 'constant instruction' scalar 32-bit 'integer type' whose
 value corresponds to a 'Cooperative Matrix Use'. +
  +
+All dynamic instances of an instruction with an operand or result that is an
+object of this type must be executed such that all the invocations in the
+'Scope' instance are active or none of them are.
+ +
 1+|Capability: +
 *CooperativeMatrixKHR*
 1+| 7 | 4456 | 'Result <id>' | '<id>' +
@@ -309,14 +313,12 @@ a description of the layouts and detailed layout-specific rules. +
 'Stride' further qualifies how matrix elements are laid out in memory. It must be a
 scalar 'integer type' and its exact semantics depend on 'MemoryLayout'. +
  +
-'Memory Operand' must be a +Memory Operand+ literal. If not present, it is the
-same as specifying *None*. +
+'Memory Operand', if present, must begin with a +Memory Operand+ literal. If not
+present, it is the same as specifying the +Memory Operand+ *None*. +
  +
-For a given dynamic instance of this instruction, all operands of this
-instruction must be the same for all invocations in a given scope instance
-(where the scope is the scope the cooperative matrix type was created with).
-All invocations in a given scope instance must be active or all must be
-inactive.
+All the operands to this instruction must be dynamically uniform within every
+instance of the 'Scope' of the cooperative matrix.
+ +
 1+|Capability: +
 *CooperativeMatrixKHR*
 1+| 5+variable | 4457 | '<id>' +
@@ -348,14 +350,12 @@ a description of the layouts and detailed layout-specific rules. +
 'Stride' further qualifies how matrix elements are laid out in memory. It must be a
 scalar 'integer type' and its exact semantics depend on 'MemoryLayout'. +
  +
-'Memory Operand' must be a +Memory Operand+ literal. If not present, it is the
-same as specifying *None*. +
+'Memory Operand', if present, must begin with a +Memory Operand+ literal. If not
+present, it is the same as specifying the +Memory Operand+ *None*. +
  +
-For a given dynamic instance of this instruction, all operands of this
-instruction must be the same for all invocations in a given scope instance
-(where the scope is the scope the cooperative matrix type was created with).
-All invocations in a given scope instance must be active or all must be
-inactive.
+All the operands to this instruction must be dynamically uniform within every
+instance of the 'Scope' of the cooperative matrix.
+ +
 1+|Capability: +
 *CooperativeMatrixKHR*
 1+| 4+variable | 4458 | '<id>' +
@@ -386,20 +386,24 @@ invocation when treated as a composite. +
 3.42.11 Conversion Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Allow cooperative matrix types for the following conversion instructions (if
-the component types are appropriate): *OpConvertFToU*, *OpConvertFToS*,
+Allow values of cooperative matrix type for the following conversion instructions
+(if the component types are appropriate): *OpConvertFToU*, *OpConvertFToS*,
 *OpConvertSToF*, *OpConvertUToF*, *OpUConvert*, *OpSConvert*, *OpFConvert*.
-Allow the use of *OpBitcast* on cooperative matrix types whose 'Component Type'
-are integer types with the same 'Width'.
+Allow the use of *OpBitcast* on objects of cooperative matrix type whose
+'Component Type' are integer types with the same 'Width'.
 The result type and value type must have the same 'Scope', number of 'Rows',
 number of 'Columns', and 'Use'.
+
+All the operands to this instruction must be dynamically uniform within every
+instance of the 'Scope' of the cooperative matrix.
 
 3.42.12 Composite Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Modify *OpCompositeConstruct* to make an exception for cooperative matrix types:
 "If the 'Result Type' is a cooperative matrix type, then there must be only one
-'Constituent' and it is used to initialize all members."
+'Constituent' and it is used to initialize all members. The 'Constituent' must
+be dynamically uniform within the 'Scope' of the cooperative matrix type.
 
 3.42.13 Arithmetic Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -451,9 +455,9 @@ _Cooperative Matrix Operand_ is present and are treated as unsigned otherwise. +
 'Cooperative Matrix Operands' is an optional _Cooperative Matrix Operand_ literal. If
 not present, it is the same as specifying the _Cooperative Matrix Operand_ *None*. +
  +
-For a given dynamic instance of this instruction, all invocations in a given
-scope instance must be active or all must be inactive (where the scope is the
-scope of the operation). +
+All the operands to this instruction must be dynamically uniform within every
+instance of the 'Scope' of the cooperative matrix.
+ +
 1+|Capability: +
 *CooperativeMatrixKHR*
 1+| 6+variable | 4459 | '<id>' +
@@ -484,6 +488,9 @@ Binary arithmetic instructions operate on the individual elements of a pair
 of cooperative matrices whose type must match.
 
 Allow cooperative matrix types for *OpMatrixTimesScalar*.
+
+All the operands to this instruction must be dynamically uniform within every
+instance of the 'Scope' of the cooperative matrix.
 
 Issues
 ------
@@ -588,6 +595,30 @@ using *OpConstantComposite* or by iterating over the elements of the
 cooperative matrix to multiply each element by the scalar.
 --
 
+. Both the _Stride_ and _Memory Operand_ operands to *OpCooperativeMatrixLoadKHR*
+and *OpCooperativeMatrixStoreKHR* are optional. Can _Memory Operand_ be provided
+alone?
++
+--
+*RESOLVED*: No, in line with core SPIR-V rules, all optional operands that
+appear before a given optional operand must be provided for it to be possible to
+provide that given optional operand. Only the following combinations are valid:
+
+  * None of the optional operands are present.
+  * _Stride_ alone is present.
+  * _Stride_ and _Memory Operand_ are both present.
+--
+
+. Can elements of cooperative matrix objects treated as composites be
+accessed in non-uniform control flow?
++
+--
+*RESOLVED*: Yes, control flow uniformity requirements apply to instructions
+whose operands are cooperative matrix objects but not pointers to cooperative
+matrix objects. Dereferencing a pointer to an element of a cooperative matrix
+object can be done in non-uniform control flow.
+--
+
 Revision History
 ----------------
 
@@ -596,6 +627,7 @@ Revision History
 [options="header"]
 |========================================
 |Rev|Date|Author|Changes
+|5|2023-12-06|Kevin Petit|Clarifications, mostly of uniformity rules
 |4|2023-07-26|Kevin Petit|Add KHR suffixes to Cooperative Matrix Operands
 |3|2023-05-03|Kevin Petit|Initial revision of SPV_KHR_cooperative_matrix
 |2|2019-07-12|Jeff Bolz|Added details for integer operations

--- a/extensions/KHR/SPV_KHR_cooperative_matrix.html
+++ b/extensions/KHR/SPV_KHR_cooperative_matrix.html
@@ -1,8 +1,10 @@
-<!DOCTYPE html>
-<html lang="en">
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
+    "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta name="generator" content="AsciiDoc 10.1.2">
+<meta http-equiv="Content-Type" content="application/xhtml+xml; charset=UTF-8" />
+<meta name="generator" content="AsciiDoc 10.1.2" />
 <title>SPV_KHR_cooperative_matrix</title>
 <style type="text/css">
 /* Shared CSS for AsciiDoc xhtml11 and html5 backends */
@@ -534,40 +536,6 @@ body.manpage div.sectionbody {
 }
 
 
-@media screen {
-  body {
-    max-width: 50em; /* approximately 80 characters wide */
-    margin-left: 16em;
-  }
-
-  #toc {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 13em;
-    padding: 0.5em;
-    padding-bottom: 1.5em;
-    margin: 0;
-    overflow: auto;
-    border-right: 3px solid #f8f8f8;
-    background-color: white;
-  }
-
-  #toc .toclevel1 {
-    margin-top: 0.5em;
-  }
-
-  #toc .toclevel2 {
-    margin-top: 0.25em;
-    display: list-item;
-    color: #aaaaaa;
-  }
-
-  #toctitle {
-    margin-top: 0.5em;
-  }
-}
 </style>
 <script type="text/javascript">
 /*<![CDATA[*/
@@ -760,17 +728,13 @@ install: function(toclevels) {
 }
 
 }
-asciidoc.install(1);
+asciidoc.install();
 /*]]>*/
 </script>
 </head>
 <body class="article">
 <div id="header">
 <h1>SPV_KHR_cooperative_matrix</h1>
-<div id="toc">
-  <div id="toctitle">Table of Contents</div>
-  <noscript><p><b>JavaScript must be enabled in your browser to display the table of contents.</b></p></noscript>
-</div>
 </div>
 <div id="content">
 <div class="sect1">
@@ -925,23 +889,25 @@ Approved by the Khronos Board of Promoters: 2023-06-16
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all"
-style="
-width:40%;
-">
-<col style="width:50%;">
-<col style="width:50%;">
+<div class="tableblock">
+<table rules="all"
+width="40%"
+frame="border"
+cellspacing="0" cellpadding="4">
+<col width="50%" />
+<col width="50%" />
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2023-07-26</p></td>
+<td align="left" valign="top"><p class="table">Last Modified Date</p></td>
+<td align="left" valign="top"><p class="table">2023-12-06</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
+<td align="left" valign="top"><p class="table">Revision</p></td>
+<td align="left" valign="top"><p class="table">5</p></td>
 </tr>
 </tbody>
 </table>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -975,8 +941,8 @@ this extension allows all scope ids to be specialization constants.</p></div>
 <div class="paragraph"><p>To use this extension within a SPIR-V module, the following
 <strong>OpExtension</strong> must be present in the module:</p></div>
 <div class="listingblock">
-<div class="content monospaced">
-<pre>OpExtension "SPV_KHR_cooperative_matrix"</pre>
+<div class="content">
+<pre><code>OpExtension "SPV_KHR_cooperative_matrix"</code></pre>
 </div></div>
 </div>
 </div>
@@ -1071,28 +1037,30 @@ to "Not valid with <strong>OpStore</strong> or <strong>OpCooperativeMatrixStoreK
 <div class="paragraph"><p>Modify Section 3.31, "Capability", adding these rows to the Capability table:</p></div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:33%;">
-<col style="width:33%;">
+<div class="tableblock">
+<table rules="all"
+width="100%"
+frame="border"
+cellspacing="0" cellpadding="4">
+<col width="33%" />
+<col width="33%" />
+<col width="33%" />
 <thead>
 <tr>
-<th class="tableblock halign-center valign-top" colspan="2" > Capability </th>
-<th class="tableblock halign-center valign-top" > Enabling Capabilities</th>
+<th colspan="2" align="center" valign="top"> Capability </th>
+<th align="center" valign="top"> Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6022</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CooperativeMatrixKHR</strong><br>
+<td align="left" valign="top"><p class="table">6022</p></td>
+<td align="left" valign="top"><p class="table"><strong>CooperativeMatrixKHR</strong><br />
 Enables cooperative matrix types and instructions operating on them.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
+<td align="left" valign="top"><p class="table"></p></td>
 </tr>
 </tbody>
 </table>
+</div>
 </div></div>
 </div>
 <div class="sect2">
@@ -1100,57 +1068,59 @@ Enables cooperative matrix types and instructions operating on them.</p></td>
 <div class="paragraph"><p>New section in 3 "Binary Form".</p></div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:33%;">
-<col style="width:33%;">
+<div class="tableblock">
+<table rules="all"
+width="100%"
+frame="border"
+cellspacing="0" cellpadding="4">
+<col width="33%" />
+<col width="33%" />
+<col width="33%" />
 <thead>
 <tr>
-<th class="tableblock halign-center valign-top" colspan="2" > Cooperative Matrix Operands </th>
-<th class="tableblock halign-left valign-top" > Enabling Capabilities</th>
+<th colspan="2" align="center" valign="top"> Cooperative Matrix Operands </th>
+<th align="left" valign="top"> Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>NoneKHR</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
+<td align="left" valign="top"><p class="table">0x0</p></td>
+<td align="left" valign="top"><p class="table"><strong>NoneKHR</strong></p></td>
+<td align="left" valign="top"><p class="table"></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>MatrixASignedComponentsKHR</strong><br>
+<td align="left" valign="top"><p class="table">0x1</p></td>
+<td align="left" valign="top"><p class="table"><strong>MatrixASignedComponentsKHR</strong><br />
 The components of matrix A are treated as signed.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
+<td align="left" valign="top"><p class="table"></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>MatrixBSignedComponentsKHR</strong><br>
+<td align="left" valign="top"><p class="table">0x2</p></td>
+<td align="left" valign="top"><p class="table"><strong>MatrixBSignedComponentsKHR</strong><br />
 The components of matrix B are treated as signed.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
+<td align="left" valign="top"><p class="table"></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>MatrixCSignedComponentsKHR</strong><br>
+<td align="left" valign="top"><p class="table">0x4</p></td>
+<td align="left" valign="top"><p class="table"><strong>MatrixCSignedComponentsKHR</strong><br />
 The components of matrix C are treated as signed.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
+<td align="left" valign="top"><p class="table"></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x8</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>MatrixResultSignedComponentsKHR</strong><br>
+<td align="left" valign="top"><p class="table">0x8</p></td>
+<td align="left" valign="top"><p class="table"><strong>MatrixResultSignedComponentsKHR</strong><br />
 The components of matrix Result are treated as signed.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
+<td align="left" valign="top"><p class="table"></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x10</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>SaturatingAccumulationKHR</strong><br>
+<td align="left" valign="top"><p class="table">0x10</p></td>
+<td align="left" valign="top"><p class="table"><strong>SaturatingAccumulationKHR</strong><br />
 The accumulation of <em>A</em> x <em>B</em> and <em>C</em> performed by <strong>OpCooperativeMatrixMulAddKHR</strong> is saturating.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
+<td align="left" valign="top"><p class="table"></p></td>
 </tr>
 </tbody>
 </table>
+</div>
 </div></div>
 </div>
 <div class="sect2">
@@ -1158,23 +1128,24 @@ The accumulation of <em>A</em> x <em>B</em> and <em>C</em> performed by <strong>
 <div class="paragraph"><p>New section in 3 "Binary Form".</p></div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:33%;">
-<col style="width:33%;">
+<div class="tableblock">
+<table rules="all"
+width="100%"
+frame="border"
+cellspacing="0" cellpadding="4">
+<col width="33%" />
+<col width="33%" />
+<col width="33%" />
 <thead>
 <tr>
-<th class="tableblock halign-center valign-top" colspan="2" > Cooperative Matrix Layout </th>
-<th class="tableblock halign-left valign-top" > Enabling Capabilities</th>
+<th colspan="2" align="center" valign="top"> Cooperative Matrix Layout </th>
+<th align="left" valign="top"> Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>RowMajorKHR</strong><br>
+<td align="left" valign="top"><p class="table">0x0</p></td>
+<td align="left" valign="top"><p class="table"><strong>RowMajorKHR</strong><br />
 Elements in rows of the matrix are laid out in contiguous memory locations. Rows
 are laid out with a fixed stride communicated via the <em>Stride</em> operand to
 <strong>OpCooperativeMatrixLoadKHR</strong> or <strong>OpCooperativeMatrixStoreKHR</strong> which must be
@@ -1184,11 +1155,11 @@ in order from contiguous locations starting at <em>Pointer</em>[row*<em>Stride</
 <strong>OpCooperativeMatrixStoreKHR</strong>. <em>Stride</em> must be greater than 0 when passed to
 <strong>OpCooperativeMatrixStoreKHR</strong> and must be greater than or equal to 0 when passed
 to <strong>OpCooperativeMatrixLoadKHR</strong>.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
+<td align="left" valign="top"><p class="table"></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>ColumnMajorKHR</strong><br>
+<td align="left" valign="top"><p class="table">0x1</p></td>
+<td align="left" valign="top"><p class="table"><strong>ColumnMajorKHR</strong><br />
 Elements in columns of the matrix are laid out in contiguous memory locations. Columns
 are laid out with a fixed stride communicated via the <em>Stride</em> operand to
 <strong>OpCooperativeMatrixLoadKHR</strong> or <strong>OpCooperativeMatrixStoreKHR</strong> which must be
@@ -1198,10 +1169,11 @@ in order from contiguous locations starting at <em>Pointer</em>[col*<em>Stride</
 <strong>OpCooperativeMatrixStoreKHR</strong>. <em>Stride</em> must be greater than 0 when passed to
 <strong>OpCooperativeMatrixStoreKHR</strong> and must be greater than or equal to 0 when passed
 to <strong>OpCooperativeMatrixLoadKHR</strong>.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
+<td align="left" valign="top"><p class="table"></p></td>
 </tr>
 </tbody>
 </table>
+</div>
 </div></div>
 </div>
 <div class="sect2">
@@ -1209,91 +1181,99 @@ to <strong>OpCooperativeMatrixLoadKHR</strong>.</p></td>
 <div class="paragraph"><p>New section in 3 "Binary Form".</p></div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:33%;">
-<col style="width:33%;">
+<div class="tableblock">
+<table rules="all"
+width="100%"
+frame="border"
+cellspacing="0" cellpadding="4">
+<col width="33%" />
+<col width="33%" />
+<col width="33%" />
 <thead>
 <tr>
-<th class="tableblock halign-center valign-top" colspan="2" > Cooperative Matrix Use </th>
-<th class="tableblock halign-left valign-top" > Enabling Capabilities</th>
+<th colspan="2" align="center" valign="top"> Cooperative Matrix Use </th>
+<th align="left" valign="top"> Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>MatrixAKHR</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
+<td align="left" valign="top"><p class="table">0</p></td>
+<td align="left" valign="top"><p class="table"><strong>MatrixAKHR</strong></p></td>
+<td align="left" valign="top"><p class="table"></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>MatrixBKHR</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
+<td align="left" valign="top"><p class="table">1</p></td>
+<td align="left" valign="top"><p class="table"><strong>MatrixBKHR</strong></p></td>
+<td align="left" valign="top"><p class="table"></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>MatrixAccumulatorKHR</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
+<td align="left" valign="top"><p class="table">2</p></td>
+<td align="left" valign="top"><p class="table"><strong>MatrixAccumulatorKHR</strong></p></td>
+<td align="left" valign="top"><p class="table"></p></td>
 </tr>
 </tbody>
 </table>
+</div>
 </div></div>
 </div>
 <div class="sect2">
 <h3 id="_3_42_6_type_declaration_instructions">3.42.6 Type-Declaration Instructions</h3>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:5%;">
-<col style="width:5%;">
-<col style="width:15%;">
-<col style="width:15%;">
-<col style="width:15%;">
-<col style="width:15%;">
-<col style="width:15%;">
-<col style="width:15%;">
+<div class="tableblock">
+<table rules="all"
+width="100%"
+frame="border"
+cellspacing="0" cellpadding="4">
+<col width="5%" />
+<col width="5%" />
+<col width="15%" />
+<col width="15%" />
+<col width="15%" />
+<col width="15%" />
+<col width="15%" />
+<col width="15%" />
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="7" ><p class="tableblock"><a id="OpTypeCooperativeMatrixKHR"></a><strong>OpTypeCooperativeMatrixKHR</strong><br>
-<br>
+<td colspan="7" align="left" valign="top"><p class="table"><a id="OpTypeCooperativeMatrixKHR"></a><strong>OpTypeCooperativeMatrixKHR</strong><br />
+<br />
 Declare a new cooperative matrix type with <em>Rows</em> rows and <em>Columns</em> columns,
-where all invocations in <em>Scope</em> cooperate to compute and store the matrix.<br>
-<br>
-<em>Component Type</em> must be a scalar <em>numerical type</em>.<br>
-<br>
-<em>Scope</em> must be a <em>constant instruction</em> with scalar 32-bit <em>integer type</em>.<br>
-<br>
-<em>Rows</em> must be a <em>constant instruction</em> with scalar 32-bit <em>integer type</em>.<br>
-<br>
-<em>Columns</em> must be a <em>constant instruction</em> with scalar 32-bit <em>integer type</em>.<br>
-<br>
+where all invocations in <em>Scope</em> cooperate to compute and store the matrix.<br />
+<br />
+<em>Component Type</em> must be a scalar <em>numerical type</em>.<br />
+<br />
+<em>Scope</em> must be a <em>constant instruction</em> with scalar 32-bit <em>integer type</em>.<br />
+<br />
+<em>Rows</em> must be a <em>constant instruction</em> with scalar 32-bit <em>integer type</em>.<br />
+<br />
+<em>Columns</em> must be a <em>constant instruction</em> with scalar 32-bit <em>integer type</em>.<br />
+<br />
 <em>Use</em> must be a <em>constant instruction</em> scalar 32-bit <em>integer type</em> whose
-value corresponds to a <em>Cooperative Matrix Use</em>.<br>
-<br></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+value corresponds to a <em>Cooperative Matrix Use</em>.<br />
+<br />
+All dynamic instances of an instruction with an operand or result that is an
+object of this type must be executed such that all the invocations in the
+<em>Scope</em> instance are active or none of them are.
+<br /></p></td>
+<td align="left" valign="top"><p class="table">Capability:<br />
 <strong>CooperativeMatrixKHR</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4456</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td align="left" valign="top"><p class="table">7</p></td>
+<td align="left" valign="top"><p class="table">4456</p></td>
+<td align="left" valign="top"><p class="table"><em>Result &lt;id&gt;</em></p></td>
+<td align="left" valign="top"><p class="table"><em>&lt;id&gt;</em><br />
 <em>Component Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Scope <em>&lt;id&gt;</em><br>
+<td align="left" valign="top"><p class="table">Scope <em>&lt;id&gt;</em><br />
 <em>Scope</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td align="left" valign="top"><p class="table"><em>&lt;id&gt;</em><br />
 <em>Rows</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td align="left" valign="top"><p class="table"><em>&lt;id&gt;</em><br />
 <em>Columns</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td align="left" valign="top"><p class="table"><em>&lt;id&gt;</em><br />
 <em>Use</em></p></td>
 </tr>
 </tbody>
 </table>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_3_42_7_constant_creation_instructions">3.42.7 Constant-Creation Instructions</h3>
@@ -1303,194 +1283,200 @@ value corresponds to a <em>Cooperative Matrix Use</em>.<br>
 </div>
 <div class="sect2">
 <h3 id="_3_42_8_memory_instructions">3.42.8 Memory Instructions</h3>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:5%;">
-<col style="width:5%;">
-<col style="width:15%;">
-<col style="width:15%;">
-<col style="width:15%;">
-<col style="width:15%;">
-<col style="width:15%;">
-<col style="width:15%;">
+<div class="tableblock">
+<table rules="all"
+width="100%"
+frame="border"
+cellspacing="0" cellpadding="4">
+<col width="5%" />
+<col width="5%" />
+<col width="15%" />
+<col width="15%" />
+<col width="15%" />
+<col width="15%" />
+<col width="15%" />
+<col width="15%" />
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="7" ><p class="tableblock"><a id="OpCooperativeMatrixLoadKHR"></a><strong>OpCooperativeMatrixLoadKHR</strong><br>
-<br>
-Load a cooperative matrix through a pointer.<br>
-<br>
+<td colspan="7" align="left" valign="top"><p class="table"><a id="OpCooperativeMatrixLoadKHR"></a><strong>OpCooperativeMatrixLoadKHR</strong><br />
+<br />
+Load a cooperative matrix through a pointer.<br />
+<br />
 <em>Result Type</em> is the type of the loaded object. It must be a cooperative matrix
-type.<br>
-<br>
+type.<br />
+<br />
 <em>Pointer</em> is a pointer. Its type must be an <strong>OpTypePointer</strong> whose <em>Type</em> operand
 is a scalar or vector type. If the <strong>Shader</strong> capability was declared, <em>Pointer</em>
-must point into an array and any <strong>ArrayStride</strong> decoration on <em>Pointer</em> is ignored.<br>
-<br>
+must point into an array and any <strong>ArrayStride</strong> decoration on <em>Pointer</em> is ignored.<br />
+<br />
 <em>MemoryLayout</em> specifies how matrix elements are laid out in memory. It must come
 from a 32-bit integer <em>constant instruction</em> whose value corresponds to a
 <em>Cooperative Matrix Layout</em>. See the <em>Cooperative Matrix Layout</em> table for
-a description of the layouts and detailed layout-specific rules.<br>
-<br>
+a description of the layouts and detailed layout-specific rules.<br />
+<br />
 <em>Stride</em> further qualifies how matrix elements are laid out in memory. It must be a
-scalar <em>integer type</em> and its exact semantics depend on <em>MemoryLayout</em>.<br>
-<br>
-<em>Memory Operand</em> must be a <span class="monospaced">Memory Operand</span> literal. If not present, it is the
-same as specifying <strong>None</strong>.<br>
-<br>
-For a given dynamic instance of this instruction, all operands of this
-instruction must be the same for all invocations in a given scope instance
-(where the scope is the scope the cooperative matrix type was created with).
-All invocations in a given scope instance must be active or all must be
-inactive.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+scalar <em>integer type</em> and its exact semantics depend on <em>MemoryLayout</em>.<br />
+<br />
+<em>Memory Operand</em>, if present, must begin with a <code>Memory Operand</code> literal. If not
+present, it is the same as specifying the <code>Memory Operand</code> <strong>None</strong>.<br />
+<br />
+All the operands to this instruction must be dynamically uniform within every
+instance of the <em>Scope</em> of the cooperative matrix.
+<br /></p></td>
+<td align="left" valign="top"><p class="table">Capability:<br />
 <strong>CooperativeMatrixKHR</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5+variable</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4457</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td align="left" valign="top"><p class="table">5+variable</p></td>
+<td align="left" valign="top"><p class="table">4457</p></td>
+<td align="left" valign="top"><p class="table"><em>&lt;id&gt;</em><br />
 <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td align="left" valign="top"><p class="table"><em>Result &lt;id&gt;</em></p></td>
+<td align="left" valign="top"><p class="table"><em>&lt;id&gt;</em><br />
 <em>Pointer</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td align="left" valign="top"><p class="table"><em>&lt;id&gt;</em><br />
 <em>MemoryLayout</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Optional <em>&lt;id&gt;</em><br>
+<td align="left" valign="top"><p class="table">Optional <em>&lt;id&gt;</em><br />
 <em>Stride</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Optional<br>
+<td align="left" valign="top"><p class="table">Optional<br />
 <em>Memory Operand</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:5%;">
-<col style="width:5%;">
-<col style="width:17%;">
-<col style="width:17%;">
-<col style="width:17%;">
-<col style="width:17%;">
-<col style="width:17%;">
+</div>
+<div class="tableblock">
+<table rules="all"
+width="100%"
+frame="border"
+cellspacing="0" cellpadding="4">
+<col width="5%" />
+<col width="5%" />
+<col width="17%" />
+<col width="17%" />
+<col width="17%" />
+<col width="17%" />
+<col width="17%" />
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpCooperativeMatrixStoreKHR"></a><strong>OpCooperativeMatrixStoreKHR</strong><br>
-<br>
-Store a cooperative matrix through a pointer.<br>
-<br>
+<td colspan="6" align="left" valign="top"><p class="table"><a id="OpCooperativeMatrixStoreKHR"></a><strong>OpCooperativeMatrixStoreKHR</strong><br />
+<br />
+Store a cooperative matrix through a pointer.<br />
+<br />
 <em>Pointer</em> is a pointer. Its type must be an <strong>OpTypePointer</strong> whose <em>Type</em> operand
 is a scalar or vector type. If the <strong>Shader</strong> capability was declared, <em>Pointer</em>
-must point into an array and any <strong>ArrayStride</strong> decoration on <em>Pointer</em> is ignored.<br>
-<br>
+must point into an array and any <strong>ArrayStride</strong> decoration on <em>Pointer</em> is ignored.<br />
+<br />
 <em>Object</em> is the object to store. Its type must be an
-<strong>OpTypeCooperativeMatrixKHR</strong>.<br>
-<br>
+<strong>OpTypeCooperativeMatrixKHR</strong>.<br />
+<br />
 <em>MemoryLayout</em> specifies how matrix elements are laid out in memory. It must come
 from a 32-bit integer <em>constant instruction</em> whose value corresponds to a
 <em>Cooperative Matrix Layout</em>. See the <em>Cooperative Matrix Layout</em> table for
-a description of the layouts and detailed layout-specific rules.<br>
-<br>
+a description of the layouts and detailed layout-specific rules.<br />
+<br />
 <em>Stride</em> further qualifies how matrix elements are laid out in memory. It must be a
-scalar <em>integer type</em> and its exact semantics depend on <em>MemoryLayout</em>.<br>
-<br>
-<em>Memory Operand</em> must be a <span class="monospaced">Memory Operand</span> literal. If not present, it is the
-same as specifying <strong>None</strong>.<br>
-<br>
-For a given dynamic instance of this instruction, all operands of this
-instruction must be the same for all invocations in a given scope instance
-(where the scope is the scope the cooperative matrix type was created with).
-All invocations in a given scope instance must be active or all must be
-inactive.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+scalar <em>integer type</em> and its exact semantics depend on <em>MemoryLayout</em>.<br />
+<br />
+<em>Memory Operand</em>, if present, must begin with a <code>Memory Operand</code> literal. If not
+present, it is the same as specifying the <code>Memory Operand</code> <strong>None</strong>.<br />
+<br />
+All the operands to this instruction must be dynamically uniform within every
+instance of the <em>Scope</em> of the cooperative matrix.
+<br /></p></td>
+<td align="left" valign="top"><p class="table">Capability:<br />
 <strong>CooperativeMatrixKHR</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4+variable</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4458</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td align="left" valign="top"><p class="table">4+variable</p></td>
+<td align="left" valign="top"><p class="table">4458</p></td>
+<td align="left" valign="top"><p class="table"><em>&lt;id&gt;</em><br />
 <em>Pointer</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td align="left" valign="top"><p class="table"><em>&lt;id&gt;</em><br />
 <em>Object</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td align="left" valign="top"><p class="table"><em>&lt;id&gt;</em><br />
 <em>MemoryLayout</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Optional <em>&lt;id&gt;</em><br>
+<td align="left" valign="top"><p class="table">Optional <em>&lt;id&gt;</em><br />
 <em>Stride</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Optional<br>
+<td align="left" valign="top"><p class="table">Optional<br />
 <em>Memory Operand</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:9%;">
-<col style="width:9%;">
-<col style="width:27%;">
-<col style="width:27%;">
-<col style="width:27%;">
+</div>
+<div class="tableblock">
+<table rules="all"
+width="100%"
+frame="border"
+cellspacing="0" cellpadding="4">
+<col width="9%" />
+<col width="9%" />
+<col width="27%" />
+<col width="27%" />
+<col width="27%" />
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><a id="OpCooperativeMatrixLengthKHR"></a><strong>OpCooperativeMatrixLengthKHR</strong><br>
-<br>
+<td colspan="4" align="left" valign="top"><p class="table"><a id="OpCooperativeMatrixLengthKHR"></a><strong>OpCooperativeMatrixLengthKHR</strong><br />
+<br />
 Number of components of a cooperative matrix type accessible to the current
-invocation when treated as a composite.<br>
-<br>
-<em>Result Type</em> must be an <strong>OpTypeInt</strong> with 32-bit <em>Width</em> and 0 <em>Signedness</em>.<br>
-<br>
-<em>Type</em> is a cooperative matrix type.<br></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+invocation when treated as a composite.<br />
+<br />
+<em>Result Type</em> must be an <strong>OpTypeInt</strong> with 32-bit <em>Width</em> and 0 <em>Signedness</em>.<br />
+<br />
+<em>Type</em> is a cooperative matrix type.<br /></p></td>
+<td align="left" valign="top"><p class="table">Capability:<br />
 <strong>CooperativeMatrixKHR</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4460</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td align="left" valign="top"><p class="table">4</p></td>
+<td align="left" valign="top"><p class="table">4460</p></td>
+<td align="left" valign="top"><p class="table"><em>&lt;id&gt;</em><br />
 <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td align="left" valign="top"><p class="table"><em>Result &lt;id&gt;</em></p></td>
+<td align="left" valign="top"><p class="table"><em>&lt;id&gt;</em><br />
 <em>Type</em></p></td>
 </tr>
 </tbody>
 </table>
 </div>
+</div>
 <div class="sect2">
 <h3 id="_3_42_11_conversion_instructions">3.42.11 Conversion Instructions</h3>
-<div class="paragraph"><p>Allow cooperative matrix types for the following conversion instructions (if
-the component types are appropriate): <strong>OpConvertFToU</strong>, <strong>OpConvertFToS</strong>,
+<div class="paragraph"><p>Allow values of cooperative matrix type for the following conversion instructions
+(if the component types are appropriate): <strong>OpConvertFToU</strong>, <strong>OpConvertFToS</strong>,
 <strong>OpConvertSToF</strong>, <strong>OpConvertUToF</strong>, <strong>OpUConvert</strong>, <strong>OpSConvert</strong>, <strong>OpFConvert</strong>.
-Allow the use of <strong>OpBitcast</strong> on cooperative matrix types whose <em>Component Type</em>
-are integer types with the same <em>Width</em>.
+Allow the use of <strong>OpBitcast</strong> on objects of cooperative matrix type whose
+<em>Component Type</em> are integer types with the same <em>Width</em>.
 The result type and value type must have the same <em>Scope</em>, number of <em>Rows</em>,
 number of <em>Columns</em>, and <em>Use</em>.</p></div>
+<div class="paragraph"><p>All the operands to this instruction must be dynamically uniform within every
+instance of the <em>Scope</em> of the cooperative matrix.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_3_42_12_composite_instructions">3.42.12 Composite Instructions</h3>
 <div class="paragraph"><p>Modify <strong>OpCompositeConstruct</strong> to make an exception for cooperative matrix types:
 "If the <em>Result Type</em> is a cooperative matrix type, then there must be only one
-<em>Constituent</em> and it is used to initialize all members."</p></div>
+<em>Constituent</em> and it is used to initialize all members. The <em>Constituent</em> must
+be dynamically uniform within the <em>Scope</em> of the cooperative matrix type.</p></div>
 </div>
 <div class="sect2">
 <h3 id="_3_42_13_arithmetic_instructions">3.42.13 Arithmetic Instructions</h3>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:5%;">
-<col style="width:5%;">
-<col style="width:15%;">
-<col style="width:15%;">
-<col style="width:15%;">
-<col style="width:15%;">
-<col style="width:15%;">
-<col style="width:15%;">
+<div class="tableblock">
+<table rules="all"
+width="100%"
+frame="border"
+cellspacing="0" cellpadding="4">
+<col width="5%" />
+<col width="5%" />
+<col width="15%" />
+<col width="15%" />
+<col width="15%" />
+<col width="15%" />
+<col width="15%" />
+<col width="15%" />
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="7" ><p class="tableblock"><a id="OpCooperativeMatrixMulAddKHR"></a><strong>OpCooperativeMatrixMulAddKHR</strong><br>
-<br>
+<td colspan="7" align="left" valign="top"><p class="table"><a id="OpCooperativeMatrixMulAddKHR"></a><strong>OpCooperativeMatrixMulAddKHR</strong><br />
+<br />
 Linear-algebraic matrix multiply of <em>A</em> by <em>B</em> and then component-wise
 add <em>C</em>. The order of the operations is implementation-dependent. The
 internal precision of floating-point operations is defined by the client
@@ -1509,54 +1495,55 @@ are exact, and are saturating if the <strong>SaturatingAccumulation</strong>
 being that of the components of <em>Result Type</em>. If the <strong>SaturatingAccumulation</strong>
 <em>Cooperative Matrix Operand</em> is not present then the resulting value will equal
 the low-order N bits of the correct result R, where N is the result width and
-R is computed with enough precision to avoid overflow and underflow.<br>
-<br>
+R is computed with enough precision to avoid overflow and underflow.<br />
+<br />
 <em>Result Type</em> must be a cooperative matrix type with M rows and N columns
-whose <em>Use</em> must be <em>MatrixAccumulatorKHR</em>.<br>
-<br>
-<em>A</em> is a cooperative matrix with M rows and K columns whose <em>Use</em> must be <em>MatrixAKHR</em>.<br>
-<br>
-<em>B</em> is a cooperative matrix with K rows and N columns whose <em>Use</em> must be <em>MatrixBKHR</em>.<br>
-<br>
-<em>C</em> is a cooperative matrix with M rows and N columns whose <em>Use</em> must be <em>MatrixAccumulatorKHR</em>.<br>
-<br>
+whose <em>Use</em> must be <em>MatrixAccumulatorKHR</em>.<br />
+<br />
+<em>A</em> is a cooperative matrix with M rows and K columns whose <em>Use</em> must be <em>MatrixAKHR</em>.<br />
+<br />
+<em>B</em> is a cooperative matrix with K rows and N columns whose <em>Use</em> must be <em>MatrixBKHR</em>.<br />
+<br />
+<em>C</em> is a cooperative matrix with M rows and N columns whose <em>Use</em> must be <em>MatrixAccumulatorKHR</em>.<br />
+<br />
 The values of M, N, and K must be consistent across the result and operands.
-This is referred to as an <em>MxNxK</em> matrix multiply.<br>
-<br>
+This is referred to as an <em>MxNxK</em> matrix multiply.<br />
+<br />
 <em>A</em>, <em>B</em>, <em>C</em>, and <em>Result Type</em> must have the same scope, and this defines
 the scope of the operation. <em>A</em>, <em>B</em>, <em>C</em>, and <em>Result Type</em> need not
-necessarily have the same component type, this is defined by the client API.<br>
-<br>
+necessarily have the same component type, this is defined by the client API.<br />
+<br />
 If the <em>Component Type</em> of any matrix operand is an integer type, then its
 components are treated as signed if the <strong>Matrix{A,B,C,Result}SignedComponents</strong>
-<em>Cooperative Matrix Operand</em> is present and are treated as unsigned otherwise.<br>
-<br>
+<em>Cooperative Matrix Operand</em> is present and are treated as unsigned otherwise.<br />
+<br />
 <em>Cooperative Matrix Operands</em> is an optional <em>Cooperative Matrix Operand</em> literal. If
-not present, it is the same as specifying the <em>Cooperative Matrix Operand</em> <strong>None</strong>.<br>
-<br>
-For a given dynamic instance of this instruction, all invocations in a given
-scope instance must be active or all must be inactive (where the scope is the
-scope of the operation).<br></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+not present, it is the same as specifying the <em>Cooperative Matrix Operand</em> <strong>None</strong>.<br />
+<br />
+All the operands to this instruction must be dynamically uniform within every
+instance of the <em>Scope</em> of the cooperative matrix.
+<br /></p></td>
+<td align="left" valign="top"><p class="table">Capability:<br />
 <strong>CooperativeMatrixKHR</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6+variable</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4459</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td align="left" valign="top"><p class="table">6+variable</p></td>
+<td align="left" valign="top"><p class="table">4459</p></td>
+<td align="left" valign="top"><p class="table"><em>&lt;id&gt;</em><br />
 <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td align="left" valign="top"><p class="table"><em>Result &lt;id&gt;</em></p></td>
+<td align="left" valign="top"><p class="table"><em>&lt;id&gt;</em><br />
 <em>A</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td align="left" valign="top"><p class="table"><em>&lt;id&gt;</em><br />
 <em>B</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td align="left" valign="top"><p class="table"><em>&lt;id&gt;</em><br />
 <em>C</em>'</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Optional<br>
+<td align="left" valign="top"><p class="table">Optional<br />
 <em>Cooperative Matrix Operands</em></p></td>
 </tr>
 </tbody>
 </table>
+</div>
 <div class="paragraph"><p>Allow cooperative matrix types for the following arithmetic instructions:</p></div>
 <div class="ulist"><ul>
 <li>
@@ -1591,6 +1578,8 @@ matrices.</p></div>
 <div class="paragraph"><p>Binary arithmetic instructions operate on the individual elements of a pair
 of cooperative matrices whose type must match.</p></div>
 <div class="paragraph"><p>Allow cooperative matrix types for <strong>OpMatrixTimesScalar</strong>.</p></div>
+<div class="paragraph"><p>All the operands to this instruction must be dynamically uniform within every
+instance of the <em>Scope</em> of the cooperative matrix.</p></div>
 </div>
 </div>
 </div>
@@ -1717,63 +1706,114 @@ using <strong>OpConstantComposite</strong> or by iterating over the elements of 
 cooperative matrix to multiply each element by the scalar.</p></div>
 </div></div>
 </li>
+<li>
+<p>
+Both the <em>Stride</em> and <em>Memory Operand</em> operands to <strong>OpCooperativeMatrixLoadKHR</strong>
+and <strong>OpCooperativeMatrixStoreKHR</strong> are optional. Can <em>Memory Operand</em> be provided
+alone?
+</p>
+<div class="openblock">
+<div class="content">
+<div class="paragraph"><p><strong>RESOLVED</strong>: No, in line with core SPIR-V rules, all optional operands that
+appear before a given optional operand must be provided for it to be possible to
+provide that given optional operand. Only the following combinations are valid:</p></div>
+<div class="ulist"><ul>
+<li>
+<p>
+None of the optional operands are present.
+</p>
+</li>
+<li>
+<p>
+<em>Stride</em> alone is present.
+</p>
+</li>
+<li>
+<p>
+<em>Stride</em> and <em>Memory Operand</em> are both present.
+</p>
+</li>
+</ul></div>
+</div></div>
+</li>
+<li>
+<p>
+Can elements of cooperative matrix objects treated as composites be
+accessed in non-uniform control flow?
+</p>
+<div class="openblock">
+<div class="content">
+<div class="paragraph"><p><strong>RESOLVED</strong>: Yes, control flow uniformity requirements apply to instructions
+whose operands are cooperative matrix objects but not pointers to cooperative
+matrix objects. Dereferencing a pointer to an element of a cooperative matrix
+object can be done in non-uniform control flow.</p></div>
+</div></div>
+</li>
 </ol></div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:100%;
-">
-<col style="width:4%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:66%;">
+<div class="tableblock">
+<table rules="rows"
+width="100%"
+frame="border"
+cellspacing="0" cellpadding="4">
+<col width="4%" />
+<col width="14%" />
+<col width="14%" />
+<col width="66%" />
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" >Rev</th>
-<th class="tableblock halign-left valign-top" >Date</th>
-<th class="tableblock halign-left valign-top" >Author</th>
-<th class="tableblock halign-left valign-top" >Changes</th>
+<th align="left" valign="top">Rev</th>
+<th align="left" valign="top">Date</th>
+<th align="left" valign="top">Author</th>
+<th align="left" valign="top">Changes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2023-07-26</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Kevin Petit</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Add KHR suffixes to Cooperative Matrix Operands</p></td>
+<td align="left" valign="top"><p class="table">5</p></td>
+<td align="left" valign="top"><p class="table">2023-12-06</p></td>
+<td align="left" valign="top"><p class="table">Kevin Petit</p></td>
+<td align="left" valign="top"><p class="table">Clarifications, mostly of uniformity rules</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2023-05-03</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Kevin Petit</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Initial revision of SPV_KHR_cooperative_matrix</p></td>
+<td align="left" valign="top"><p class="table">4</p></td>
+<td align="left" valign="top"><p class="table">2023-07-26</p></td>
+<td align="left" valign="top"><p class="table">Kevin Petit</p></td>
+<td align="left" valign="top"><p class="table">Add KHR suffixes to Cooperative Matrix Operands</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2019-07-12</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Jeff Bolz</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Added details for integer operations</p></td>
+<td align="left" valign="top"><p class="table">3</p></td>
+<td align="left" valign="top"><p class="table">2023-05-03</p></td>
+<td align="left" valign="top"><p class="table">Kevin Petit</p></td>
+<td align="left" valign="top"><p class="table">Initial revision of SPV_KHR_cooperative_matrix</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2019-01-30</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Jeff Bolz</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Initial revision of SPV_NV_cooperative_matrix</p></td>
+<td align="left" valign="top"><p class="table">2</p></td>
+<td align="left" valign="top"><p class="table">2019-07-12</p></td>
+<td align="left" valign="top"><p class="table">Jeff Bolz</p></td>
+<td align="left" valign="top"><p class="table">Added details for integer operations</p></td>
+</tr>
+<tr>
+<td align="left" valign="top"><p class="table">1</p></td>
+<td align="left" valign="top"><p class="table">2019-01-30</p></td>
+<td align="left" valign="top"><p class="table">Jeff Bolz</p></td>
+<td align="left" valign="top"><p class="table">Initial revision of SPV_NV_cooperative_matrix</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 </div>
 </div>
-<div id="footnotes"><hr></div>
+</div>
+<div id="footnotes"><hr /></div>
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2023-07-26 17:00:15 BST
+ 2023-12-06 10:40:44 GMT
 </div>
 </div>
 </body>


### PR DESCRIPTION
- Change the description of 'Memory Operand' operands to load/store instructions to make it clear that multiple words can be used (in line with the language used for OpLoad/OpStore).
- Require all instructions that have a cooperative matrix object as an operand or produce a cooperative matrix object result only be executed in uniform control flow within the scope of the matrix type.
- Require the constituent provided to OpCompositeConstruct to be the same for all invocations in the scope of the cooperative matrix.
- Require the operands to arithmetic and conversion instructions operating on cooperative matrix objects to be the same for all invocations within the scope of the cooperative matrix.
- Clarify when _Stride_ and _Memory Operand_ operands can be provided.
- Clarify when referring to cooperative matrix types or objects/values of that type in the description of conversion instructions.


Fixes #208
Fixes #211