### PR TITLE
Fix formatting for SPV_KHR_float_controls2

### DIFF
--- a/extensions/KHR/SPV_KHR_float_controls2.asciidoc
+++ b/extensions/KHR/SPV_KHR_float_controls2.asciidoc
@@ -201,6 +201,7 @@ Indicates a floating-point fast math flag. 2+| <<FP_Fast_Math_Mode,'FP Fast Math
 In section 3.31 "Capability" add the following row to the capability table:
 [cols="^.^2,16,15",options="header",width = "100%"]
 |====
+2+| Capability | Implicitly Declares
 | 6029 | *FloatControls2* +
 Uses *FPFastMathDefault* execution mode or uses *FPFastMath* decoration (unless enabled with the *Kernel* capability). |
 |====

--- a/extensions/KHR/SPV_KHR_float_controls2.html
+++ b/extensions/KHR/SPV_KHR_float_controls2.html
@@ -848,12 +848,18 @@ Indicates a floating-point fast math flag.</p></td>
 </colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-center valign-middle">6029</th>
-<th class="tableblock halign-left valign-top"><strong>FloatControls2</strong><br>
-Uses <strong>FPFastMathDefault</strong> execution mode or uses <strong>FPFastMath</strong> decoration (unless enabled with the <strong>Kernel</strong> capability).</th>
-<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-center valign-middle" colspan="2">Capability</th>
+<th class="tableblock halign-left valign-top">Implicitly Declares</th>
 </tr>
 </thead>
+<tbody>
+<tr>
+<td class="tableblock halign-center valign-middle"><p class="tableblock">6029</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>FloatControls2</strong><br>
+Uses <strong>FPFastMathDefault</strong> execution mode or uses <strong>FPFastMath</strong> decoration (unless enabled with the <strong>Kernel</strong> capability).</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+</tbody>
 </table>
 </div>
 </div>
@@ -1023,7 +1029,7 @@ is outside the scope of this extension.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-02-14 14:58:41 UTC
+Last updated 2024-03-08 17:57:37 UTC
 </div>
 </div>
 </body>


### PR DESCRIPTION
One of the tables was missing a header, so the whole contents of the table was being treated as a header.