### PR TITLE
Add HTML building action

### DIFF
--- a/.github/workflows/html-build.yml
+++ b/.github/workflows/html-build.yml
@@ -14,14 +14,13 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    # We now refer to the container by its SHA instead of the name, to prevent
+    # caching problems when updating the image.
+    # container: khronosgroup/docker-images:asciidoctor-spec.20240726
+    container: khronosgroup/docker-images@sha256:089687083ceb36483a3917389e4278718ab19c594099634f5dd80e22540c960f
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt -y install dos2unix
-          sudo apt -y install asciidoctor
       - name: Build AsciiDoctor
         run: |
           find . -name "*.asciidoc" -exec touch {} \;

--- a/.github/workflows/html-build.yml
+++ b/.github/workflows/html-build.yml
@@ -1,0 +1,34 @@
+name: Rebuild all with asciidoctor
+
+on:
+  # Runs on pushes targeting the main branch.
+  push:
+    branches: ["main"]
+  # Runs on pull requests, uses the action's description from the target branch.
+  pull_request_target:
+    types: [opened,synchronize]
+
+  workflow_dispatch:
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt -y install dos2unix
+          sudo apt -y install asciidoctor
+      - name: Build AsciiDoctor
+        run: |
+          find . -name "*.asciidoc" -exec touch {} \;
+          make all
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: HTML
+          path: ${{github.workspace}}/**/*.html


### PR DESCRIPTION
This adds a basic GitHub action to build the HTML documentation using asciidoctor and upload the generated HTML artifact.

This build fails right now due to errors from asciidoctor, but if it's useful it is a good way to see what is going on.