### PR TITLE
Fix typo and resolve issue in SPV_KHR_maximal_reconvergence

### DIFF
--- a/extensions/KHR/SPV_KHR_maximal_reconvergence.asciidoc
+++ b/extensions/KHR/SPV_KHR_maximal_reconvergence.asciidoc
@@ -42,8 +42,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2022-01-24
-| Revision           | 1
+| Last Modified Date | 2024-04-18
+| Revision           | 2
 |========================================
 
 Dependencies
@@ -261,7 +261,7 @@ The only related instances introduced during execution are the following:
   ** An invocation 'i' executes both 'L' and 'S', and
   ** 'S' is the last execution of the *OpSwitch* before executing 'L' for 'i', then
   ** 'L' is related to 'S', and
-  ** 'T(L)' *may* include a subset of non-escaping invocations in 'T(J)'
+  ** 'T(L)' *may* include a subset of non-escaping invocations in 'T(S)'
 
 * Given dynamic instances 'L' of an *OpLabel* and 'M' of an *OpLoopMerge*, where:
   ** The *OpLabel* is the declared *Merge Block* of the *OpLoopMerge*, and
@@ -324,7 +324,9 @@ same case construct.
 . Should any structured control flow rules be tightened for this extension?
 +
 --
-*Unresolved*
+*Resolved*
+
+Yes, see the modifications to *2.11 Structured Control Flow*.
 --
 
 . Should this extension make any mention of forward progress?
@@ -354,5 +356,6 @@ Revision History
 |===
 |Rev|Date|Author|Changes
 |1|2022-01-22|Alan Baker|Initial Revision
+|2|2024-04-18|Alan Baker|Fix typo and resolve issue
 |===
 

--- a/extensions/KHR/SPV_KHR_maximal_reconvergence.html
+++ b/extensions/KHR/SPV_KHR_maximal_reconvergence.html
@@ -869,11 +869,11 @@ width:40%;
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2022-01-24</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2024-04-18</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
 </tr>
 </tbody>
 </table>
@@ -1193,7 +1193,7 @@ An invocation <em>i</em> executes both <em>L</em> and <em>S</em>, and
 </li>
 <li>
 <p>
-<em>T(L)</em> <strong>may</strong> include a subset of non-escaping invocations in <em>T(J)</em>
+<em>T(L)</em> <strong>may</strong> include a subset of non-escaping invocations in <em>T(S)</em>
 </p>
 </li>
 </ul></div>
@@ -1345,7 +1345,8 @@ Should any structured control flow rules be tightened for this extension?
 </p>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p><strong>Unresolved</strong></p></div>
+<div class="paragraph"><p><strong>Resolved</strong></p></div>
+<div class="paragraph"><p>Yes, see the modifications to <strong>2.11 Structured Control Flow</strong>.</p></div>
 </div></div>
 </li>
 <li>
@@ -1399,6 +1400,12 @@ width:100%;
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Alan Baker</p></td>
 <td class="tableblock halign-left valign-top" ><p class="tableblock">Initial Revision</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">2024-04-18</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Alan Baker</p></td>
+<td class="tableblock halign-left valign-top" ><p class="tableblock">Fix typo and resolve issue</p></td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -1408,7 +1415,7 @@ width:100%;
 <div id="footer">
 <div id="footer-text">
 Last updated
- 2024-01-24 10:02:28 EST
+ 2024-04-18 09:24:29 EDT
 </div>
 </div>
 </body>


### PR DESCRIPTION
* Fix a typo in the description of OpSwitch reconvergence
* Resolve the issue about changes to structured control flow