### PR TITLE
Upstream SPV_INTEL_masked_gather_scatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Khronos SPIR-V Registry](https://www.khronos.org/registry/spir-v/).
 1. [SPV_INTEL_cache_controls                ]( http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/INTEL/SPV_INTEL_cache_controls.html)
 1. [SPV_NV_displacement_micromap            ]( http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/NV/SPV_NV_displacement_micromap.html)
 1. [SPV_INTEL_long_composites               ]( http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/INTEL/SPV_INTEL_long_composites.html)
+1. [SPV_INTEL_masked_gather_scatter         ]( http://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/INTEL/SPV_INTEL_masked_gather_scatter.html)
 
 ## Non-Semantic Extended Instruction Set Specifications
 

--- a/extensions/INTEL/SPV_INTEL_masked_gather_scatter.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_masked_gather_scatter.asciidoc
@@ -37,7 +37,7 @@ Copyright (c) 2023 Intel Corporation.  All rights reserved.
 [width="40%",cols="25,25"]
 |========================================
 | Last Modified Date | 2023-09-05
-| Revision           | 2
+| Revision           | 1
 |========================================
 
 == Dependencies
@@ -286,6 +286,5 @@ Revision History
 [options="header"]
 |========================================
 |Rev|Date|Author|Changes
-|1|2022-08-19|Dmitry Sidorov|Initial revision
-|2|2023-09-05|Dmitry Sidorov|Prepare to ship
+|1|2023-09-05|Dmitry Sidorov|Prepare to ship
 |========================================

--- a/extensions/INTEL/SPV_INTEL_masked_gather_scatter.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_masked_gather_scatter.asciidoc
@@ -1,0 +1,291 @@
+:extension_name: SPV_INTEL_masked_gather_scatter
+:capability_name: MaskedGatherScatterINTEL
+:capability_token: 6427
+:OpMaskedGatherINTEL_token: 6428
+:OpMaskedScatterINTEL_token: 6429
+
+{extension_name}
+================
+
+
+== Name Strings
+
+{extension_name}
+
+== Contact
+
+To report problems with this extension, please open a new issue at:
+
+https://github.com/KhronosGroup/SPIRV-Registry
+
+== Contributors
+
+- Dmitry Sidorov, Intel +
+- Ben Ashbaugh, Intel +
+- Arvind Sudarsanam, Intel +
+
+== Notice
+
+Copyright (c) 2023 Intel Corporation.  All rights reserved.
+
+== Status
+
+* Shipping.
+
+== Version
+
+[width="40%",cols="25,25"]
+|========================================
+| Last Modified Date | 2023-09-05
+| Revision           | 2
+|========================================
+
+== Dependencies
+
+This extension is written against the SPIR-V Specification,
+Version 1.6 Revision 2.
+
+This extension requires SPIR-V 1.0.
+
+== Overview
+
+This extension allows *OpTypeVector* to have a _physical pointer type_ _Component Type_ and introduces gather/scatter instructions.
+These are important operations for many explicitly vectorized kernels.
+
+== Extension Name
+
+
+To use this extension within a SPIR-V module, the appropriate *OpExtension* must
+be present in the module:
+
+[subs="attributes"]
+----
+OpExtension "{extension_name}"
+----
+
+== New Capabilities
+
+This extension introduces new capabilities:
+
+[subs="attributes"]
+----
+{capability_name}
+----
+
+== New Instructions
+
+Instructions added under the *{capability_name}* capability:
+
+----
+OpMaskedGatherINTEL
+OpMaskedScatterINTEL
+----
+
+== Token Number Assignments
+
+[width="40%"]
+[cols="70%,30%"]
+[grid="rows"]
+|====
+|*{capability_name}*  | {capability_token}
+|*OpMaskedGatherINTEL*    | {OpMaskedGatherINTEL_token}
+|*OpMaskedScatterINTEL*    | {OpMaskedScatterINTEL_token}
+|====
+
+== Modifications to the SPIR-V Specification, Version 1.5
+
+
+=== 2.2.2. Types
+
+Update the definition of _Vector_, adding pointers to the set of supported component types:
+An ordered homogeneous collection of two or more _scalars_ or pointers of _physical pointer type_.
+Vector sizes are quite restrictive and dependent on the execution model.
+
+=== 2.16.1. Universal Validation Rules
+
+Modify Data rules section, replacing following segment:
+
+- Vector types must be parameterized only with numerical types or the *OpTypeBool* type.
+
+with:
+
+- Vector types must be parameterized only with numerical types or the *OpTypeBool* type. They can also
+ be parameterized with _physical pointer type_ types under *{capability_name}* capability.
+
+
+=== Capabilities
+
+Modify Section 3.31, Capability, adding rows to the Capability table:
+
+--
+[options="header"]
+|====
+2+^| Capability ^| Implicitly Declares 
+| {capability_token}
+| *{capability_name}* +
+ +
+Allow *OpTypeVector* to have a _physical pointer type_ _Component Type_. +
+ +
+See also extension: *{extension_name}* +
+|
+*Addresses*
+|====
+--
+
+
+=== 3.42.6. Type-Declaration Instructions
+
+Modify *OpTypeVector*, changing the description of _Component Type_ to:
+  _Component Type_ is the type of each component in the resulting type. It must be a _scalar type_ or _physical pointer type_.
+
+
+=== 3.42.7. Constant-Creation Instructions
+
+Modify *OpConstantNull*, allowing _Result Type_ to be a vector of _physical pointer type_.
+
+
+=== 3.42.8. Memory Instructions
+
+Allow _vector_ of _physical pointer type_ to be used by *OpVariable*, *OpAccessChain*, *OpInBoundsAccessChain*,
+*OpPtrAccessChain*, *OpInBoundsPtrAccessChain*, *OpPtrEqual*, *OpPtrNotEqual* and *OpPtrDiff* instructions. When _vector_ of
+_physical pointer type_ is allowed for *OpVariable* it is implicitly possible to be used by *OpStore* and *OpLoad* which can
+store/load through a pointer to this vector.
+
+Change the _Overview_ of *OpVariable* as follows:
+Allocate an object or a vector of objects in memory, resulting in a pointer or appropriately a vector of pointers to it,
+which can be used with *OpLoad* and *OpStore*.
+Change the _Result Type_ of *OpVariable* as follows:
+_Result Type_ must be an *OpTypePointer* or a _vector_ with _physical pointer type_ _Component Type_.
+Its _Type_ operand is the type of object or vector of objects in memory.
+
+Modify *OpAccessChain* (implicitly modifies *OpInBoundsAccessChain*, *OpPtrAccessChain* and *OpInBoundsPtrAccessChain* instructions)
+Change the _Base_ as follows:
+_Base_ must be a pointer, pointing to the base of a composite object or a _vector_ of _physical pointer type_.
+
+Allow _vector_ of _physical pointer type_ to be the type of _Operand 1_ and _Operand 2_ of *OpPtrEqual*, *OpPtrNotEqual* and
+*OpPtrDiff* instructions. If operands are vectors of pointers, then the _Result Type_ of *OpPtrEqual* and *OpPtrNotEqual* is a
+vector with boolean _Component Type_ and _Result Type_ of *OpPtrDiff* is a vector with integer _Component Type_.
+
+Add the following new entries:
+
+[cols="1,1,6*3",width="100%"]
+|=====
+7+|[[OpMaskedGatherINTEL]]*OpMaskedGatherINTEL* +
+ +
+Reads values from a vector of pointers gathering them into one vector. Returns the gathered vector. Memory access
+is specified by a mask instruction parameter. +
+ +
+'Result Type' is a type of the gathered vector. Its _Component Type_ must be the same as the base type of
+'PtrVector'.
+ +
+'PtrVector' is a _vector_ with _physical pointer type_ _Component Type_, containing addresses from where the instruction reads. +
+ +
+'Alignment' is an unsigned 32-bit integer literal whose value is
+either 0 or a power of two. When the value is not 0, it is an assertion that
+each pointer value in 'PtrVector' has this alignment. The behavior is undefined if
+any pointer value in 'PtrVector' does not have this alignment. +
+ +
+'Mask' is a vector of boolean values with the same number of elements as the _Result Type_. It specifies which elements of
+'PtrVector' should be gathered. +
+ +
+'FillEmpty' is used to fill the masked-off lanes of the result. It must be of the same type as the _Component Type_ of _Result Type_. +
+
+1+|Capability: +
+*{capability_name}*
+1+| 7 | {OpMaskedGatherINTEL_token}
+| '<id>' +
+'Result Type'
+|'Result <id>'
+| '<id>' +
+'PtrVector'
+| '<literal>' +
+'Alignment'
+| '<id>' +
+'Mask'
+| '<id>' +
+'FillEmpty'
+|=====
+
+[cols="1,1,4*3",width="100%"]
+|=====
+5+|[[OpMaskedScatterINTEL]]*OpMaskedScatterINTEL* +
+ +
+Writes values from a vector to the corresponding memory address of the given vector of pointers. Memory access
+is specified by a mask instruction parameter. +
+ +
+'InputVector' is a _vector_ of values to scatter. +
+ +
+'PtrVector' is a _vector_ with _physical pointer type_ _Component Type_, containing addresses where the instruction stores the scattered values. +
+ +
+'Alignment' is an unsigned 32-bit integer literal whose value is
+either 0 or a power of two. When the value is not 0, it is an assertion that
+each pointer value in 'PtrVector' has this alignment. The behavior is undefined if
+any pointer value in 'PtrVector' does not have this alignment. +
+ +
+'Mask' is a vector of boolean values with the same number of elements as the _InputVector_. It specifies which elements of
+'InputVector' should be scattered. +
+
+1+|Capability: +
+*{capability_name}*
+1+| 5 | {OpMaskedScatterINTEL_token}
+| '<id>' +
+'InputVector'
+| '<id>' +
+'PtrVector'
+| '<literal>' +
+'Alignment'
+| '<id>' +
+'Mask'
+|=====
+
+
+=== 3.42.11. Conversion Instructions
+
+Allow *OpTypeVector* to be _Result Type_ and type of an input for *OpConvertPtrToU*, *OpConvertUToPtr* instructions:
+Change the _Result Type_ of *OpConvertPtrToU* as follows:
+_Result Type_ must be a scalar or vector of _integer type_, whose Signedness operand is 0.
+
+Change the  _Pointer_ of *OpConvertPtrToU* as follows:
+_Pointer_ must be a _physical pointer type_ or a _vector_ with _physical pointer type_ _Component Type_.
+If the bit width of _Pointer_ is smaller than that of _Result Type_, the conversion zero-extends _Pointer_.
+If the bit width of _Pointer_ is larger than that of _Result Type_, the conversion truncates Pointer. For
+same bit width Pointer and _Result Type_, this is the same as *OpBitcast*.
+
+Change the _Result Type_ of *OpConvertUToPtr* as follows:
+_Result Type_ must be a _physical pointer type_ or a _vector_ with _physical pointer type_ _Component Type_.
+
+Change the _Integer Value_ of *OpConvertUToPtr* as follows:
+_Integer Value_ must be a scalar or vector of _integer type_, whose Signedness operand is 0.
+If the bit width of _Integer Value_ is smaller than that of _Result Type_, the
+conversion zero-extends _Integer Value_. If the bit width of _Integer Value_ is larger
+than that of _Result Type_, the conversion truncates Integer Value. For same width _Integer Value_ and _Result Type_,
+this is the same as *OpBitcast*.
+
+Allow _vector_ of _physical pointer type_ to be _Result Type_ and type of a _Pointer_ for
+*OpPtrCastToGeneric*, *OpGenericCastToPtr* and *OpGenericCastToPtrExplicit* instructions.
+
+Allow _vector_ of _physical pointer type_ to be _Result Type_ and type of an _Operand_ for *OpBitcast* instruction.
+
+
+=== 3.42.12. Composite Instructions
+
+Most of the Composite Instructions that are supposed to work with vector type do not have any restrictions about _Component Type_.
+This extension allows these instructions to operate on _vector_ of _physical pointer type_.
+
+Allow _physical pointer type_ to be a _Result Type_ of *OpVectorExtractDynamic*.
+
+
+=== Issues
+
+None
+
+Revision History
+----------------
+[cols="5,15,15,70"]
+[grid="rows"]
+[options="header"]
+|========================================
+|Rev|Date|Author|Changes
+|1|2022-08-19|Dmitry Sidorov|Initial revision
+|2|2023-09-05|Dmitry Sidorov|Prepare to ship
+|========================================

--- a/extensions/INTEL/SPV_INTEL_masked_gather_scatter.html
+++ b/extensions/INTEL/SPV_INTEL_masked_gather_scatter.html
@@ -1,0 +1,1191 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<meta name="generator" content="AsciiDoc 9.1.0">
+<title>SPV_INTEL_masked_gather_scatter</title>
+<style type="text/css">
+/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
+
+/* Default font. */
+body {
+  font-family: Georgia,serif;
+}
+
+/* Title font. */
+h1, h2, h3, h4, h5, h6,
+div.title, caption.title,
+thead, p.table.header,
+#toctitle,
+#author, #revnumber, #revdate, #revremark,
+#footer {
+  font-family: Arial,Helvetica,sans-serif;
+}
+
+body {
+  margin: 1em 5% 1em 5%;
+}
+
+a {
+  color: blue;
+  text-decoration: underline;
+}
+a:visited {
+  color: fuchsia;
+}
+
+em {
+  font-style: italic;
+  color: navy;
+}
+
+strong {
+  font-weight: bold;
+  color: #083194;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #527bbd;
+  margin-top: 1.2em;
+  margin-bottom: 0.5em;
+  line-height: 1.3;
+}
+
+h1, h2, h3 {
+  border-bottom: 2px solid silver;
+}
+h2 {
+  padding-top: 0.5em;
+}
+h3 {
+  float: left;
+}
+h3 + * {
+  clear: left;
+}
+h5 {
+  font-size: 1.0em;
+}
+
+div.sectionbody {
+  margin-left: 0;
+}
+
+hr {
+  border: 1px solid silver;
+}
+
+p {
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+ul, ol, li > p {
+  margin-top: 0;
+}
+ul > li     { color: #aaa; }
+ul > li > * { color: black; }
+
+.monospaced, code, pre {
+  font-family: "Courier New", Courier, monospace;
+  font-size: inherit;
+  color: navy;
+  padding: 0;
+  margin: 0;
+}
+pre {
+  white-space: pre-wrap;
+}
+
+#author {
+  color: #527bbd;
+  font-weight: bold;
+  font-size: 1.1em;
+}
+#email {
+}
+#revnumber, #revdate, #revremark {
+}
+
+#footer {
+  font-size: small;
+  border-top: 2px solid silver;
+  padding-top: 0.5em;
+  margin-top: 4.0em;
+}
+#footer-text {
+  float: left;
+  padding-bottom: 0.5em;
+}
+#footer-badges {
+  float: right;
+  padding-bottom: 0.5em;
+}
+
+#preamble {
+  margin-top: 1.5em;
+  margin-bottom: 1.5em;
+}
+div.imageblock, div.exampleblock, div.verseblock,
+div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
+div.admonitionblock {
+  margin-top: 1.0em;
+  margin-bottom: 1.5em;
+}
+div.admonitionblock {
+  margin-top: 2.0em;
+  margin-bottom: 2.0em;
+  margin-right: 10%;
+  color: #606060;
+}
+
+div.content { /* Block element content. */
+  padding: 0;
+}
+
+/* Block element titles. */
+div.title, caption.title {
+  color: #527bbd;
+  font-weight: bold;
+  text-align: left;
+  margin-top: 1.0em;
+  margin-bottom: 0.5em;
+}
+div.title + * {
+  margin-top: 0;
+}
+
+td div.title:first-child {
+  margin-top: 0.0em;
+}
+div.content div.title:first-child {
+  margin-top: 0.0em;
+}
+div.content + div.title {
+  margin-top: 0.0em;
+}
+
+div.sidebarblock > div.content {
+  background: #ffffee;
+  border: 1px solid #dddddd;
+  border-left: 4px solid #f0f0f0;
+  padding: 0.5em;
+}
+
+div.listingblock > div.content {
+  border: 1px solid #dddddd;
+  border-left: 5px solid #f0f0f0;
+  background: #f8f8f8;
+  padding: 0.5em;
+}
+
+div.quoteblock, div.verseblock {
+  padding-left: 1.0em;
+  margin-left: 1.0em;
+  margin-right: 10%;
+  border-left: 5px solid #f0f0f0;
+  color: #888;
+}
+
+div.quoteblock > div.attribution {
+  padding-top: 0.5em;
+  text-align: right;
+}
+
+div.verseblock > pre.content {
+  font-family: inherit;
+  font-size: inherit;
+}
+div.verseblock > div.attribution {
+  padding-top: 0.75em;
+  text-align: left;
+}
+/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
+div.verseblock + div.attribution {
+  text-align: left;
+}
+
+div.admonitionblock .icon {
+  vertical-align: top;
+  font-size: 1.1em;
+  font-weight: bold;
+  text-decoration: underline;
+  color: #527bbd;
+  padding-right: 0.5em;
+}
+div.admonitionblock td.content {
+  padding-left: 0.5em;
+  border-left: 3px solid #dddddd;
+}
+
+div.exampleblock > div.content {
+  border-left: 3px solid #dddddd;
+  padding-left: 0.5em;
+}
+
+div.imageblock div.content { padding-left: 0; }
+span.image img { border-style: none; vertical-align: text-bottom; }
+a.image:visited { color: white; }
+
+dl {
+  margin-top: 0.8em;
+  margin-bottom: 0.8em;
+}
+dt {
+  margin-top: 0.5em;
+  margin-bottom: 0;
+  font-style: normal;
+  color: navy;
+}
+dd > *:first-child {
+  margin-top: 0.1em;
+}
+
+ul, ol {
+    list-style-position: outside;
+}
+ol.arabic {
+  list-style-type: decimal;
+}
+ol.loweralpha {
+  list-style-type: lower-alpha;
+}
+ol.upperalpha {
+  list-style-type: upper-alpha;
+}
+ol.lowerroman {
+  list-style-type: lower-roman;
+}
+ol.upperroman {
+  list-style-type: upper-roman;
+}
+
+div.compact ul, div.compact ol,
+div.compact p, div.compact p,
+div.compact div, div.compact div {
+  margin-top: 0.1em;
+  margin-bottom: 0.1em;
+}
+
+tfoot {
+  font-weight: bold;
+}
+td > div.verse {
+  white-space: pre;
+}
+
+div.hdlist {
+  margin-top: 0.8em;
+  margin-bottom: 0.8em;
+}
+div.hdlist tr {
+  padding-bottom: 15px;
+}
+dt.hdlist1.strong, td.hdlist1.strong {
+  font-weight: bold;
+}
+td.hdlist1 {
+  vertical-align: top;
+  font-style: normal;
+  padding-right: 0.8em;
+  color: navy;
+}
+td.hdlist2 {
+  vertical-align: top;
+}
+div.hdlist.compact tr {
+  margin: 0;
+  padding-bottom: 0;
+}
+
+.comment {
+  background: yellow;
+}
+
+.footnote, .footnoteref {
+  font-size: 0.8em;
+}
+
+span.footnote, span.footnoteref {
+  vertical-align: super;
+}
+
+#footnotes {
+  margin: 20px 0 20px 0;
+  padding: 7px 0 0 0;
+}
+
+#footnotes div.footnote {
+  margin: 0 0 5px 0;
+}
+
+#footnotes hr {
+  border: none;
+  border-top: 1px solid silver;
+  height: 1px;
+  text-align: left;
+  margin-left: 0;
+  width: 20%;
+  min-width: 100px;
+}
+
+div.colist td {
+  padding-right: 0.5em;
+  padding-bottom: 0.3em;
+  vertical-align: top;
+}
+div.colist td img {
+  margin-top: 0.3em;
+}
+
+@media print {
+  #footer-badges { display: none; }
+}
+
+#toc {
+  margin-bottom: 2.5em;
+}
+
+#toctitle {
+  color: #527bbd;
+  font-size: 1.1em;
+  font-weight: bold;
+  margin-top: 1.0em;
+  margin-bottom: 0.1em;
+}
+
+div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+div.toclevel2 {
+  margin-left: 2em;
+  font-size: 0.9em;
+}
+div.toclevel3 {
+  margin-left: 4em;
+  font-size: 0.9em;
+}
+div.toclevel4 {
+  margin-left: 6em;
+  font-size: 0.9em;
+}
+
+span.aqua { color: aqua; }
+span.black { color: black; }
+span.blue { color: blue; }
+span.fuchsia { color: fuchsia; }
+span.gray { color: gray; }
+span.green { color: green; }
+span.lime { color: lime; }
+span.maroon { color: maroon; }
+span.navy { color: navy; }
+span.olive { color: olive; }
+span.purple { color: purple; }
+span.red { color: red; }
+span.silver { color: silver; }
+span.teal { color: teal; }
+span.white { color: white; }
+span.yellow { color: yellow; }
+
+span.aqua-background { background: aqua; }
+span.black-background { background: black; }
+span.blue-background { background: blue; }
+span.fuchsia-background { background: fuchsia; }
+span.gray-background { background: gray; }
+span.green-background { background: green; }
+span.lime-background { background: lime; }
+span.maroon-background { background: maroon; }
+span.navy-background { background: navy; }
+span.olive-background { background: olive; }
+span.purple-background { background: purple; }
+span.red-background { background: red; }
+span.silver-background { background: silver; }
+span.teal-background { background: teal; }
+span.white-background { background: white; }
+span.yellow-background { background: yellow; }
+
+span.big { font-size: 2em; }
+span.small { font-size: 0.6em; }
+
+span.underline { text-decoration: underline; }
+span.overline { text-decoration: overline; }
+span.line-through { text-decoration: line-through; }
+
+div.unbreakable { page-break-inside: avoid; }
+
+
+/*
+ * xhtml11 specific
+ *
+ * */
+
+div.tableblock {
+  margin-top: 1.0em;
+  margin-bottom: 1.5em;
+}
+div.tableblock > table {
+  border: 3px solid #527bbd;
+}
+thead, p.table.header {
+  font-weight: bold;
+  color: #527bbd;
+}
+p.table {
+  margin-top: 0;
+}
+/* Because the table frame attribute is overridden by CSS in most browsers. */
+div.tableblock > table[frame="void"] {
+  border-style: none;
+}
+div.tableblock > table[frame="hsides"] {
+  border-left-style: none;
+  border-right-style: none;
+}
+div.tableblock > table[frame="vsides"] {
+  border-top-style: none;
+  border-bottom-style: none;
+}
+
+
+/*
+ * html5 specific
+ *
+ * */
+
+table.tableblock {
+  margin-top: 1.0em;
+  margin-bottom: 1.5em;
+}
+thead, p.tableblock.header {
+  font-weight: bold;
+  color: #527bbd;
+}
+p.tableblock {
+  margin-top: 0;
+}
+table.tableblock {
+  border-width: 3px;
+  border-spacing: 0px;
+  border-style: solid;
+  border-color: #527bbd;
+  border-collapse: collapse;
+}
+th.tableblock, td.tableblock {
+  border-width: 1px;
+  padding: 4px;
+  border-style: solid;
+  border-color: #527bbd;
+}
+
+table.tableblock.frame-topbot {
+  border-left-style: hidden;
+  border-right-style: hidden;
+}
+table.tableblock.frame-sides {
+  border-top-style: hidden;
+  border-bottom-style: hidden;
+}
+table.tableblock.frame-none {
+  border-style: hidden;
+}
+
+th.tableblock.halign-left, td.tableblock.halign-left {
+  text-align: left;
+}
+th.tableblock.halign-center, td.tableblock.halign-center {
+  text-align: center;
+}
+th.tableblock.halign-right, td.tableblock.halign-right {
+  text-align: right;
+}
+
+th.tableblock.valign-top, td.tableblock.valign-top {
+  vertical-align: top;
+}
+th.tableblock.valign-middle, td.tableblock.valign-middle {
+  vertical-align: middle;
+}
+th.tableblock.valign-bottom, td.tableblock.valign-bottom {
+  vertical-align: bottom;
+}
+
+
+/*
+ * manpage specific
+ *
+ * */
+
+body.manpage h1 {
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+  border-top: 2px solid silver;
+  border-bottom: 2px solid silver;
+}
+body.manpage h2 {
+  border-style: none;
+}
+body.manpage div.sectionbody {
+  margin-left: 3em;
+}
+
+@media print {
+  body.manpage div#toc { display: none; }
+}
+
+
+@media screen {
+  body {
+    max-width: 50em; /* approximately 80 characters wide */
+    margin-left: 16em;
+  }
+
+  #toc {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 13em;
+    padding: 0.5em;
+    padding-bottom: 1.5em;
+    margin: 0;
+    overflow: auto;
+    border-right: 3px solid #f8f8f8;
+    background-color: white;
+  }
+
+  #toc .toclevel1 {
+    margin-top: 0.5em;
+  }
+
+  #toc .toclevel2 {
+    margin-top: 0.25em;
+    display: list-item;
+    color: #aaaaaa;
+  }
+
+  #toctitle {
+    margin-top: 0.5em;
+  }
+}
+</style>
+<script type="text/javascript">
+/*<![CDATA[*/
+var asciidoc = {  // Namespace.
+
+/////////////////////////////////////////////////////////////////////
+// Table Of Contents generator
+/////////////////////////////////////////////////////////////////////
+
+/* Author: Mihai Bazon, September 2002
+ * http://students.infoiasi.ro/~mishoo
+ *
+ * Table Of Content generator
+ * Version: 0.4
+ *
+ * Feel free to use this script under the terms of the GNU General Public
+ * License, as long as you do not remove or alter this notice.
+ */
+
+ /* modified by Troy D. Hanson, September 2006. License: GPL */
+ /* modified by Stuart Rackham, 2006, 2009. License: GPL */
+
+// toclevels = 1..4.
+toc: function (toclevels) {
+
+  function getText(el) {
+    var text = "";
+    for (var i = el.firstChild; i != null; i = i.nextSibling) {
+      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
+        text += i.data;
+      else if (i.firstChild != null)
+        text += getText(i);
+    }
+    return text;
+  }
+
+  function TocEntry(el, text, toclevel) {
+    this.element = el;
+    this.text = text;
+    this.toclevel = toclevel;
+  }
+
+  function tocEntries(el, toclevels) {
+    var result = new Array;
+    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
+    // Function that scans the DOM tree for header elements (the DOM2
+    // nodeIterator API would be a better technique but not supported by all
+    // browsers).
+    var iterate = function (el) {
+      for (var i = el.firstChild; i != null; i = i.nextSibling) {
+        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
+          var mo = re.exec(i.tagName);
+          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
+            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
+          }
+          iterate(i);
+        }
+      }
+    }
+    iterate(el);
+    return result;
+  }
+
+  var toc = document.getElementById("toc");
+  if (!toc) {
+    return;
+  }
+
+  // Delete existing TOC entries in case we're reloading the TOC.
+  var tocEntriesToRemove = [];
+  var i;
+  for (i = 0; i < toc.childNodes.length; i++) {
+    var entry = toc.childNodes[i];
+    if (entry.nodeName.toLowerCase() == 'div'
+     && entry.getAttribute("class")
+     && entry.getAttribute("class").match(/^toclevel/))
+      tocEntriesToRemove.push(entry);
+  }
+  for (i = 0; i < tocEntriesToRemove.length; i++) {
+    toc.removeChild(tocEntriesToRemove[i]);
+  }
+
+  // Rebuild TOC entries.
+  var entries = tocEntries(document.getElementById("content"), toclevels);
+  for (var i = 0; i < entries.length; ++i) {
+    var entry = entries[i];
+    if (entry.element.id == "")
+      entry.element.id = "_toc_" + i;
+    var a = document.createElement("a");
+    a.href = "#" + entry.element.id;
+    a.appendChild(document.createTextNode(entry.text));
+    var div = document.createElement("div");
+    div.appendChild(a);
+    div.className = "toclevel" + entry.toclevel;
+    toc.appendChild(div);
+  }
+  if (entries.length == 0)
+    toc.parentNode.removeChild(toc);
+},
+
+
+/////////////////////////////////////////////////////////////////////
+// Footnotes generator
+/////////////////////////////////////////////////////////////////////
+
+/* Based on footnote generation code from:
+ * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
+ */
+
+footnotes: function () {
+  // Delete existing footnote entries in case we're reloading the footnodes.
+  var i;
+  var noteholder = document.getElementById("footnotes");
+  if (!noteholder) {
+    return;
+  }
+  var entriesToRemove = [];
+  for (i = 0; i < noteholder.childNodes.length; i++) {
+    var entry = noteholder.childNodes[i];
+    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
+      entriesToRemove.push(entry);
+  }
+  for (i = 0; i < entriesToRemove.length; i++) {
+    noteholder.removeChild(entriesToRemove[i]);
+  }
+
+  // Rebuild footnote entries.
+  var cont = document.getElementById("content");
+  var spans = cont.getElementsByTagName("span");
+  var refs = {};
+  var n = 0;
+  for (i=0; i<spans.length; i++) {
+    if (spans[i].className == "footnote") {
+      n++;
+      var note = spans[i].getAttribute("data-note");
+      if (!note) {
+        // Use [\s\S] in place of . so multi-line matches work.
+        // Because JavaScript has no s (dotall) regex flag.
+        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
+        spans[i].innerHTML =
+          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
+          "' title='View footnote' class='footnote'>" + n + "</a>]";
+        spans[i].setAttribute("data-note", note);
+      }
+      noteholder.innerHTML +=
+        "<div class='footnote' id='_footnote_" + n + "'>" +
+        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
+        n + "</a>. " + note + "</div>";
+      var id =spans[i].getAttribute("id");
+      if (id != null) refs["#"+id] = n;
+    }
+  }
+  if (n == 0)
+    noteholder.parentNode.removeChild(noteholder);
+  else {
+    // Process footnoterefs.
+    for (i=0; i<spans.length; i++) {
+      if (spans[i].className == "footnoteref") {
+        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
+        href = href.match(/#.*/)[0];  // Because IE return full URL.
+        n = refs[href];
+        spans[i].innerHTML =
+          "[<a href='#_footnote_" + n +
+          "' title='View footnote' class='footnote'>" + n + "</a>]";
+      }
+    }
+  }
+},
+
+install: function(toclevels) {
+  var timerId;
+
+  function reinstall() {
+    asciidoc.footnotes();
+    if (toclevels) {
+      asciidoc.toc(toclevels);
+    }
+  }
+
+  function reinstallAndRemoveTimer() {
+    clearInterval(timerId);
+    reinstall();
+  }
+
+  timerId = setInterval(reinstall, 500);
+  if (document.addEventListener)
+    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
+  else
+    window.onload = reinstallAndRemoveTimer;
+}
+
+}
+asciidoc.install(1);
+/*]]>*/
+</script>
+</head>
+<body class="article">
+<div id="header">
+<h1>SPV_INTEL_masked_gather_scatter</h1>
+<div id="toc">
+  <div id="toctitle">Table of Contents</div>
+  <noscript><p><b>JavaScript must be enabled in your browser to display the table of contents.</b></p></noscript>
+</div>
+</div>
+<div id="content">
+<div class="sect1">
+<h2 id="_name_strings">Name Strings</h2>
+<div class="sectionbody">
+<div class="paragraph"><p>SPV_INTEL_masked_gather_scatter</p></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_contact">Contact</h2>
+<div class="sectionbody">
+<div class="paragraph"><p>To report problems with this extension, please open a new issue at:</p></div>
+<div class="paragraph"><p><a href="https://github.com/KhronosGroup/SPIRV-Registry">https://github.com/KhronosGroup/SPIRV-Registry</a></p></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_contributors">Contributors</h2>
+<div class="sectionbody">
+<div class="ulist"><ul>
+<li>
+<p>
+Dmitry Sidorov, Intel<br>
+</p>
+</li>
+<li>
+<p>
+Ben Ashbaugh, Intel<br>
+</p>
+</li>
+<li>
+<p>
+Arvind Sudarsanam, Intel<br>
+</p>
+</li>
+</ul></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_notice">Notice</h2>
+<div class="sectionbody">
+<div class="paragraph"><p>Copyright (c) 2023 Intel Corporation.  All rights reserved.</p></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_status">Status</h2>
+<div class="sectionbody">
+<div class="ulist"><ul>
+<li>
+<p>
+Shipping.
+</p>
+</li>
+</ul></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_version">Version</h2>
+<div class="sectionbody">
+<table class="tableblock frame-all grid-all"
+style="
+width:40%;
+">
+<col style="width:50%;">
+<col style="width:50%;">
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Last Modified Date</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2023-09-05</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Revision</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_dependencies">Dependencies</h2>
+<div class="sectionbody">
+<div class="paragraph"><p>This extension is written against the SPIR-V Specification,
+Version 1.6 Revision 2.</p></div>
+<div class="paragraph"><p>This extension requires SPIR-V 1.0.</p></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_overview">Overview</h2>
+<div class="sectionbody">
+<div class="paragraph"><p>This extension allows <strong>OpTypeVector</strong> to have a <em>physical pointer type</em> <em>Component Type</em> and introduces gather/scatter instructions.
+These are important operations for many explicitly vectorized kernels.</p></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_extension_name">Extension Name</h2>
+<div class="sectionbody">
+<div class="paragraph"><p>To use this extension within a SPIR-V module, the appropriate <strong>OpExtension</strong> must
+be present in the module:</p></div>
+<div class="listingblock">
+<div class="content monospaced">
+<pre>OpExtension "SPV_INTEL_masked_gather_scatter"</pre>
+</div></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_new_capabilities">New Capabilities</h2>
+<div class="sectionbody">
+<div class="paragraph"><p>This extension introduces new capabilities:</p></div>
+<div class="listingblock">
+<div class="content monospaced">
+<pre>MaskedGatherScatterINTEL</pre>
+</div></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_new_instructions">New Instructions</h2>
+<div class="sectionbody">
+<div class="paragraph"><p>Instructions added under the <strong>MaskedGatherScatterINTEL</strong> capability:</p></div>
+<div class="listingblock">
+<div class="content monospaced">
+<pre>OpMaskedGatherINTEL
+OpMaskedScatterINTEL</pre>
+</div></div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_token_number_assignments">Token Number Assignments</h2>
+<div class="sectionbody">
+<table class="tableblock frame-all grid-rows"
+style="
+width:40%;
+">
+<col style="width:70%;">
+<col style="width:30%;">
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>MaskedGatherScatterINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6427</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>OpMaskedGatherINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6428</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>OpMaskedScatterINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6429</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_modifications_to_the_spir_v_specification_version_1_5">Modifications to the SPIR-V Specification, Version 1.5</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_2_2_2_types">2.2.2. Types</h3>
+<div class="paragraph"><p>Update the definition of <em>Vector</em>, adding pointers to the set of supported component types:
+An ordered homogeneous collection of two or more <em>scalars</em> or pointers of <em>physical pointer type</em>.
+Vector sizes are quite restrictive and dependent on the execution model.</p></div>
+</div>
+<div class="sect2">
+<h3 id="_2_16_1_universal_validation_rules">2.16.1. Universal Validation Rules</h3>
+<div class="paragraph"><p>Modify Data rules section, replacing following segment:</p></div>
+<div class="ulist"><ul>
+<li>
+<p>
+Vector types must be parameterized only with numerical types or the <strong>OpTypeBool</strong> type.
+</p>
+</li>
+</ul></div>
+<div class="paragraph"><p>with:</p></div>
+<div class="ulist"><ul>
+<li>
+<p>
+Vector types must be parameterized only with numerical types or the <strong>OpTypeBool</strong> type. They can also
+ be parameterized with <em>physical pointer type</em> types under <strong>MaskedGatherScatterINTEL</strong> capability.
+</p>
+</li>
+</ul></div>
+</div>
+<div class="sect2">
+<h3 id="_capabilities">Capabilities</h3>
+<div class="paragraph"><p>Modify Section 3.31, Capability, adding rows to the Capability table:</p></div>
+<div class="openblock">
+<div class="content">
+<table class="tableblock frame-all grid-all"
+style="
+width:100%;
+">
+<col style="width:33%;">
+<col style="width:33%;">
+<col style="width:33%;">
+<thead>
+<tr>
+<th class="tableblock halign-center valign-top" colspan="2" > Capability </th>
+<th class="tableblock halign-center valign-top" > Implicitly Declares</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6427</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>MaskedGatherScatterINTEL</strong><br>
+<br>
+Allow <strong>OpTypeVector</strong> to have a <em>physical pointer type</em> <em>Component Type</em>.<br>
+<br>
+See also extension: <strong>SPV_INTEL_masked_gather_scatter</strong><br></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>Addresses</strong></p></td>
+</tr>
+</tbody>
+</table>
+</div></div>
+</div>
+<div class="sect2">
+<h3 id="_3_42_6_type_declaration_instructions">3.42.6. Type-Declaration Instructions</h3>
+<div class="paragraph"><p>Modify <strong>OpTypeVector</strong>, changing the description of <em>Component Type</em> to:
+  <em>Component Type</em> is the type of each component in the resulting type. It must be a <em>scalar type</em> or <em>physical pointer type</em>.</p></div>
+</div>
+<div class="sect2">
+<h3 id="_3_42_7_constant_creation_instructions">3.42.7. Constant-Creation Instructions</h3>
+<div class="paragraph"><p>Modify <strong>OpConstantNull</strong>, allowing <em>Result Type</em> to be a vector of <em>physical pointer type</em>.</p></div>
+</div>
+<div class="sect2">
+<h3 id="_3_42_8_memory_instructions">3.42.8. Memory Instructions</h3>
+<div class="paragraph"><p>Allow <em>vector</em> of <em>physical pointer type</em> to be used by <strong>OpVariable</strong>, <strong>OpAccessChain</strong>, <strong>OpInBoundsAccessChain</strong>,
+<strong>OpPtrAccessChain</strong>, <strong>OpInBoundsPtrAccessChain</strong>, <strong>OpPtrEqual</strong>, <strong>OpPtrNotEqual</strong> and <strong>OpPtrDiff</strong> instructions. When <em>vector</em> of
+<em>physical pointer type</em> is allowed for <strong>OpVariable</strong> it is implicitly possible to be used by <strong>OpStore</strong> and <strong>OpLoad</strong> which can
+store/load through a pointer to this vector.</p></div>
+<div class="paragraph"><p>Change the <em>Overview</em> of <strong>OpVariable</strong> as follows:
+Allocate an object or a vector of objects in memory, resulting in a pointer or appropriately a vector of pointers to it,
+which can be used with <strong>OpLoad</strong> and <strong>OpStore</strong>.
+Change the <em>Result Type</em> of <strong>OpVariable</strong> as follows:
+<em>Result Type</em> must be an <strong>OpTypePointer</strong> or a <em>vector</em> with <em>physical pointer type</em> <em>Component Type</em>.
+Its <em>Type</em> operand is the type of object or vector of objects in memory.</p></div>
+<div class="paragraph"><p>Modify <strong>OpAccessChain</strong> (implicitly modifies <strong>OpInBoundsAccessChain</strong>, <strong>OpPtrAccessChain</strong> and <strong>OpInBoundsPtrAccessChain</strong> instructions)
+Change the <em>Base</em> as follows:
+<em>Base</em> must be a pointer, pointing to the base of a composite object or a <em>vector</em> of <em>physical pointer type</em>.</p></div>
+<div class="paragraph"><p>Allow <em>vector</em> of <em>physical pointer type</em> to be the type of <em>Operand 1</em> and <em>Operand 2</em> of <strong>OpPtrEqual</strong>, <strong>OpPtrNotEqual</strong> and
+<strong>OpPtrDiff</strong> instructions. If operands are vectors of pointers, then the <em>Result Type</em> of <strong>OpPtrEqual</strong> and <strong>OpPtrNotEqual</strong> is a
+vector with boolean <em>Component Type</em> and <em>Result Type</em> of <strong>OpPtrDiff</strong> is a vector with integer <em>Component Type</em>.</p></div>
+<div class="paragraph"><p>Add the following new entries:</p></div>
+<table class="tableblock frame-all grid-all"
+style="
+width:100%;
+">
+<col style="width:5%;">
+<col style="width:5%;">
+<col style="width:15%;">
+<col style="width:15%;">
+<col style="width:15%;">
+<col style="width:15%;">
+<col style="width:15%;">
+<col style="width:15%;">
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="7" ><p class="tableblock"><a id="OpMaskedGatherINTEL"></a><strong>OpMaskedGatherINTEL</strong><br>
+<br>
+Reads values from a vector of pointers gathering them into one vector. Returns the gathered vector. Memory access
+is specified by a mask instruction parameter.<br>
+<br>
+<em>Result Type</em> is a type of the gathered vector. Its <em>Component Type</em> must be the same as the base type of
+<em>PtrVector</em>.
+<br>
+<em>PtrVector</em> is a <em>vector</em> with <em>physical pointer type</em> <em>Component Type</em>, containing addresses from where the instruction reads.<br>
+<br>
+<em>Alignment</em> is an unsigned 32-bit integer literal whose value is
+either 0 or a power of two. When the value is not 0, it is an assertion that
+each pointer value in <em>PtrVector</em> has this alignment. The behavior is undefined if
+any pointer value in <em>PtrVector</em> does not have this alignment.<br>
+<br>
+<em>Mask</em> is a vector of boolean values with the same number of elements as the <em>Result Type</em>. It specifies which elements of
+<em>PtrVector</em> should be gathered.<br>
+<br>
+<em>FillEmpty</em> is used to fill the masked-off lanes of the result. It must be of the same type as the <em>Component Type</em> of <em>Result Type</em>.<br></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<strong>MaskedGatherScatterINTEL</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">7</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6428</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>Result Type</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>PtrVector</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;literal&gt;</em><br>
+<em>Alignment</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>Mask</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>FillEmpty</em></p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all"
+style="
+width:100%;
+">
+<col style="width:7%;">
+<col style="width:7%;">
+<col style="width:21%;">
+<col style="width:21%;">
+<col style="width:21%;">
+<col style="width:21%;">
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" colspan="5" ><p class="tableblock"><a id="OpMaskedScatterINTEL"></a><strong>OpMaskedScatterINTEL</strong><br>
+<br>
+Writes values from a vector to the corresponding memory address of the given vector of pointers. Memory access
+is specified by a mask instruction parameter.<br>
+<br>
+<em>InputVector</em> is a <em>vector</em> of values to scatter.<br>
+<br>
+<em>PtrVector</em> is a <em>vector</em> with <em>physical pointer type</em> <em>Component Type</em>, containing addresses where the instruction stores the scattered values.<br>
+<br>
+<em>Alignment</em> is an unsigned 32-bit integer literal whose value is
+either 0 or a power of two. When the value is not 0, it is an assertion that
+each pointer value in <em>PtrVector</em> has this alignment. The behavior is undefined if
+any pointer value in <em>PtrVector</em> does not have this alignment.<br>
+<br>
+<em>Mask</em> is a vector of boolean values with the same number of elements as the <em>InputVector</em>. It specifies which elements of
+<em>InputVector</em> should be scattered.<br></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<strong>MaskedGatherScatterINTEL</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">6429</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>InputVector</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>PtrVector</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;literal&gt;</em><br>
+<em>Alignment</em></p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<em>Mask</em></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_3_42_11_conversion_instructions">3.42.11. Conversion Instructions</h3>
+<div class="paragraph"><p>Allow <strong>OpTypeVector</strong> to be <em>Result Type</em> and type of an input for <strong>OpConvertPtrToU</strong>, <strong>OpConvertUToPtr</strong> instructions:
+Change the <em>Result Type</em> of <strong>OpConvertPtrToU</strong> as follows:
+<em>Result Type</em> must be a scalar or vector of <em>integer type</em>, whose Signedness operand is 0.</p></div>
+<div class="paragraph"><p>Change the  <em>Pointer</em> of <strong>OpConvertPtrToU</strong> as follows:
+<em>Pointer</em> must be a <em>physical pointer type</em> or a <em>vector</em> with <em>physical pointer type</em> <em>Component Type</em>.
+If the bit width of <em>Pointer</em> is smaller than that of <em>Result Type</em>, the conversion zero-extends <em>Pointer</em>.
+If the bit width of <em>Pointer</em> is larger than that of <em>Result Type</em>, the conversion truncates Pointer. For
+same bit width Pointer and <em>Result Type</em>, this is the same as <strong>OpBitcast</strong>.</p></div>
+<div class="paragraph"><p>Change the <em>Result Type</em> of <strong>OpConvertUToPtr</strong> as follows:
+<em>Result Type</em> must be a <em>physical pointer type</em> or a <em>vector</em> with <em>physical pointer type</em> <em>Component Type</em>.</p></div>
+<div class="paragraph"><p>Change the <em>Integer Value</em> of <strong>OpConvertUToPtr</strong> as follows:
+<em>Integer Value</em> must be a scalar or vector of <em>integer type</em>, whose Signedness operand is 0.
+If the bit width of <em>Integer Value</em> is smaller than that of <em>Result Type</em>, the
+conversion zero-extends <em>Integer Value</em>. If the bit width of <em>Integer Value</em> is larger
+than that of <em>Result Type</em>, the conversion truncates Integer Value. For same width <em>Integer Value</em> and <em>Result Type</em>,
+this is the same as <strong>OpBitcast</strong>.</p></div>
+<div class="paragraph"><p>Allow <em>vector</em> of <em>physical pointer type</em> to be <em>Result Type</em> and type of a <em>Pointer</em> for
+<strong>OpPtrCastToGeneric</strong>, <strong>OpGenericCastToPtr</strong> and <strong>OpGenericCastToPtrExplicit</strong> instructions.</p></div>
+<div class="paragraph"><p>Allow <em>vector</em> of <em>physical pointer type</em> to be <em>Result Type</em> and type of an <em>Operand</em> for <strong>OpBitcast</strong> instruction.</p></div>
+</div>
+<div class="sect2">
+<h3 id="_3_42_12_composite_instructions">3.42.12. Composite Instructions</h3>
+<div class="paragraph"><p>Most of the Composite Instructions that are supposed to work with vector type do not have any restrictions about <em>Component Type</em>.
+This extension allows these instructions to operate on <em>vector</em> of <em>physical pointer type</em>.</p></div>
+<div class="paragraph"><p>Allow <em>physical pointer type</em> to be a <em>Result Type</em> of <strong>OpVectorExtractDynamic</strong>.</p></div>
+</div>
+<div class="sect2">
+<h3 id="_issues">Issues</h3>
+<div class="paragraph"><p>None</p></div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_revision_history">Revision History</h2>
+<div class="sectionbody">
+<table class="tableblock frame-all grid-rows"
+style="
+width:100%;
+">
+<col style="width:4%;">
+<col style="width:14%;">
+<col style="width:14%;">
+<col style="width:66%;">
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top" >Rev</th>
+<th class="tableblock halign-left valign-top" >Date</th>
+<th class="tableblock halign-left valign-top" >Author</th>
+<th class="tableblock halign-left valign-top" >Changes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2022-08-19</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Dmitry Sidorov</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Initial revision</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2023-09-05</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Dmitry Sidorov</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Prepare to ship</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div id="footnotes"><hr></div>
+<div id="footer">
+<div id="footer-text">
+Last updated
+ 2023-11-14 03:43:11 PST
+</div>
+</div>
+</body>
+</html>

--- a/extensions/INTEL/SPV_INTEL_masked_gather_scatter.html
+++ b/extensions/INTEL/SPV_INTEL_masked_gather_scatter.html
@@ -842,7 +842,7 @@ width:40%;
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
 </tr>
 </tbody>
 </table>
@@ -1165,12 +1165,6 @@ width:100%;
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2022-08-19</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Dmitry Sidorov</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Initial revision</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">2023-09-05</p></td>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Dmitry Sidorov</p></td>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Prepare to ship</p></td>
@@ -1184,7 +1178,7 @@ width:100%;
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2023-11-14 03:43:11 PST
+ 2023-11-29 04:15:40 PST
 </div>
 </div>
 </body>


### PR DESCRIPTION
This extension allows TypeVector to have a physical pointer type Component Type and introduces gather/scatter instructions. It will be useful for explicitly vectorized kernels.

SPIR-V validator adjustments will be done later.

SPIR-V Headers: https://github.com/KhronosGroup/SPIRV-Headers/pull/391