### PR TITLE
Update DebugGlobalVariable's Variable field

### DIFF
--- a/nonsemantic/NonSemantic.Shader.DebugInfo.100.asciidoc
+++ b/nonsemantic/NonSemantic.Shader.DebugInfo.100.asciidoc
@@ -1174,9 +1174,12 @@ Global Variables
  +
 'Linkage Name' is an *OpString*, holding the linkage name of the variable. +
  +
-'Variable' is the '<id>' of the source global variable or constant that
- is described by this instruction. If the variable is optimized out, this
- operand must be <<DebugInfoNone,*DebugInfoNone*>>. +
+'Variable' can hold two kinds of values.  First it can hold the '<id>' of the
+ source global variable or constant that is described by this instruction. If
+ the variable is optimized out, this operand can be the '<id>' of a
+ <<DebugExpression,*DebugExpression*>> instruction that contains the constant
+ value of the variable that was optimized out. Otherwise this operand must be
+ <<DebugInfoNone,*DebugInfoNone*>>. +
  +
 {flags} +
  +


### PR DESCRIPTION
Update description of DebugGlobalVariable's Variable field to allow Variable to hold a DebugExpression if the associated variable was optimized out.  The DebugExpression will hold the constant value of the variable that was optimized out.