### PR TITLE
Update Makefile to better align with main spec generator

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -4,7 +4,7 @@ This document describes how to create HTML specifications for this repo.
 
 ## Asciidoc Specification Source
 
-Khronos recommends using [Asciidoc](https://asciidoc-py.github.io/index.html) to author SPIR-V extensions.
+Khronos recommends using [Asciidoctor](https://asciidoctor.org/) to author SPIR-V extensions.
 Asciidoc is a text-based document format that is easy to store and manage in a version control system, like this GitHub repo.
 For information about the Asciidoc format, please refer to the online documentation.
 
@@ -12,16 +12,30 @@ For most SPIR-V specifications it is easiest to copy and modify an existing SPIR
 
 ## Converting from Asciidoc to HTML
 
-The Asciidoc toolchain supports many output formats.
+The Asciidoctor toolchain supports many output formats.
 To publish an extension in this repo, generate an HTML specification.
 
-Most specifications in this repo are built with the older Asciidoc toolchain.
+Most specifications in this repo are built with the Asciidoc toolchain.
 Please refer to the online documentation to install the Asciidoc toolchain.
+
+Alternatively, Khronos maintains and publishes docker containers with the toolchain installed.
+The `khronosgroup/docker-images:asciidoctor-spec` image provides the minimal tooling to convert to HTML.
 
 A recommended command line to build an HTML specification from Asciidoc source is:
 
 ```sh
-$ asciidoc -b html5 -a icons -a toc2 -a toclevels=1 -o SPV_my_extension.html SPV_my_extension.asciidoc
+$ asciidoctor --trace --safe-mode safe -b html5 -a icons=font -a data-uri -a toc2 -a toclevels=1 -o SPV_my_extension.html SPV_my_extension.asciidoc
 ```
 
 The included Makefile in this repo can also be used to generate an HTML specification from Asciidoc source.
+For example:
+
+```sh
+$ make SPV_my_extension.html
+```
+
+To run the same step inside the `asciidoctor-spec` docker image:
+
+```sh
+$ make docker-SPV_my_extension.html
+```

--- a/BUILD.md
+++ b/BUILD.md
@@ -14,12 +14,13 @@ For most SPIR-V specifications it is easiest to copy and modify an existing SPIR
 
 The Asciidoctor toolchain supports many output formats.
 To publish an extension in this repo, generate an HTML specification.
+Please refer to the online documentation to install the Asciidoctor toolchain.
 
-Most specifications in this repo are built with the Asciidoc toolchain.
-Please refer to the online documentation to install the Asciidoc toolchain.
+Khronos maintains and publishes docker containers with the toolchain installed.
+The `khronosgroup/docker-images:asciidoctor-spec` image provides the minimal tooling to convert to HTML using asciidoctor.
 
-Alternatively, Khronos maintains and publishes docker containers with the toolchain installed.
-The `khronosgroup/docker-images:asciidoctor-spec` image provides the minimal tooling to convert to HTML.
+Most specifications in this repo were built with the older Asciidoc toolchain rather than Asciidoctor.
+Please refer to the online documentation to install the Asciidoc toolchain if need be.
 
 A recommended command line to build an HTML specification from Asciidoc source is:
 

--- a/Makefile
+++ b/Makefile
@@ -15,15 +15,23 @@
 ASCIIDOC ?= asciidoctor
 DOS2UNIX ?= dos2unix
 
-ASCIIDOC_HTML_OPTIONS = --trace --safe-mode safe -b html5 -a icons=font -a data-uri -a toc2 -a toclevels=1
-
-SRC_ASCIIDOC = $(wildcard extensions/*/*.asciidoc)
-DST_HTML = $(SRC_ASCIIDOC:.asciidoc=.html)
-
 # Compute the absolute directory name from the location of this Makefile
 # so that we can compile from anywhere even if we use make -f
 # <this_makefile>:
 SPIRV_DIR := $(abspath $(dir $(firstword $(MAKEFILE_LIST))))
+
+
+ASCIIDOC_HTML_OPTIONS = --trace \
+  -b html5 \
+  -a icons=font \
+  -a data-uri \
+  -a stylesdir=$(SPIRV_DIR)/resources \
+  -a stylesheet=spirv.css \
+  -a toc2 \
+  -a toclevels=1
+
+SRC_ASCIIDOC = $(wildcard extensions/*/*.asciidoc)
+DST_HTML = $(SRC_ASCIIDOC:.asciidoc=.html)
 
 all: $(DST_HTML)
 
@@ -46,11 +54,12 @@ $(foreach file, $(DST_HTML), $(eval $(call SHORTHAND_RULE,$(notdir $(file)),$(fi
 #   make docker-clean docker-html docker-pdf
 # Also useful to have a shell inside docker:
 #   make docker-bash
+#
+# Run with current user and group id the published AsciiDoctor
+# capable Khronos docker image.
+# Re-set MAKEFLAGS to pass variables to the inner make since
+# variables are dropped by docker.
 docker-%:
-	# Run with current user and group id the published AsciiDoctor
-	# capable Khronos docker image.
-	# Re-set MAKEFLAGS to pass variables to the inner make since
-	# variables are dropped by docker.
 	docker run --user `id --user`:`id --group` \
 	  --interactive --tty --rm \
 	  --volume $(SPIRV_DIR):/spirv khronosgroup/docker-images:asciidoctor-spec \

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ASCIIDOC ?= asciidoc
+ASCIIDOC ?= asciidoctor
 DOS2UNIX ?= dos2unix
+
+ASCIIDOC_HTML_OPTIONS = --trace --safe-mode safe -b html5 -a icons=font -a data-uri -a toc2 -a toclevels=1
 
 SRC_ASCIIDOC = $(wildcard extensions/*/*.asciidoc)
 DST_HTML = $(SRC_ASCIIDOC:.asciidoc=.html)
 
+# Compute the absolute directory name from the location of this Makefile
+# so that we can compile from anywhere even if we use make -f
+# <this_makefile>:
+SPIRV_DIR := $(abspath $(dir $(firstword $(MAKEFILE_LIST))))
+
 all: $(DST_HTML)
 
+
+# Define shorthand rules (skip the path to the extension document)
+# Useful to use make docker-extension.html (docker-extensions/KHR/ext.html doesn't work)
+define SHORTHAND_RULE
+$(1): $(2)
+endef
+
+$(foreach file, $(DST_HTML), $(eval $(call SHORTHAND_RULE,$(notdir $(file)),$(file))))
+
 %.html: %.asciidoc
-	$(ASCIIDOC) -b html5 -a icons -a toc2 -a toclevels=1 -o $@ $<
+	$(ASCIIDOC) $(ASCIIDOC_HTML_OPTIONS) -o $@ $<
 	$(DOS2UNIX) $@
+
+
+# Expose docker-TARGET to forward a TARGET inside a Docker container.
+# For example:
+#   make docker-clean docker-html docker-pdf
+# Also useful to have a shell inside docker:
+#   make docker-bash
+docker-%:
+	# Run with current user and group id the published AsciiDoctor
+	# capable Khronos docker image.
+	# Re-set MAKEFLAGS to pass variables to the inner make since
+	# variables are dropped by docker.
+	docker run --user `id --user`:`id --group` \
+	  --interactive --tty --rm \
+	  --volume $(SPIRV_DIR):/spirv khronosgroup/docker-images:asciidoctor-spec \
+	  $(MAKE) MAKEFLAGS="$(MAKEFLAGS)" --directory=/spirv $*

--- a/resources/spirv.css
+++ b/resources/spirv.css
@@ -1,0 +1,10 @@
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}


### PR DESCRIPTION
- Recommend use of asciidoctor rather than asciidoc
- Use similar invocation as main SPIR-V specs
- Add shorthand to just name the extension rather than the whole path
- Add rule to run steps inside the asciidoctor-spec docker image
- Update the BUILD.md

Should address comments in https://github.com/KhronosGroup/SPIRV-Registry/issues/245