### PR TITLE
Update SPV_KHR_float_controls2

### DIFF
--- a/extensions/KHR/SPV_KHR_float_controls2.asciidoc
+++ b/extensions/KHR/SPV_KHR_float_controls2.asciidoc
@@ -32,8 +32,8 @@ http://www.khronos.org/registry/speccopyright.html
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2024-03-15
-| Revision           | 9
+| Last Modified Date | 2024-04-03
+| Revision           | 10
 |========================================
 
 == Dependencies
@@ -75,7 +75,7 @@ In section 2.16.1 "Universal Validation Rules" add the rules:
   - Contain any *FP Fast Math Mode* bitmask containing *Fast*.
 
 * It is not valid for any instruction to be decorated with both *NoContraction*
-  and *FPFastMath*.
+  and *FPFastMathMode*.
 
 * Any *FP Fast Math Mode* bitmask that includes the *AllowTransform* bit must also
   include the *AllowContract* and *AllowReassoc* bits.
@@ -95,6 +95,7 @@ Type' must be a scalar, floating-point type. 'Fast-Math Mode' must be the <id>
 of a <<ConstantInstruction,'constant instruction'>> of 32-bit integer type
 containing a valid <<FP_Fast_Math_Mode,'FP Fast Math Mode'>> bitmask.
 'Fast-Math Mode' must not be a specialization-constant instruction.
+May be applied at most once per 'Target Type' to any execution mode.
 | <id> +
 'Target Type'
 | <id> +
@@ -204,7 +205,7 @@ In section 3.31 "Capability" add the following row to the capability table:
 |====
 2+| Capability | Implicitly Declares
 | 6029 | *FloatControls2* +
-Uses *FPFastMathDefault* execution mode or uses *FPFastMath* decoration (unless enabled with the *Kernel* capability). |
+Uses *FPFastMathDefault* execution mode or uses *FPFastMathMode* decoration (unless enabled with the *Kernel* capability). |
 |====
 
 
@@ -223,9 +224,9 @@ This extension deprecates the following features:
 
 * The execution modes *ContractionOff* and *SignedZeroInfNanPreserve*. Use
   *FPFastMathDefault* with the appropriate flags instead.
-* The decoration *NoContraction*. Use the *FPFastMath* decoration instead.
-* The *FPFastMath* mode bit *Fast*. Set all the other *FPFastMath* bits instead.
-* Enabling the *FPFastMath* decoration using the *Kernel* capability. All uses should
+* The decoration *NoContraction*. Use the *FPFastMathMode* decoration instead.
+* The *FPFastMathMode* mode bit *Fast*. Set all the other *FPFastMathMode* bits instead.
+* Enabling the *FPFastMathMode* decoration using the *Kernel* capability. All uses should
   declare the *FloatControls2* capability.
 * The *OpenCL.std* instructions *fmin_common*, *fmax_common*. Use *fmin*, *fmax* with
   *NInf* and *NNaN* instead.
@@ -265,13 +266,14 @@ is outside the scope of this extension.
 [options="header"]
 |========================================
 |Rev|Date|Author|Changes
-|1|2021-09-15|Graeme Leese|Initial KHR extension.
-|2|2021-09-24|Graeme Leese|Updated following review.
-|3|2022-04-06|Graeme Leese|Updated following review.
-|4|2023-04-26|Graeme Leese|Clarify which operations must be decorated.
-|5|2023-05-09|Graeme Leese|Resolve issues.
-|6|2023-05-17|Graeme Leese|Clarify interaction of transforms with inf/nan.
-|7|2023-06-08|Graeme Leese|Update deprecations, fix defaults to use IDs.
-|8|2023-10-02|Graeme Leese|Update required SPIR-V version, clarify deprecation of 'fast'.
-|9|2024-03-15|Graeme Leese|Clarify rules for modules declaring no *FPFastMathDefault*.
+| 1|2021-09-15|Graeme Leese|Initial KHR extension.
+| 2|2021-09-24|Graeme Leese|Updated following review.
+| 3|2022-04-06|Graeme Leese|Updated following review.
+| 4|2023-04-26|Graeme Leese|Clarify which operations must be decorated.
+| 5|2023-05-09|Graeme Leese|Resolve issues.
+| 6|2023-05-17|Graeme Leese|Clarify interaction of transforms with inf/nan.
+| 7|2023-06-08|Graeme Leese|Update deprecations, fix defaults to use IDs.
+| 8|2023-10-02|Graeme Leese|Update required SPIR-V version, clarify deprecation of 'fast'.
+| 9|2024-03-15|Graeme Leese|Clarify rules for modules declaring no *FPFastMathDefault*.
+|10|2024-04-03|Graeme Leese|Fix some spellings and clarify multiple use of execution mode.
 |========================================

--- a/extensions/KHR/SPV_KHR_float_controls2.html
+++ b/extensions/KHR/SPV_KHR_float_controls2.html
@@ -539,11 +539,11 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-03-15</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-04-03</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">9</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">10</p></td>
 </tr>
 </tbody>
 </table>
@@ -620,7 +620,7 @@ modifications to the floating-point semantics.</p>
 </li>
 <li>
 <p>It is not valid for any instruction to be decorated with both <strong>NoContraction</strong>
-and <strong>FPFastMath</strong>.</p>
+and <strong>FPFastMathMode</strong>.</p>
 </li>
 <li>
 <p>Any <strong>FP Fast Math Mode</strong> bitmask that includes the <strong>AllowTransform</strong> bit must also
@@ -659,7 +659,8 @@ type that is 'Target Type' or an <strong>OpTypeMatrix</strong> or <strong>OpType
 Type' must be a scalar, floating-point type. 'Fast-Math Mode' must be the &lt;id&gt;
 of a <a href="#ConstantInstruction">'constant instruction'</a> of 32-bit integer type
 containing a valid <a href="#FP_Fast_Math_Mode">'FP Fast Math Mode'</a> bitmask.
-'Fast-Math Mode' must not be a specialization-constant instruction.</p></td>
+'Fast-Math Mode' must not be a specialization-constant instruction.
+May be applied at most once per 'Target Type' to any execution mode.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt;<br>
 'Target Type'</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt;<br>
@@ -858,7 +859,7 @@ Indicates a floating-point fast math flag.</p></td>
 <tr>
 <td class="tableblock halign-center valign-middle"><p class="tableblock">6029</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>FloatControls2</strong><br>
-Uses <strong>FPFastMathDefault</strong> execution mode or uses <strong>FPFastMath</strong> decoration (unless enabled with the <strong>Kernel</strong> capability).</p></td>
+Uses <strong>FPFastMathDefault</strong> execution mode or uses <strong>FPFastMathMode</strong> decoration (unless enabled with the <strong>Kernel</strong> capability).</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 </tbody>
@@ -893,13 +894,13 @@ type for either operands or result".</p>
 <strong>FPFastMathDefault</strong> with the appropriate flags instead.</p>
 </li>
 <li>
-<p>The decoration <strong>NoContraction</strong>. Use the <strong>FPFastMath</strong> decoration instead.</p>
+<p>The decoration <strong>NoContraction</strong>. Use the <strong>FPFastMathMode</strong> decoration instead.</p>
 </li>
 <li>
-<p>The <strong>FPFastMath</strong> mode bit <strong>Fast</strong>. Set all the other <strong>FPFastMath</strong> bits instead.</p>
+<p>The <strong>FPFastMathMode</strong> mode bit <strong>Fast</strong>. Set all the other <strong>FPFastMathMode</strong> bits instead.</p>
 </li>
 <li>
-<p>Enabling the <strong>FPFastMath</strong> decoration using the <strong>Kernel</strong> capability. All uses should
+<p>Enabling the <strong>FPFastMathMode</strong> decoration using the <strong>Kernel</strong> capability. All uses should
 declare the <strong>FloatControls2</strong> capability.</p>
 </li>
 <li>
@@ -1030,6 +1031,12 @@ is outside the scope of this extension.</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Graeme Leese</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Clarify rules for modules declaring no <strong>FPFastMathDefault</strong>.</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">10</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-04-03</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Graeme Leese</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fix some spellings and clarify multiple use of execution mode.</p></td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -1037,7 +1044,7 @@ is outside the scope of this extension.</p>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2024-03-20 10:19:57 UTC
+Last updated 2024-04-03 11:18:13 +0100
 </div>
 </div>
 </body>


### PR DESCRIPTION
Correct spelling of FPFastMathMode (not FPFastMath). Fixes #246

Specify that execution modes may be used at most once per type. Fixes internal issue 780.