### PR TITLE
Disable asciidoctor footer and enable failure on errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,11 @@ DOS2UNIX ?= dos2unix
 SPIRV_DIR := $(abspath $(dir $(firstword $(MAKEFILE_LIST))))
 
 
-ASCIIDOC_HTML_OPTIONS = --trace \
+ASCIIDOC_HTML_OPTIONS = --trace --failure-level ERROR \
   -b html5 \
   -a icons=font \
   -a data-uri \
+  -a nofooter \
   -a stylesdir=$(SPIRV_DIR)/resources \
   -a stylesheet=spirv.css \
   -a toc2 \


### PR DESCRIPTION
- Disable footer with automatically generated "Last modified time" so HTML files don't change when the asciidoc source does not. This makes landing #267 much easier.
- Fail HTML file generation when asciidoctor encounters an error. This makes it easier for contributors to spot and fix errors.


Change-Id: I719718c40a8dd09c1109484b2c31c9c16f75ee90