### PR TITLE
asciidoc fixes for Intel extensions

### DIFF
--- a/extensions/INTEL/SPV_INTEL_arbitrary_precision_fixed_point.html
+++ b/extensions/INTEL/SPV_INTEL_arbitrary_precision_fixed_point.html
@@ -4,497 +4,105 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.17">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_arbitrary_precision_fixed_point</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-html{font-family:sans-serif;-webkit-text-size-adjust:100%}
-a{background:none}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-b,strong{font-weight:bold}
-abbr{font-size:.9em}
-abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
-dfn{font-style:italic}
-hr{height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-audio,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type=checkbox],input[type=radio]{padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,::before,::after{box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:0}
-p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-:not(pre).nobreak{word-wrap:normal}
-:not(pre).nowrap{white-space:nowrap}
-:not(pre).pre-wrap{white-space:pre-wrap}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
-pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
-pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
-pre>code{display:block}
-pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #e7e7e9}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details{margin-left:1.25rem}
-details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
-details>summary::-webkit-details-marker{display:none}
-details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
-details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
-details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
-@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
-.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
-.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.prettyprint{background:#f7f7f8}
-pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
-pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
-pre.prettyprint li code[data-lang]::before{opacity:1}
-pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
-table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
-table.linenotable td.code{padding-left:.75em}
-table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
-pre.pygments span.linenos{display:inline-block;margin-right:.75em}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
-.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
-.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
-.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
-td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>*>tr>*{border-width:1px}
-table.grid-cols>*>tr>*{border-width:0 1px}
-table.grid-rows>*>tr>*{border-width:1px 0}
-table.frame-all{border-width:1px}
-table.frame-ends{border-width:1px 0}
-table.frame-sides{border-width:0 1px}
-table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
-table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
-table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
-table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
-table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-li>p:empty:only-child::before{content:"";display:inline-block}
-ul.checklist>li>p:first-child{margin-left:-1em}
-ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
-ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-td.hdlist2{word-wrap:anywhere}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
-.imageblock.left{margin:.25em .625em 1.25em 0}
-.imageblock.right{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background:#00fafa}
-.black{color:#000}
-.black-background{background:#000}
-.blue{color:#0000bf}
-.blue-background{background:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background:#fa00fa}
-.gray{color:#606060}
-.gray-background{background:#7d7d7d}
-.green{color:#006000}
-.green-background{background:#007d00}
-.lime{color:#00bf00}
-.lime-background{background:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background:#7d0000}
-.navy{color:#000060}
-.navy-background{background:#00007d}
-.olive{color:#606000}
-.olive-background{background:#7d7d00}
-.purple{color:#600060}
-.purple-background{background:#7d007d}
-.red{color:#bf0000}
-.red-background{background:#fa0000}
-.silver{color:#909090}
-.silver-background{background:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]{border-bottom:1px dotted}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#header,#content,#footnotes,#footer{max-width:none}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article data-line-1">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_arbitrary_precision_fixed_point</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_new_instructions">New Instructions</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification Version 1.6</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
-<div class="sect1 data-line-4">
+<div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-6">
+<div class="paragraph">
 <p>SPV_INTEL_arbitrary_precision_fixed_point</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-8">
+<div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-10">
+<div class="paragraph">
 <p>To report problems with this extension, please open a new issue at:</p>
 </div>
-<div class="paragraph data-line-12">
-<p><a href="https://github.com/KhronosGroup/SPIRV-Headers" class="undefined" data-href="https://github.com/KhronosGroup/SPIRV-Headers">https://github.com/KhronosGroup/SPIRV-Headers</a></p>
+<div class="paragraph">
+<p><a href="https://github.com/KhronosGroup/SPIRV-Headers" class="bare">https://github.com/KhronosGroup/SPIRV-Headers</a></p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-14">
+<div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="ulist data-line-16">
+<div class="ulist">
 <ul>
-<li class="data-line-16">
+<li>
 <p>Ajaykumar Kannan, Intel</p>
 </li>
-<li class="data-line-17">
+<li>
 <p>Shuo Niu, Intel</p>
 </li>
-<li class="data-line-18">
+<li>
 <p>Daniel Zhang, Intel</p>
 </li>
 </ul>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-20">
+<div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-22">
+<div class="paragraph">
 <p>Copyright (c) 2023 Intel Corporation</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-24">
+<div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-26">
+<div class="paragraph">
 <p>Final draft</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-28">
+<div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all data-line-31" style="width: 40%;">
+<table class="tableblock frame-all grid-all" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -502,7 +110,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2023-03-21</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-09</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -512,62 +120,62 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </table>
 </div>
 </div>
-<div class="sect1 data-line-36">
+<div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-38">
+<div class="paragraph">
 <p>This extension is written against the SPIR-V Specification Version 1.6, Revision 2.</p>
 </div>
-<div class="paragraph data-line-40">
+<div class="paragraph">
 <p>While this extension does not require SPV_INTEL_arbitrary_precision_integers, the new operators it adds are significantly more useful when that extension is supported as the combination of the two extensions allows for more freedom in the width of arbitrary precision data types that can be represented (see the definition of the <code>W</code> parameter below).</p>
 </div>
-<div class="paragraph data-line-42">
+<div class="paragraph">
 <p>This extension is built on Mentor Graphics ac_datatypes spec v3.9.2.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-44">
+<div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-46">
+<div class="paragraph">
 <p>This extension introduces operations for arbitrary precision fixed point numbers called ac_fixed.
-The ac_fixed datatype is an industry standard for fixed point numbers and is published by Mentor Graphics at <a href="https://hlslibs.org" data-href="https://hlslibs.org">hlslibs.org</a>.
+The ac_fixed datatype is an industry standard for fixed point numbers and is published by Mentor Graphics at <a href="https://hlslibs.org">hlslibs.org</a>.
 This datatype and its corresponding operations can be useful on targets that can take advantage of narrower representation such as FPGAs.</p>
 </div>
-<div class="sect2 data-line-50">
+<div class="sect2">
 <h3 id="_data_representation">Data Representation</h3>
-<div class="paragraph data-line-52">
+<div class="paragraph">
 <p>The ac_fixed datatype will be represented in SPIR-V as a <em>pseudo type</em> using <strong>OpTypeInt</strong>.
 It is characterized by three parameters: <code>W</code>, <code>I</code>, and <code>S</code>.</p>
 </div>
-<div class="ulist data-line-55">
+<div class="ulist">
 <ul>
-<li class="data-line-55">
+<li>
 <p><code>W</code> is the total width of the datatype (including a sign bit, if required) and is encoded in the width of the <strong>OpTypeInt</strong>.</p>
 </li>
-<li class="data-line-56">
+<li>
 <p><code>I</code> determines the position of the decimal point.</p>
-<div class="ulist data-line-57">
+<div class="ulist">
 <ul>
-<li class="data-line-57">
+<li>
 <p>When <code>I</code> &gt;= 0, <code>I</code> bits starting from the MSB of <code>W</code> are before the decimal point. If <code>I</code> is greater than <code>W</code>, then additional 0 bits are implied after the bits of <code>W</code> and before the decimal point.</p>
 </li>
-<li class="data-line-58">
+<li>
 <p>When <code>I</code> &lt; 0, <code>-I</code> 0 bits are implied after the decimal point and before the MSB of <code>W</code>.</p>
 </li>
 </ul>
 </div>
 </li>
-<li class="data-line-59">
+<li>
 <p><code>S</code> determines if this is a signed or an unsigned number. Note that the support for signedness in <strong>OpTypeInt</strong> is not leveraged here. If the ac_fixed is signed, then the MSB (most significant bit) will contain the sign bit.</p>
 </li>
 </ul>
 </div>
-<div class="paragraph data-line-61">
+<div class="paragraph">
 <p>The datatype itself does not contain any information regarding <code>I</code> and <code>S</code>.
 Each operation will contain information about the input and result datatypes (including <code>W</code>, <code>S</code>, and <code>I</code>) where <code>W</code> is implicit from the size of the <strong>OpTypeInt</strong>.</p>
 </div>
-<div class="paragraph data-line-64">
+<div class="paragraph">
 <p>A variable of ac_fixed type can contain both an integer component and a fractional component depending on the value of <code>I</code>.
 Based on its value, the number of bits allocated for the integer and fractional portions will change.
 Note that it is also possible that one of the two portions may have no bits.</p>
@@ -575,39 +183,39 @@ Note that it is also possible that one of the two portions may have no bits.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-68">
+<div class="sect1">
 <h2 id="_extension_name">Extension Name</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-70">
+<div class="paragraph">
 <p>To use this extension within a SPIR-V module, the following <strong>OpExtension</strong> must be present in the module:</p>
 </div>
-<div class="listingblock data-line-72">
+<div class="listingblock">
 <div class="content">
 <pre>OpExtension "SPV_INTEL_arbitrary_precision_fixed_point"</pre>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-76">
+<div class="sect1">
 <h2 id="_new_capabilities">New Capabilities</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-78">
+<div class="paragraph">
 <p>This extension introduces a new capability:</p>
 </div>
-<div class="listingblock data-line-80">
+<div class="listingblock">
 <div class="content">
 <pre>ArbitraryPrecisionFixedPointINTEL</pre>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-84">
+<div class="sect1">
 <h2 id="_new_instructions">New Instructions</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-86">
+<div class="paragraph">
 <p>Instructions added under the <strong>ArbitraryPrecisionFixedPointINTEL</strong> capability:</p>
 </div>
-<div class="listingblock data-line-88">
+<div class="listingblock">
 <div class="content">
 <pre>OpFixedSqrtINTEL
 OpFixedRecipINTEL
@@ -624,10 +232,10 @@ OpFixedExpINTEL</pre>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-102">
+<div class="sect1">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows data-line-106" style="width: 40%;">
+<table class="tableblock frame-all grid-rows" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -685,15 +293,15 @@ OpFixedExpINTEL</pre>
 </table>
 </div>
 </div>
-<div class="sect1 data-line-122">
+<div class="sect1">
 <h2 id="_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification Version 1.6</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-124">
+<div class="paragraph">
 <p>After Section 3.16, add a new section "3.16b Quantization Modes" as follows:</p>
 </div>
-<div class="sect2 data-line-126">
+<div class="sect2">
 <h3 id="_quantization_modes">Quantization Modes</h3>
-<table class="tableblock frame-all grid-all data-line-130" style="width: 80%;">
+<table class="tableblock frame-all grid-all" style="width: 80%;">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 20%;">
@@ -759,13 +367,13 @@ OpFixedExpINTEL</pre>
 </tr>
 </tbody>
 </table>
-<div class="paragraph data-line-142">
+<div class="paragraph">
 <p>After Section 3.16, add a new section "3.16c Overflow Modes" as follows:</p>
 </div>
 </div>
-<div class="sect2 data-line-144">
+<div class="sect2">
 <h3 id="_overflow_modes">Overflow Modes</h3>
-<table class="tableblock frame-all grid-all data-line-148" style="width: 80%;">
+<table class="tableblock frame-all grid-all" style="width: 80%;">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 20%;">
@@ -808,13 +416,13 @@ OpFixedExpINTEL</pre>
 </tr>
 </tbody>
 </table>
-<div class="paragraph data-line-160">
+<div class="paragraph">
 <p>After Section 3.16, add a new section "3.16d Signedness Modes" as follows:</p>
 </div>
 </div>
-<div class="sect2 data-line-162">
+<div class="sect2">
 <h3 id="_signedness_modes">Signedness Modes</h3>
-<table class="tableblock frame-all grid-all data-line-166" style="width: 80%;">
+<table class="tableblock frame-all grid-all" style="width: 80%;">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 20%;">
@@ -845,12 +453,12 @@ OpFixedExpINTEL</pre>
 </tbody>
 </table>
 </div>
-<div class="sect2 data-line-172">
+<div class="sect2">
 <h3 id="_capability">Capability</h3>
-<div class="paragraph data-line-173">
+<div class="paragraph">
 <p>Modify Section 3.31, <strong>Capability</strong>, adding a row to the Capability table:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch data-line-176">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -872,12 +480,12 @@ OpFixedExpINTEL</pre>
 </tbody>
 </table>
 </div>
-<div class="sect2 data-line-184">
+<div class="sect2">
 <h3 id="_instructions">Instructions</h3>
-<div class="paragraph data-line-186">
+<div class="paragraph">
 <p>In Section 3.32.13, <strong>Arithmetic Instructions</strong>, add the following instructions:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch data-line-189">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -919,7 +527,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-216">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -960,7 +568,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-242">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1002,7 +610,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-269">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1043,7 +651,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-295">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1084,7 +692,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-321">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1124,7 +732,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-345">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1165,7 +773,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-371">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1206,7 +814,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-398">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1246,7 +854,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-422">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1287,7 +895,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-448">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1329,26 +937,26 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tbody>
 </table>
 </div>
-<div class="sect2 data-line-473">
+<div class="sect2">
 <h3 id="_validation_rules">Validation Rules</h3>
-<div class="paragraph data-line-475">
+<div class="paragraph">
 <p>None.</p>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-477">
+<div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-479">
+<div class="paragraph">
 <p>None.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-481">
+<div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all stretch data-line-484">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -1366,18 +974,13 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 <tbody>
 <tr>
 <td class="tableblock halign-center valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2023-03-21</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-09</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Ajaykumar Kannan</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Initial Public Release</strong></p></td>
 </tr>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2023-03-21 11:29:24 -0700
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_arbitrary_precision_floating_point.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_arbitrary_precision_floating_point.asciidoc
@@ -528,7 +528,7 @@ _Accuracy_ is a RoundingAccuracy chosen from _Table 3.16d_ that controls the rou
 |=====
 9+<|*OpArbitraryFloatSqrtINTEL* +
 
-An *OpTypeInt* representing an arbitrary precision floating point number is passed in as _A_ and the square root of the value is returned in _Result.
+An *OpTypeInt* representing an arbitrary precision floating point number is passed in as _A_ and the square root of the value is returned in _Result_.
 
 _Result Type_ must be *OpTypeInt*.
 

--- a/extensions/INTEL/SPV_INTEL_arbitrary_precision_floating_point.html
+++ b/extensions/INTEL/SPV_INTEL_arbitrary_precision_floating_point.html
@@ -4,497 +4,105 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.17">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_arbitrary_precision_floating_point</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-html{font-family:sans-serif;-webkit-text-size-adjust:100%}
-a{background:none}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-b,strong{font-weight:bold}
-abbr{font-size:.9em}
-abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
-dfn{font-style:italic}
-hr{height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-audio,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type=checkbox],input[type=radio]{padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,::before,::after{box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:0}
-p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-:not(pre).nobreak{word-wrap:normal}
-:not(pre).nowrap{white-space:nowrap}
-:not(pre).pre-wrap{white-space:pre-wrap}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
-pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
-pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
-pre>code{display:block}
-pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #e7e7e9}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details{margin-left:1.25rem}
-details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
-details>summary::-webkit-details-marker{display:none}
-details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
-details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
-details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
-@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
-.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
-.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.prettyprint{background:#f7f7f8}
-pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
-pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
-pre.prettyprint li code[data-lang]::before{opacity:1}
-pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
-table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
-table.linenotable td.code{padding-left:.75em}
-table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
-pre.pygments span.linenos{display:inline-block;margin-right:.75em}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
-.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
-.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
-.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
-td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>*>tr>*{border-width:1px}
-table.grid-cols>*>tr>*{border-width:0 1px}
-table.grid-rows>*>tr>*{border-width:1px 0}
-table.frame-all{border-width:1px}
-table.frame-ends{border-width:1px 0}
-table.frame-sides{border-width:0 1px}
-table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
-table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
-table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
-table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
-table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-li>p:empty:only-child::before{content:"";display:inline-block}
-ul.checklist>li>p:first-child{margin-left:-1em}
-ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
-ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-td.hdlist2{word-wrap:anywhere}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
-.imageblock.left{margin:.25em .625em 1.25em 0}
-.imageblock.right{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background:#00fafa}
-.black{color:#000}
-.black-background{background:#000}
-.blue{color:#0000bf}
-.blue-background{background:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background:#fa00fa}
-.gray{color:#606060}
-.gray-background{background:#7d7d7d}
-.green{color:#006000}
-.green-background{background:#007d00}
-.lime{color:#00bf00}
-.lime-background{background:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background:#7d0000}
-.navy{color:#000060}
-.navy-background{background:#00007d}
-.olive{color:#606000}
-.olive-background{background:#7d7d00}
-.purple{color:#600060}
-.purple-background{background:#7d007d}
-.red{color:#bf0000}
-.red-background{background:#fa0000}
-.silver{color:#909090}
-.silver-background{background:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]{border-bottom:1px dotted}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#header,#content,#footnotes,#footer{max-width:none}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article data-line-1">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_arbitrary_precision_floating_point</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_new_instructions">New Instructions</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification Version 1.6</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
-<div class="sect1 data-line-4">
+<div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-6">
+<div class="paragraph">
 <p>SPV_INTEL_arbitrary_precision_floating_point</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-8">
+<div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-10">
+<div class="paragraph">
 <p>To report problems with this extension, please open a new issue at:</p>
 </div>
-<div class="paragraph data-line-12">
-<p><a href="https://github.com/KhronosGroup/SPIRV-Headers" class="undefined" data-href="https://github.com/KhronosGroup/SPIRV-Headers">https://github.com/KhronosGroup/SPIRV-Headers</a></p>
+<div class="paragraph">
+<p><a href="https://github.com/KhronosGroup/SPIRV-Headers" class="bare">https://github.com/KhronosGroup/SPIRV-Headers</a></p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-14">
+<div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="ulist data-line-16">
+<div class="ulist">
 <ul>
-<li class="data-line-16">
+<li>
 <p>Ajaykumar Kannan, Intel</p>
 </li>
-<li class="data-line-17">
+<li>
 <p>Shuo Niu, Intel</p>
 </li>
-<li class="data-line-18">
+<li>
 <p>Daniel Zhang, Intel</p>
 </li>
 </ul>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-20">
+<div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-22">
+<div class="paragraph">
 <p>Copyright (c) 2023 Intel Corporation</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-24">
+<div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-26">
+<div class="paragraph">
 <p>Supported</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-28">
+<div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all data-line-31" style="width: 40%;">
+<table class="tableblock frame-all grid-all" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -502,7 +110,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2023-04-13</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-09</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -512,91 +120,91 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </table>
 </div>
 </div>
-<div class="sect1 data-line-36">
+<div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-38">
+<div class="paragraph">
 <p>This extension is written against the SPIR-V Specification Version 1.6, Revision 2.</p>
 </div>
-<div class="paragraph data-line-40">
+<div class="paragraph">
 <p>While this extension does not require SPV_INTEL_arbitrary_precision_integers, the new operators it adds are significantly more useful when that extension is supported as the combination of the two extensions allows for more freedom in the width of arbitrary precision floating point data types that can be represented.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-42">
+<div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-44">
+<div class="paragraph">
 <p>This extension adds instructions for performing arbitrary precision floating point computations. Each arbitrary-precision floating point value is represented as an <strong>OpTypeInt</strong> as described below.
 This datatype and its corresponding operations can be useful on targets that can take advantage of narrower representation such as FPGAs.</p>
 </div>
-<div class="paragraph data-line-47">
+<div class="paragraph">
 <p>The datatype can be characterized by two parameters:</p>
 </div>
-<div class="ulist data-line-49">
+<div class="ulist">
 <ul>
-<li class="data-line-49">
+<li>
 <p><em>E</em>: the number of exponent bits</p>
 </li>
-<li class="data-line-50">
+<li>
 <p><em>M</em>: the number of mantissa bits</p>
 </li>
 </ul>
 </div>
-<div class="paragraph data-line-52">
+<div class="paragraph">
 <p>The total width of the <strong>OpTypeInt</strong> container is <code>E+M+1</code> where the extra bit is used to represent the sign.
 Note that the signedness capabilities of <strong>OpTypeInt</strong> are not used for any of the operations.
 The data layout is shown below:</p>
 </div>
-<div class="paragraph data-line-56">
+<div class="paragraph">
 <p><code>[ S (sign bit) ][ E (Exponent) ][ M (Mantissa) ]
 ^--MSB                                    LSB--^</code></p>
 </div>
-<div class="paragraph data-line-59">
+<div class="paragraph">
 <p>The width of the data <code>(E+M+1)</code> is encoded with the width of the <strong>OpTypeInt</strong>.
 The other parameters regarding the type (namely <code>E</code> and <code>M</code>) are encoded in the arguments of the operations.</p>
 </div>
-<div class="sect2 data-line-62">
+<div class="sect2">
 <h3 id="_operation_controls">Operation Controls</h3>
-<div class="paragraph data-line-64">
+<div class="paragraph">
 <p>Each of the operations will also provide some control over the <em>Rounding Mode</em> and the <em>Subnormal support</em>.</p>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-66">
+<div class="sect1">
 <h2 id="_extension_name">Extension Name</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-68">
+<div class="paragraph">
 <p>To use this extension within a SPIR-V module, the following <strong>OpExtension</strong> must be present in the module:</p>
 </div>
-<div class="listingblock data-line-70">
+<div class="listingblock">
 <div class="content">
 <pre>OpExtension "SPV_INTEL_arbitrary_precision_floating_point"</pre>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-74">
+<div class="sect1">
 <h2 id="_new_capabilities">New Capabilities</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-76">
+<div class="paragraph">
 <p>This extension introduces a new capability:</p>
 </div>
-<div class="listingblock data-line-78">
+<div class="listingblock">
 <div class="content">
 <pre>ArbitraryPrecisionFloatingPointINTEL</pre>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-82">
+<div class="sect1">
 <h2 id="_new_instructions">New Instructions</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-84">
+<div class="paragraph">
 <p>Instructions added under the <strong>ArbitraryPrecisionFloatingPointINTEL</strong> capability:</p>
 </div>
-<div class="listingblock data-line-86">
+<div class="listingblock">
 <div class="content">
 <pre>OpArbitraryFloatAddINTEL
 OpArbitraryFloatSubINTEL
@@ -645,10 +253,10 @@ OpArbitraryFloatConvertToSIntINTEL</pre>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-132">
+<div class="sect1">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows data-line-136" style="width: 40%;">
+<table class="tableblock frame-all grid-rows" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -834,18 +442,18 @@ OpArbitraryFloatConvertToSIntINTEL</pre>
 </table>
 </div>
 </div>
-<div class="sect1 data-line-183">
+<div class="sect1">
 <h2 id="_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification Version 1.6</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-185">
+<div class="paragraph">
 <p>After Section 3.16, add a new section "3.16a Subnormal Support" as follows:</p>
 </div>
-<div class="sect2 data-line-187">
+<div class="sect2">
 <h3 id="_subnormal_support">Subnormal Support</h3>
-<div class="paragraph data-line-189">
+<div class="paragraph">
 <p>Control whether subnormal support is enabled or not.</p>
 </div>
-<table class="tableblock frame-all grid-all data-line-194" style="width: 60%;">
+<table class="tableblock frame-all grid-all" style="width: 60%;">
 <colgroup>
 <col style="width: 15%;">
 <col style="width: 85%;">
@@ -867,16 +475,16 @@ OpArbitraryFloatConvertToSIntINTEL</pre>
 </tr>
 </tbody>
 </table>
-<div class="paragraph data-line-200">
+<div class="paragraph">
 <p>After Section 3.16, add a new section "3.16d Rounding Accuracy" as follows:</p>
 </div>
 </div>
-<div class="sect2 data-line-202">
+<div class="sect2">
 <h3 id="_rounding_accuracy">Rounding Accuracy</h3>
-<div class="paragraph data-line-204">
+<div class="paragraph">
 <p>Controls whether rounding operations can be relaxed to trade correctness for improved resource utilization.</p>
 </div>
-<table class="tableblock frame-all grid-all data-line-209" style="width: 80%;">
+<table class="tableblock frame-all grid-all" style="width: 80%;">
 <colgroup>
 <col style="width: 15%;">
 <col style="width: 20%;">
@@ -905,12 +513,12 @@ The returned result is one of the two floating point values closest to the mathe
 </tbody>
 </table>
 </div>
-<div class="sect2 data-line-218">
+<div class="sect2">
 <h3 id="_capability">Capability</h3>
-<div class="paragraph data-line-219">
+<div class="paragraph">
 <p>Modify Section 3.31, <strong>Capability</strong>, adding a row to the Capability table:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch data-line-222">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -932,12 +540,12 @@ The returned result is one of the two floating point values closest to the mathe
 </tbody>
 </table>
 </div>
-<div class="sect2 data-line-231">
+<div class="sect2">
 <h3 id="_instructions">Instructions</h3>
-<div class="paragraph data-line-233">
+<div class="paragraph">
 <p>In Section 3.32.13, <strong>Arithmetic Instructions</strong>, add the following instructions:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch data-line-236">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 8.3333%;">
 <col style="width: 8.3333%;">
@@ -982,7 +590,7 @@ Note that the exponent values (Ea, Eb, Eresult) are inferred from the width of t
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-260">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 8.3333%;">
 <col style="width: 8.3333%;">
@@ -1027,7 +635,7 @@ Note that the exponent values (Ea, Eb, Eresult) are inferred from the width of t
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-284">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 8.3333%;">
 <col style="width: 8.3333%;">
@@ -1072,7 +680,7 @@ Note that the exponent values (Ea, Eb, Eresult) are inferred from the width of t
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-308">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 8.3333%;">
 <col style="width: 8.3333%;">
@@ -1117,7 +725,7 @@ Note that the exponent values (Ea, Eb, Eresult) are inferred from the width of t
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-332">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -1153,7 +761,7 @@ Note that the exponent values (Ea, Eb) are inferred from the width of the <stron
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-352">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -1189,7 +797,7 @@ Note that the exponent values (Ea, Eb) are inferred from the width of the <stron
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-372">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -1225,7 +833,7 @@ Note that the exponent values (Ea, Eb) are inferred from the width of the <stron
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-392">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -1261,7 +869,7 @@ Note that the exponent values (Ea, Eb) are inferred from the width of the <stron
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-412">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -1297,7 +905,7 @@ Note that the exponent values (Ea, Eb) are inferred from the width of the <stron
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-432">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1338,7 +946,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-456">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1379,7 +987,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-480">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1420,7 +1028,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-504">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 8.3333%;">
 <col style="width: 8.3333%;">
@@ -1465,7 +1073,7 @@ Note that the exponent values (Ea, Eb, Eresult) are inferred from the width of t
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-528">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1506,7 +1114,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-552">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1547,7 +1155,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-576">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1588,7 +1196,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-600">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1629,7 +1237,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-624">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1670,7 +1278,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-648">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1711,7 +1319,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-672">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1752,7 +1360,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-696">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1793,7 +1401,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-720">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1834,7 +1442,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-744">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1875,7 +1483,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-768">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1916,7 +1524,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-792">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1956,7 +1564,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-814">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1997,7 +1605,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-838">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -2038,7 +1646,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-862">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -2078,7 +1686,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-884">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -2119,7 +1727,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-908">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -2160,7 +1768,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-932">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -2201,7 +1809,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-956">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -2242,7 +1850,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-980">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -2283,7 +1891,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-1004">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -2324,7 +1932,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-1028">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 8.3333%;">
 <col style="width: 8.3333%;">
@@ -2369,7 +1977,7 @@ Note that the exponent values (Ea, Eb, Eresult) are inferred from the width of t
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-1052">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 8.3333%;">
 <col style="width: 8.3333%;">
@@ -2414,7 +2022,7 @@ Note that the exponent values (Ea, Eb, Eresult) are inferred from the width of t
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-1076">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 8.3333%;">
 <col style="width: 8.3333%;">
@@ -2460,7 +2068,7 @@ Note that the exponent values (Ea, Eb, Eresult) are inferred from the width of t
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-1101">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 8.3333%;">
 <col style="width: 8.3333%;">
@@ -2507,7 +2115,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-1128">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 11.1111%;">
 <col style="width: 11.1111%;">
@@ -2545,7 +2153,7 @@ It is type converted into an arbitrary precision floating point number with the 
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-1150">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -2578,7 +2186,7 @@ It is type converted into an arbitrary precision floating point number with the 
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-1170">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -2611,7 +2219,7 @@ It is type converted into an arbitrary precision floating point number with the 
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-1190">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -2644,7 +2252,7 @@ It is type converted into an unsigned integer and returned as <em>Result</em>.</
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-1210">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -2678,11 +2286,11 @@ It is type converted into a signed integer and returned as <em>Result</em>.</p>
 </tbody>
 </table>
 </div>
-<div class="sect2 data-line-1229">
+<div class="sect2">
 <h3 id="_validation_rules">Validation Rules</h3>
-<div class="ulist data-line-1231">
+<div class="ulist">
 <ul>
-<li class="data-line-1231">
+<li>
 <p>Any <code>M*</code> literal argument to any instruction added in this extension can&#8217;t exceed the width of its corresponding <strong>OpTypeInt</strong> argument minus 1</p>
 </li>
 </ul>
@@ -2690,18 +2298,18 @@ It is type converted into a signed integer and returned as <em>Result</em>.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-1233">
+<div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-1235">
+<div class="paragraph">
 <p>None.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-1237">
+<div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all stretch data-line-1240">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -2719,18 +2327,13 @@ It is type converted into a signed integer and returned as <em>Result</em>.</p>
 <tbody>
 <tr>
 <td class="tableblock halign-center valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2023-04-13</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-09</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Ajaykumar Kannan</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Initial Public Release</strong></p></td>
 </tr>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2023-04-13 13:43:49 -0700
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_arbitrary_precision_floating_point.html
+++ b/extensions/INTEL/SPV_INTEL_arbitrary_precision_floating_point.html
@@ -110,7 +110,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-09</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-27</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -1089,8 +1089,8 @@ Note that the exponent values (Ea, Eb, Eresult) are inferred from the width of t
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top" colspan="9"><p class="tableblock"><strong>OpArbitraryFloatSqrtINTEL</strong><br></p>
-<p class="tableblock">An <strong>OpTypeInt</strong> representing an arbitrary precision floating point number is passed in as <em>A</em> and the square root of the value is returned in <em>Result.</p>
-<p class="tableblock">_Result Type</em> must be <strong>OpTypeInt</strong>.</p>
+<p class="tableblock">An <strong>OpTypeInt</strong> representing an arbitrary precision floating point number is passed in as <em>A</em> and the square root of the value is returned in <em>Result</em>.</p>
+<p class="tableblock"><em>Result Type</em> must be <strong>OpTypeInt</strong>.</p>
 <p class="tableblock"><em>Result</em> is the &lt;id&gt; of the operation&#8217;s result, which is an arbitrary precision floating point number.</p>
 <p class="tableblock"><em>Mresult</em> and <em>Ma</em> are 32-bit unsigned integers that define the mantissa widths of the floating point types within <em>Result</em> and <em>A</em> respectively.
 Note that the exponent values (Ea, Eresult) are inferred from the width of the <strong>OpTypeInt</strong>.</p>
@@ -2327,7 +2327,7 @@ It is type converted into a signed integer and returned as <em>Result</em>.</p>
 <tbody>
 <tr>
 <td class="tableblock halign-center valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-09</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-27</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Ajaykumar Kannan</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Initial Public Release</strong></p></td>
 </tr>

--- a/extensions/INTEL/SPV_INTEL_arbitrary_precision_integers.html
+++ b/extensions/INTEL/SPV_INTEL_arbitrary_precision_integers.html
@@ -2,425 +2,46 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 1.5.5">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_arbitrary_precision_integers</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
-/* Remove comment around @import statement below when using as a custom stylesheet */
-/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
-article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
-audio,canvas,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-[hidden],template{display:none}
-script{display:none!important}
-html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
-a{background:transparent}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-abbr[title]{border-bottom:1px dotted}
-b,strong{font-weight:bold}
-dfn{font-style:italic}
-hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
-input[type="search"]{-webkit-appearance:textfield;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;box-sizing:content-box}
-input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,*:before,*:after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.center{margin-left:auto;margin-right:auto}
-.spread{width:100%}
-p.lead,.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{font-size:1.21875em;line-height:1.6}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:none}
-p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #ddddd8;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol,ul.no-bullet,ol.no-bullet{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ul.no-bullet{list-style:none}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
-abbr{text-transform:none}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
-blockquote cite:before{content:"\2014 \0020"}
-blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media only screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
-table thead,table tfoot{background:#f7f8f7;font-weight:bold}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.clearfix:before,.clearfix:after,.float-group:before,.float-group:after{content:" ";display:table}
-.clearfix:after,.float-group:after{clear:both}
-*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
-*:not(pre)>code.nobreak{word-wrap:normal}
-*:not(pre)>code.nowrap{white-space:nowrap}
-pre,pre>code{line-height:1.45;color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;text-rendering:optimizeSpeed}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menu{color:rgba(0,0,0,.8)}
-b.button:before,b.button:after{position:relative;top:-1px;font-weight:400}
-b.button:before{content:"[";padding:0 3px 0 2px}
-b.button:after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header:before,#header:after,#content:before,#content:after,#footnotes:before,#footnotes:after,#footer:before,#footer:after{content:" ";display:table}
-#header:after,#content:after,#footnotes:after,#footer:after{clear:both}
-#content{margin-top:1.25em}
-#content:before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #ddddd8}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #ddddd8;padding-bottom:8px}
-#header .details{border-bottom:1px solid #ddddd8;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span:before{content:"\00a0\2013\00a0"}
-#header .details br+span.author:before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark:before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber:after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #ddddd8;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #efefed;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media only screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background-color:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #efefed;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #efefed;left:auto;right:0}}
-@media only screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:100%;background-color:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
-.sect1{padding-bottom:.625em}
-@media only screen and (min-width:768px){.sect1{padding-bottom:1.25em}}
-.sect1+.sect1{border-top:1px solid #efefed}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor:before,h2>a.anchor:before,h3>a.anchor:before,#toctitle>a.anchor:before,.sidebarblock>.content>.title>a.anchor:before,h4>a.anchor:before,h5>a.anchor:before,h6>a.anchor:before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock>caption.title{white-space:nowrap;overflow:visible;max-width:0}
-.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{color:rgba(0,0,0,.85)}
-table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inherit}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color:rgba(0,0,0,.6)}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock pre:not(.highlight),.listingblock pre[class="highlight"],.listingblock pre[class^="highlight "],.listingblock pre.CodeRay,.listingblock pre.prettyprint{background:#f7f7f8}
-.sidebarblock .literalblock pre,.sidebarblock .listingblock pre:not(.highlight),.sidebarblock .listingblock pre[class="highlight"],.sidebarblock .listingblock pre[class^="highlight "],.sidebarblock .listingblock pre.CodeRay,.sidebarblock .listingblock pre.prettyprint{background:#f2f1f1}
-.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;padding:1em;font-size:.8125em}
-.literalblock pre.nowrap,.literalblock pre[class].nowrap,.listingblock pre.nowrap,.listingblock pre[class].nowrap{overflow-x:auto;white-space:pre;word-wrap:normal}
-@media only screen and (min-width:768px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:.90625em}}
-@media only screen and (min-width:1280px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:1em}}
-.literalblock.output pre{color:#f7f7f8;background-color:rgba(0,0,0,.9)}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]:before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:#999}
-.listingblock:hover code[data-lang]:before{display:block}
-.listingblock.terminal pre .command:before{content:attr(data-prompt);padding-right:.5em;color:#999}
-.listingblock.terminal pre .command:not([data-prompt]):before{content:"$"}
-table.pyhltable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.pyhltable td{vertical-align:top;padding-top:0;padding-bottom:0;line-height:1.45}
-table.pyhltable td.code{padding-left:.75em;padding-right:0}
-pre.pygments .lineno,table.pyhltable td:not(.code){color:#999;padding-left:0;padding-right:.5em;border-right:1px solid #ddddd8}
-pre.pygments .lineno{display:inline-block;margin-right:.25em}
-table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock blockquote p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote:before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.5em;margin-right:.5ex;text-align:right}
-.quoteblock .quoteblock{margin-left:0;margin-right:0;padding:.5em 0;border-left:3px solid rgba(0,0,0,.6)}
-.quoteblock .quoteblock blockquote{padding:0 0 0 .75em}
-.quoteblock .quoteblock blockquote:before{display:none}
-.verseblock{margin:0 1em 1.25em 1em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract{margin:0 0 1.25em 0;display:block}
-.quoteblock.abstract blockquote,.quoteblock.abstract blockquote p{text-align:left;word-spacing:0}
-.quoteblock.abstract blockquote:before,.quoteblock.abstract blockquote p:first-of-type:before{display:none}
-table.tableblock{max-width:100%;border-collapse:separate}
-table.tableblock td>.paragraph:last-child p>p:last-child,table.tableblock th>p:last-child,table.tableblock td>p:last-child{margin-bottom:0}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all th.tableblock,table.grid-all td.tableblock{border-width:0 1px 1px 0}
-table.grid-all tfoot>tr>th.tableblock,table.grid-all tfoot>tr>td.tableblock{border-width:1px 1px 0 0}
-table.grid-cols th.tableblock,table.grid-cols td.tableblock{border-width:0 1px 0 0}
-table.grid-all *>tr>.tableblock:last-child,table.grid-cols *>tr>.tableblock:last-child{border-right-width:0}
-table.grid-rows th.tableblock,table.grid-rows td.tableblock{border-width:0 0 1px 0}
-table.grid-all tbody>tr:last-child>th.tableblock,table.grid-all tbody>tr:last-child>td.tableblock,table.grid-all thead:last-child>tr>th.tableblock,table.grid-rows tbody>tr:last-child>th.tableblock,table.grid-rows tbody>tr:last-child>td.tableblock,table.grid-rows thead:last-child>tr>th.tableblock{border-bottom-width:0}
-table.grid-rows tfoot>tr>th.tableblock,table.grid-rows tfoot>tr>td.tableblock{border-width:1px 0 0 0}
-table.frame-all{border-width:1px}
-table.frame-sides{border-width:0 1px}
-table.frame-topbot{border-width:1px 0}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-td>div.verse{white-space:pre}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.unstyled,ol.unnumbered,ul.checklist,ul.none{list-style-type:none}
-ul.unstyled,ol.unnumbered,ul.checklist{margin-left:.625em}
-ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1em;font-size:.85em}
-ul.checklist li>p:first-child>input[type="checkbox"]:first-child{width:1em;position:relative;top:1px}
-ul.inline{margin:0 auto .625em auto;margin-left:-1.375em;margin-right:0;padding:0;list-style:none;overflow:hidden}
-ul.inline>li{list-style:none;float:left;margin-left:1.375em;display:block}
-ul.inline>li>*{display:block}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist>table tr>td:first-of-type{padding:0 .75em;line-height:1}
-.colist>table tr>td:last-of-type{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
-.imageblock.left,.imageblock[style*="float: left"]{margin:.25em .625em 1.25em 0}
-.imageblock.right,.imageblock[style*="float: right"]{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em 0;border-width:1px 0 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;text-indent:-1.05em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
-.gist .file-data>table td.line-data{width:99%}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background-color:#00fafa}
-.black{color:#000}
-.black-background{background-color:#000}
-.blue{color:#0000bf}
-.blue-background{background-color:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background-color:#fa00fa}
-.gray{color:#606060}
-.gray-background{background-color:#7d7d7d}
-.green{color:#006000}
-.green-background{background-color:#007d00}
-.lime{color:#00bf00}
-.lime-background{background-color:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background-color:#7d0000}
-.navy{color:#000060}
-.navy-background{background-color:#00007d}
-.olive{color:#606000}
-.olive-background{background-color:#7d7d00}
-.purple{color:#600060}
-.purple-background{background-color:#7d007d}
-.red{color:#bf0000}
-.red-background{background-color:#fa0000}
-.silver{color:#909090}
-.silver-background{background-color:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background-color:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background-color:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background-color:#fafa00}
-span.icon>.fa{cursor:default}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note:before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip:before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning:before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution:before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important:before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background-color:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]:after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background-color:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@media print{@page{margin:1.25cm .75cm}
-*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare):after,a[href^="https:"]:not(.bare):after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]:after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #ddddd8!important;padding-bottom:0!important}
-.sect1{padding-bottom:0!important}
-.sect1+.sect1{border:0!important}
-#header>h1:first-child{margin-top:1.25rem}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em 0}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span:before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]:before{display:block}
-#footer{background:none!important;padding:0 .9375em}
-#footer-text{color:rgba(0,0,0,.6)!important;font-size:.9em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_arbitrary_precision_integers</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_5">Modifications to the SPIR-V Specification Version 1.5</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
 <div class="sect1">
@@ -481,7 +102,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2020-03-27</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-02-02</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -560,7 +181,7 @@ Ints of arbitrary bit widths can be beneficial on targets that can exploit narro
 <div class="paragraph">
 <p>Modify Section 3.31, <strong>Capability</strong>, adding a row to the Capability table:</p>
 </div>
-<table class="tableblock frame-all grid-all spread">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -575,8 +196,8 @@ Ints of arbitrary bit widths can be beneficial on targets that can exploit narro
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">5844</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>ArbitraryPrecisionIntegersINTEL</strong><br>
-</p><p class="tableblock">Allows the use of the <strong>OpTypeInt</strong> to declare integers of any arbitrary width.
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>ArbitraryPrecisionIntegersINTEL</strong><br></p>
+<p class="tableblock">Allows the use of the <strong>OpTypeInt</strong> to declare integers of any arbitrary width.
 The minimum requirement is that all bitwidths up to 32-bits must be supported, but implementations can extend the support beyond 32-bits.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Int8, Int16</p></td>
 </tr>
@@ -602,7 +223,7 @@ The minimum requirement is that all bitwidths up to 32-bits must be supported, b
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all spread">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -627,11 +248,6 @@ The minimum requirement is that all bitwidths up to 32-bits must be supported, b
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2020-03-27 12:37:23 ADT
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_bfloat16_conversion.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_bfloat16_conversion.asciidoc
@@ -119,7 +119,6 @@ Results are computed per component. +
 | 'Result <id>'
 | '<id>' +
 'Float Value'
-| '<id>' +
 |=====
 
 [cols="1,1,3*3",width="100%"]
@@ -147,7 +146,6 @@ Results are computed per component. +
 | 'Result <id>'
 | '<id>' +
 'BFloat16 Value'
-| '<id>' +
 |=====
 
 

--- a/extensions/INTEL/SPV_INTEL_bfloat16_conversion.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_bfloat16_conversion.asciidoc
@@ -101,12 +101,12 @@ Add to Section 3.42.11, Conversion Instructions:
 Convert value numerically from 32-bit floating point to `bfloat16`, which is
 represented as a 16-bit unsigned integer. +
  +
-'Result Type' must be a scalar or vector of integer type.
+_Result Type_ must be a scalar or vector of integer type.
 The component width must be 16 bits.
-The bit pattern in the 'Result' represents a `bfloat16` value. +
+The bit pattern in the _Result_ represents a `bfloat16` value. +
  +
-'Float Value' must be a scalar or vector of floating-point type.
-It must have the same number of components as 'Result Type'.
+_Float Value_ must be a scalar or vector of floating-point type.
+It must have the same number of components as _Result Type_.
 The component width must be 32 bits. +
  +
 Results are computed per component. +
@@ -114,11 +114,11 @@ Results are computed per component. +
 1+|Capability: +
 *{capability_name}*
 1+| 4 | {FToBF16_token}
-| '<id>' +
-'Result Type'
-| 'Result <id>'
-| '<id>' +
-'Float Value'
+| _<id>_ +
+_Result Type_
+| _Result <id>_
+| _<id>_ +
+_Float Value_
 |=====
 
 [cols="1,1,3*3",width="100%"]
@@ -128,12 +128,12 @@ Results are computed per component. +
 Interpret a 16-bit integer value as `bfloat16` and convert the value numerically
 to 32-bit floating point. +
  +
-'Result Type' must be a scalar or vector of floating-point type.
+_Result Type_ must be a scalar or vector of floating-point type.
 The component width must be 32 bits. +
  +
-'BFloat16 Value' must be a scalar or vector of integer type, which is
+_BFloat16 Value_ must be a scalar or vector of integer type, which is
 interpreted as a `bfloat16`.
-The type must have the same number of components as 'Result Type'.
+The type must have the same number of components as _Result Type_.
 The component width must be 16 bits. +
  +
 Results are computed per component. +
@@ -141,11 +141,11 @@ Results are computed per component. +
 1+|Capability: +
 *{capability_name}*
 1+| 4 | {BF16ToF_token}
-| '<id>' +
-'Result Type'
-| 'Result <id>'
-| '<id>' +
-'BFloat16 Value'
+| _<id>_ +
+_Result Type_
+| _Result <id>_
+| _<id>_ +
+_BFloat16 Value_
 |=====
 
 

--- a/extensions/INTEL/SPV_INTEL_bfloat16_conversion.html
+++ b/extensions/INTEL/SPV_INTEL_bfloat16_conversion.html
@@ -1,853 +1,124 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta name="generator" content="AsciiDoc 10.2.0">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_bfloat16_conversion</title>
-<style type="text/css">
-/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
-
-/* Default font. */
-body {
-  font-family: Georgia,serif;
-}
-
-/* Title font. */
-h1, h2, h3, h4, h5, h6,
-div.title, caption.title,
-thead, p.table.header,
-#toctitle,
-#author, #revnumber, #revdate, #revremark,
-#footer {
-  font-family: Arial,Helvetica,sans-serif;
-}
-
-body {
-  margin: 1em 5% 1em 5%;
-}
-
-a {
-  color: blue;
-  text-decoration: underline;
-}
-a:visited {
-  color: fuchsia;
-}
-
-em {
-  font-style: italic;
-  color: navy;
-}
-
-strong {
-  font-weight: bold;
-  color: #083194;
-}
-
-h1, h2, h3, h4, h5, h6 {
-  color: #527bbd;
-  margin-top: 1.2em;
-  margin-bottom: 0.5em;
-  line-height: 1.3;
-}
-
-h1, h2, h3 {
-  border-bottom: 2px solid silver;
-}
-h2 {
-  padding-top: 0.5em;
-}
-h3 {
-  float: left;
-}
-h3 + * {
-  clear: left;
-}
-h5 {
-  font-size: 1.0em;
-}
-
-div.sectionbody {
-  margin-left: 0;
-}
-
-hr {
-  border: 1px solid silver;
-}
+<style>
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
 
 p {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
 }
 
-ul, ol, li > p {
-  margin-top: 0;
-}
-ul > li     { color: #aaa; }
-ul > li > * { color: black; }
-
-.monospaced, code, pre {
-  font-family: "Courier New", Courier, monospace;
-  font-size: inherit;
-  color: navy;
-  padding: 0;
-  margin: 0;
-}
-pre {
-  white-space: pre-wrap;
-}
-
-#author {
-  color: #527bbd;
-  font-weight: bold;
-  font-size: 1.1em;
-}
-#email {
-}
-#revnumber, #revdate, #revremark {
-}
-
-#footer {
-  font-size: small;
-  border-top: 2px solid silver;
-  padding-top: 0.5em;
-  margin-top: 4.0em;
-}
-#footer-text {
-  float: left;
-  padding-bottom: 0.5em;
-}
-#footer-badges {
-  float: right;
-  padding-bottom: 0.5em;
-}
-
-#preamble {
-  margin-top: 1.5em;
-  margin-bottom: 1.5em;
-}
-div.imageblock, div.exampleblock, div.verseblock,
-div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
-div.admonitionblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.admonitionblock {
-  margin-top: 2.0em;
-  margin-bottom: 2.0em;
-  margin-right: 10%;
-  color: #606060;
-}
-
-div.content { /* Block element content. */
-  padding: 0;
-}
-
-/* Block element titles. */
-div.title, caption.title {
-  color: #527bbd;
-  font-weight: bold;
-  text-align: left;
-  margin-top: 1.0em;
-  margin-bottom: 0.5em;
-}
-div.title + * {
-  margin-top: 0;
-}
-
-td div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content + div.title {
-  margin-top: 0.0em;
-}
-
-div.sidebarblock > div.content {
-  background: #ffffee;
-  border: 1px solid #dddddd;
-  border-left: 4px solid #f0f0f0;
-  padding: 0.5em;
-}
-
-div.listingblock > div.content {
-  border: 1px solid #dddddd;
-  border-left: 5px solid #f0f0f0;
-  background: #f8f8f8;
-  padding: 0.5em;
-}
-
-div.quoteblock, div.verseblock {
-  padding-left: 1.0em;
-  margin-left: 1.0em;
-  margin-right: 10%;
-  border-left: 5px solid #f0f0f0;
-  color: #888;
-}
-
-div.quoteblock > div.attribution {
-  padding-top: 0.5em;
-  text-align: right;
-}
-
-div.verseblock > pre.content {
-  font-family: inherit;
-  font-size: inherit;
-}
-div.verseblock > div.attribution {
-  padding-top: 0.75em;
-  text-align: left;
-}
-/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
-div.verseblock + div.attribution {
-  text-align: left;
-}
-
-div.admonitionblock .icon {
-  vertical-align: top;
-  font-size: 1.1em;
-  font-weight: bold;
-  text-decoration: underline;
-  color: #527bbd;
-  padding-right: 0.5em;
-}
-div.admonitionblock td.content {
-  padding-left: 0.5em;
-  border-left: 3px solid #dddddd;
-}
-
-div.exampleblock > div.content {
-  border-left: 3px solid #dddddd;
-  padding-left: 0.5em;
-}
-
-div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; vertical-align: text-bottom; }
-a.image:visited { color: white; }
-
-dl {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-dt {
-  margin-top: 0.5em;
-  margin-bottom: 0;
-  font-style: normal;
-  color: navy;
-}
-dd > *:first-child {
-  margin-top: 0.1em;
-}
-
-ul, ol {
-    list-style-position: outside;
-}
-ol.arabic {
-  list-style-type: decimal;
-}
-ol.loweralpha {
-  list-style-type: lower-alpha;
-}
-ol.upperalpha {
-  list-style-type: upper-alpha;
-}
-ol.lowerroman {
-  list-style-type: lower-roman;
-}
-ol.upperroman {
-  list-style-type: upper-roman;
-}
-
-div.compact ul, div.compact ol,
-div.compact p, div.compact p,
-div.compact div, div.compact div {
-  margin-top: 0.1em;
-  margin-bottom: 0.1em;
-}
-
-tfoot {
-  font-weight: bold;
-}
-td > div.verse {
-  white-space: pre;
-}
-
-div.hdlist {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-div.hdlist tr {
-  padding-bottom: 15px;
-}
-dt.hdlist1.strong, td.hdlist1.strong {
-  font-weight: bold;
-}
-td.hdlist1 {
-  vertical-align: top;
-  font-style: normal;
-  padding-right: 0.8em;
-  color: navy;
-}
-td.hdlist2 {
-  vertical-align: top;
-}
-div.hdlist.compact tr {
-  margin: 0;
-  padding-bottom: 0;
-}
-
-.comment {
-  background: yellow;
-}
-
-.footnote, .footnoteref {
-  font-size: 0.8em;
-}
-
-span.footnote, span.footnoteref {
-  vertical-align: super;
-}
-
-#footnotes {
-  margin: 20px 0 20px 0;
-  padding: 7px 0 0 0;
-}
-
-#footnotes div.footnote {
-  margin: 0 0 5px 0;
-}
-
-#footnotes hr {
-  border: none;
-  border-top: 1px solid silver;
-  height: 1px;
-  text-align: left;
-  margin-left: 0;
-  width: 20%;
-  min-width: 100px;
-}
-
-div.colist td {
-  padding-right: 0.5em;
-  padding-bottom: 0.3em;
-  vertical-align: top;
-}
-div.colist td img {
-  margin-top: 0.3em;
-}
-
-@media print {
-  #footer-badges { display: none; }
-}
-
-#toc {
-  margin-bottom: 2.5em;
-}
-
-#toctitle {
-  color: #527bbd;
-  font-size: 1.1em;
-  font-weight: bold;
-  margin-top: 1.0em;
-  margin-bottom: 0.1em;
-}
-
-div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-div.toclevel2 {
-  margin-left: 2em;
-  font-size: 0.9em;
-}
-div.toclevel3 {
-  margin-left: 4em;
-  font-size: 0.9em;
-}
-div.toclevel4 {
-  margin-left: 6em;
-  font-size: 0.9em;
-}
-
-span.aqua { color: aqua; }
-span.black { color: black; }
-span.blue { color: blue; }
-span.fuchsia { color: fuchsia; }
-span.gray { color: gray; }
-span.green { color: green; }
-span.lime { color: lime; }
-span.maroon { color: maroon; }
-span.navy { color: navy; }
-span.olive { color: olive; }
-span.purple { color: purple; }
-span.red { color: red; }
-span.silver { color: silver; }
-span.teal { color: teal; }
-span.white { color: white; }
-span.yellow { color: yellow; }
-
-span.aqua-background { background: aqua; }
-span.black-background { background: black; }
-span.blue-background { background: blue; }
-span.fuchsia-background { background: fuchsia; }
-span.gray-background { background: gray; }
-span.green-background { background: green; }
-span.lime-background { background: lime; }
-span.maroon-background { background: maroon; }
-span.navy-background { background: navy; }
-span.olive-background { background: olive; }
-span.purple-background { background: purple; }
-span.red-background { background: red; }
-span.silver-background { background: silver; }
-span.teal-background { background: teal; }
-span.white-background { background: white; }
-span.yellow-background { background: yellow; }
-
-span.big { font-size: 2em; }
-span.small { font-size: 0.6em; }
-
-span.underline { text-decoration: underline; }
-span.overline { text-decoration: overline; }
-span.line-through { text-decoration: line-through; }
-
-div.unbreakable { page-break-inside: avoid; }
-
-
-/*
- * xhtml11 specific
- *
- * */
-
-div.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.tableblock > table {
-  border: 3px solid #527bbd;
-}
-thead, p.table.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.table {
-  margin-top: 0;
-}
-/* Because the table frame attribute is overridden by CSS in most browsers. */
-div.tableblock > table[frame="void"] {
-  border-style: none;
-}
-div.tableblock > table[frame="hsides"] {
-  border-left-style: none;
-  border-right-style: none;
-}
-div.tableblock > table[frame="vsides"] {
-  border-top-style: none;
-  border-bottom-style: none;
-}
-
-
-/*
- * html5 specific
- *
- * */
-
-table.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-thead, p.tableblock.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.tableblock {
-  margin-top: 0;
-}
-table.tableblock {
-  border-width: 3px;
-  border-spacing: 0px;
-  border-style: solid;
-  border-color: #527bbd;
-  border-collapse: collapse;
-}
-th.tableblock, td.tableblock {
-  border-width: 1px;
-  padding: 4px;
-  border-style: solid;
-  border-color: #527bbd;
-}
-
-table.tableblock.frame-topbot {
-  border-left-style: hidden;
-  border-right-style: hidden;
-}
-table.tableblock.frame-sides {
-  border-top-style: hidden;
-  border-bottom-style: hidden;
-}
-table.tableblock.frame-none {
-  border-style: hidden;
-}
-
-th.tableblock.halign-left, td.tableblock.halign-left {
-  text-align: left;
-}
-th.tableblock.halign-center, td.tableblock.halign-center {
-  text-align: center;
-}
-th.tableblock.halign-right, td.tableblock.halign-right {
-  text-align: right;
-}
-
-th.tableblock.valign-top, td.tableblock.valign-top {
-  vertical-align: top;
-}
-th.tableblock.valign-middle, td.tableblock.valign-middle {
-  vertical-align: middle;
-}
-th.tableblock.valign-bottom, td.tableblock.valign-bottom {
-  vertical-align: bottom;
-}
-
-
-/*
- * manpage specific
- *
- * */
-
-body.manpage h1 {
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
-  border-top: 2px solid silver;
-  border-bottom: 2px solid silver;
-}
-body.manpage h2 {
-  border-style: none;
-}
-body.manpage div.sectionbody {
-  margin-left: 3em;
-}
-
-@media print {
-  body.manpage div#toc { display: none; }
-}
-
-
-@media screen {
-  body {
-    max-width: 50em; /* approximately 80 characters wide */
-    margin-left: 16em;
-  }
-
-  #toc {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 13em;
-    padding: 0.5em;
-    padding-bottom: 1.5em;
-    margin: 0;
-    overflow: auto;
-    border-right: 3px solid #f8f8f8;
-    background-color: white;
-  }
-
-  #toc .toclevel1 {
-    margin-top: 0.5em;
-  }
-
-  #toc .toclevel2 {
-    margin-top: 0.25em;
-    display: list-item;
-    color: #aaaaaa;
-  }
-
-  #toctitle {
-    margin-top: 0.5em;
-  }
-}
 </style>
-<script type="text/javascript">
-/*<![CDATA[*/
-var asciidoc = {  // Namespace.
-
-/////////////////////////////////////////////////////////////////////
-// Table Of Contents generator
-/////////////////////////////////////////////////////////////////////
-
-/* Author: Mihai Bazon, September 2002
- * http://students.infoiasi.ro/~mishoo
- *
- * Table Of Content generator
- * Version: 0.4
- *
- * Feel free to use this script under the terms of the GNU General Public
- * License, as long as you do not remove or alter this notice.
- */
-
- /* modified by Troy D. Hanson, September 2006. License: GPL */
- /* modified by Stuart Rackham, 2006, 2009. License: GPL */
-
-// toclevels = 1..4.
-toc: function (toclevels) {
-
-  function getText(el) {
-    var text = "";
-    for (var i = el.firstChild; i != null; i = i.nextSibling) {
-      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
-        text += i.data;
-      else if (i.firstChild != null)
-        text += getText(i);
-    }
-    return text;
-  }
-
-  function TocEntry(el, text, toclevel) {
-    this.element = el;
-    this.text = text;
-    this.toclevel = toclevel;
-  }
-
-  function tocEntries(el, toclevels) {
-    var result = new Array;
-    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
-    // Function that scans the DOM tree for header elements (the DOM2
-    // nodeIterator API would be a better technique but not supported by all
-    // browsers).
-    var iterate = function (el) {
-      for (var i = el.firstChild; i != null; i = i.nextSibling) {
-        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
-          var mo = re.exec(i.tagName);
-          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
-            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
-          }
-          iterate(i);
-        }
-      }
-    }
-    iterate(el);
-    return result;
-  }
-
-  var toc = document.getElementById("toc");
-  if (!toc) {
-    return;
-  }
-
-  // Delete existing TOC entries in case we're reloading the TOC.
-  var tocEntriesToRemove = [];
-  var i;
-  for (i = 0; i < toc.childNodes.length; i++) {
-    var entry = toc.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div'
-     && entry.getAttribute("class")
-     && entry.getAttribute("class").match(/^toclevel/))
-      tocEntriesToRemove.push(entry);
-  }
-  for (i = 0; i < tocEntriesToRemove.length; i++) {
-    toc.removeChild(tocEntriesToRemove[i]);
-  }
-
-  // Rebuild TOC entries.
-  var entries = tocEntries(document.getElementById("content"), toclevels);
-  for (var i = 0; i < entries.length; ++i) {
-    var entry = entries[i];
-    if (entry.element.id == "")
-      entry.element.id = "_toc_" + i;
-    var a = document.createElement("a");
-    a.href = "#" + entry.element.id;
-    a.appendChild(document.createTextNode(entry.text));
-    var div = document.createElement("div");
-    div.appendChild(a);
-    div.className = "toclevel" + entry.toclevel;
-    toc.appendChild(div);
-  }
-  if (entries.length == 0)
-    toc.parentNode.removeChild(toc);
-},
-
-
-/////////////////////////////////////////////////////////////////////
-// Footnotes generator
-/////////////////////////////////////////////////////////////////////
-
-/* Based on footnote generation code from:
- * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
- */
-
-footnotes: function () {
-  // Delete existing footnote entries in case we're reloading the footnodes.
-  var i;
-  var noteholder = document.getElementById("footnotes");
-  if (!noteholder) {
-    return;
-  }
-  var entriesToRemove = [];
-  for (i = 0; i < noteholder.childNodes.length; i++) {
-    var entry = noteholder.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
-      entriesToRemove.push(entry);
-  }
-  for (i = 0; i < entriesToRemove.length; i++) {
-    noteholder.removeChild(entriesToRemove[i]);
-  }
-
-  // Rebuild footnote entries.
-  var cont = document.getElementById("content");
-  var spans = cont.getElementsByTagName("span");
-  var refs = {};
-  var n = 0;
-  for (i=0; i<spans.length; i++) {
-    if (spans[i].className == "footnote") {
-      n++;
-      var note = spans[i].getAttribute("data-note");
-      if (!note) {
-        // Use [\s\S] in place of . so multi-line matches work.
-        // Because JavaScript has no s (dotall) regex flag.
-        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
-        spans[i].innerHTML =
-          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-        spans[i].setAttribute("data-note", note);
-      }
-      noteholder.innerHTML +=
-        "<div class='footnote' id='_footnote_" + n + "'>" +
-        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
-        n + "</a>. " + note + "</div>";
-      var id =spans[i].getAttribute("id");
-      if (id != null) refs["#"+id] = n;
-    }
-  }
-  if (n == 0)
-    noteholder.parentNode.removeChild(noteholder);
-  else {
-    // Process footnoterefs.
-    for (i=0; i<spans.length; i++) {
-      if (spans[i].className == "footnoteref") {
-        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
-        href = href.match(/#.*/)[0];  // Because IE return full URL.
-        n = refs[href];
-        spans[i].innerHTML =
-          "[<a href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-      }
-    }
-  }
-},
-
-install: function(toclevels) {
-  var timerId;
-
-  function reinstall() {
-    asciidoc.footnotes();
-    if (toclevels) {
-      asciidoc.toc(toclevels);
-    }
-  }
-
-  function reinstallAndRemoveTimer() {
-    clearInterval(timerId);
-    reinstall();
-  }
-
-  timerId = setInterval(reinstall, 500);
-  if (document.addEventListener)
-    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
-  else
-    window.onload = reinstallAndRemoveTimer;
-}
-
-}
-asciidoc.install(1);
-/*]]>*/
-</script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_bfloat16_conversion</h1>
-<div id="toc">
-  <div id="toctitle">Table of Contents</div>
-  <noscript><p><b>JavaScript must be enabled in your browser to display the table of contents.</b></p></noscript>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification, Version 1.6</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
 </div>
 </div>
 <div id="content">
 <div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>SPV_INTEL_bfloat16_conversion</p></div>
+<div class="paragraph">
+<p>SPV_INTEL_bfloat16_conversion</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>To report problems with this extension, please open a new issue at:</p></div>
-<div class="paragraph"><p><a href="https://github.com/KhronosGroup/SPIRV-Registry">https://github.com/KhronosGroup/SPIRV-Registry</a></p></div>
+<div class="paragraph">
+<p>To report problems with this extension, please open a new issue at:</p>
+</div>
+<div class="paragraph">
+<p><a href="https://github.com/KhronosGroup/SPIRV-Registry" class="bare">https://github.com/KhronosGroup/SPIRV-Registry</a></p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Ben Ashbaugh, Intel<br>
-</p>
+<p>Ben Ashbaugh, Intel<br></p>
 </li>
 <li>
-<p>
-Greg Lueck, Intel<br>
-</p>
+<p>Greg Lueck, Intel<br></p>
 </li>
 <li>
-<p>
-Alexey Sotkin, Intel<br>
-</p>
+<p>Alexey Sotkin, Intel<br></p>
 </li>
 <li>
-<p>
-Arvind Sudarsanam, Intel<br>
-</p>
+<p>Arvind Sudarsanam, Intel<br></p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Copyright (c) 2023 Intel Corporation.  All rights reserved.</p></div>
+<div class="paragraph">
+<p>Copyright (c) 2023 Intel Corporation.  All rights reserved.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Shipping
-</p>
+<p>Shipping</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all"
-style="
-width:40%;
-">
-<col style="width:50%;">
-<col style="width:50%;">
+<table class="tableblock frame-all grid-all" style="width: 40%;">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2023-03-06</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-21</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
 </tr>
 </tbody>
 </table>
@@ -856,35 +127,46 @@ width:40%;
 <div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension is written against the SPIR-V Specification, Version 1.6 Revision
-2.</p></div>
-<div class="paragraph"><p>This extension requires SPIR-V 1.0.</p></div>
+<div class="paragraph">
+<p>This extension is written against the SPIR-V Specification, Version 1.6 Revision
+2.</p>
+</div>
+<div class="paragraph">
+<p>This extension requires SPIR-V 1.0.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension adds instructions to convert between single-precision 32-bit
-floating-point values and 16-bit <span class="monospaced">bfloat16</span> values.
-The <span class="monospaced">bfloat16</span> floating-point format is a truncated variant of the IEEE 754
+<div class="paragraph">
+<p>This extension adds instructions to convert between single-precision 32-bit
+floating-point values and 16-bit <code>bfloat16</code> values.
+The <code>bfloat16</code> floating-point format is a truncated variant of the IEEE 754
 single-precision 32-bit floating-point format with one sign bit, eight exponent
 bits, and seven mantissa bits.
-This gives the 16-bit <span class="monospaced">bfloat16</span> format similar dynamic range as the 32-bit
-<span class="monospaced">float</span> format, albeit with lower precision than the 16-bit <span class="monospaced">half</span> format.</p></div>
-<div class="paragraph"><p>Please note that this extension does not introduce a <span class="monospaced">bfloat16</span> type to SPIR-V
+This gives the 16-bit <code>bfloat16</code> format similar dynamic range as the 32-bit
+<code>float</code> format, albeit with lower precision than the 16-bit <code>half</code> format.</p>
+</div>
+<div class="paragraph">
+<p>Please note that this extension does not introduce a <code>bfloat16</code> type to SPIR-V
 and instead the new instructions convert to or from a 16-bit integer type whose
-bit pattern represents a <span class="monospaced">bfloat16</span> value.</p></div>
+bit pattern represents a <code>bfloat16</code> value.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_extension_name">Extension Name</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>To use this extension within a SPIR-V module, the appropriate <strong>OpExtension</strong> must
-be present in the module:</p></div>
+<div class="paragraph">
+<p>To use this extension within a SPIR-V module, the appropriate <strong>OpExtension</strong> must
+be present in the module:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpExtension "SPV_INTEL_bfloat16_conversion"</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -892,109 +174,111 @@ be present in the module:</p></div>
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_capabilities">Capabilities</h3>
-<div class="paragraph"><p>Modify Section 3.31, Capability, adding rows to the Capability table:</p></div>
+<div class="paragraph">
+<p>Modify Section 3.31, Capability, adding rows to the Capability table:</p>
+</div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:33%;">
-<col style="width:33%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-center valign-top" colspan="2" > Capability </th>
-<th class="tableblock halign-center valign-top" > Implicitly Declares</th>
+<th class="tableblock halign-center valign-top" colspan="2">Capability</th>
+<th class="tableblock halign-center valign-top">Implicitly Declares</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6115</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>BFloat16ConversionINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6115</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>BFloat16ConversionINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"></td>
 </tr>
 </tbody>
 </table>
-</div></div>
+</div>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_instructions">Instructions</h3>
-<div class="paragraph"><p>Add to Section 3.42.11, Conversion Instructions:</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:9%;">
-<col style="width:9%;">
-<col style="width:27%;">
-<col style="width:27%;">
-<col style="width:27%;">
+<div class="paragraph">
+<p>Add to Section 3.42.11, Conversion Instructions:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 9.0909%;">
+<col style="width: 9.0909%;">
+<col style="width: 27.2727%;">
+<col style="width: 27.2727%;">
+<col style="width: 27.2728%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><a id="OpConvertFToBF16"></a><strong>OpConvertFToBF16INTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><a id="OpConvertFToBF16"></a><strong>OpConvertFToBF16INTEL</strong><br>
 <br>
-Convert value numerically from 32-bit floating point to <span class="monospaced">bfloat16</span>, which is
+Convert value numerically from 32-bit floating point to <code>bfloat16</code>, which is
 represented as a 16-bit unsigned integer.<br>
 <br>
 <em>Result Type</em> must be a scalar or vector of integer type.
 The component width must be 16 bits.
-The bit pattern in the <em>Result</em> represents a <span class="monospaced">bfloat16</span> value.<br>
+The bit pattern in the <em>Result</em> represents a <code>bfloat16</code> value.<br>
 <br>
 <em>Float Value</em> must be a scalar or vector of floating-point type.
 It must have the same number of components as <em>Result Type</em>.
 The component width must be 32 bits.<br>
 <br>
 Results are computed per component.<br></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>BFloat16ConversionINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6116</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6116</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Float Value</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:9%;">
-<col style="width:9%;">
-<col style="width:27%;">
-<col style="width:27%;">
-<col style="width:27%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 9.0909%;">
+<col style="width: 9.0909%;">
+<col style="width: 27.2727%;">
+<col style="width: 27.2727%;">
+<col style="width: 27.2728%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><a id="OpConvertBF16ToF"></a><strong>OpConvertBF16ToFINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><a id="OpConvertBF16ToF"></a><strong>OpConvertBF16ToFINTEL</strong><br>
 <br>
-Interpret a 16-bit integer value as <span class="monospaced">bfloat16</span> and convert the value numerically
+Interpret a 16-bit integer value as <code>bfloat16</code> and convert the value numerically
 to 32-bit floating point.<br>
 <br>
 <em>Result Type</em> must be a scalar or vector of floating-point type.
 The component width must be 32 bits.<br>
 <br>
 <em>BFloat16 Value</em> must be a scalar or vector of integer type, which is
-interpreted as a <span class="monospaced">bfloat16</span>.
+interpreted as a <code>bfloat16</code>.
 The type must have the same number of components as <em>Result Type</em>.
 The component width must be 16 bits.<br>
 <br>
 Results are computed per component.<br></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>BFloat16ConversionINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6117</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6117</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>BFloat16 Value</em></p></td>
 </tr>
 </tbody>
@@ -1005,45 +289,39 @@ Results are computed per component.<br></p></td>
 <div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:100%;
-">
-<col style="width:4%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:66%;">
+<table class="tableblock frame-all grid-rows stretch">
+<colgroup>
+<col style="width: 4.7619%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" >Rev</th>
-<th class="tableblock halign-left valign-top" >Date</th>
-<th class="tableblock halign-left valign-top" >Author</th>
-<th class="tableblock halign-left valign-top" >Changes</th>
+<th class="tableblock halign-left valign-top">Rev</th>
+<th class="tableblock halign-left valign-top">Date</th>
+<th class="tableblock halign-left valign-top">Author</th>
+<th class="tableblock halign-left valign-top">Changes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2023-03-06</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Initial revision for publication</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-03-06</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Initial revision for publication</p></td>
 </tr>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footnotes"><hr></div>
-<div id="footer">
-<div id="footer-text">
-Last updated
- 2023-03-06 16:00:00 PST
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_blocking_pipes.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_blocking_pipes.asciidoc
@@ -98,7 +98,7 @@ In section 3.32.23, Pipe Instructions, add two new instructions: *OpReadPipeBloc
 
 [cols="6", width="100%"]
 |=====
-5+^|*OpReadPipeBlockingINTEL* +
+5+|*OpReadPipeBlockingINTEL* +
 
 Read a packet from the pipe object specified by _Pipe_ into _Pointer_.  This instruction will not return until the read has completed successfully and thus if the pipe is empty it will block until there is data in the pipe. +
 
@@ -127,7 +127,7 @@ _Packet Alignment_
 
 [cols="6", width="100%"]
 |=====
-5+^|*OpWritePipeBlockingINTEL* +
+5+|*OpWritePipeBlockingINTEL* +
 
 Write a packet from _Pointer_ to the pipe object specified by _Pipe_. This instruction will not return until the write has completed successfully and thus if the pipe is full it will block until there is available capacity in the pipe. +
 

--- a/extensions/INTEL/SPV_INTEL_blocking_pipes.html
+++ b/extensions/INTEL/SPV_INTEL_blocking_pipes.html
@@ -2,437 +2,48 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 1.5.7">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_blocking_pipes</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
-/* Uncomment @import statement below to use as custom stylesheet */
-/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
-article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
-audio,canvas,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-script{display:none!important}
-html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
-a{background:transparent}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-abbr[title]{border-bottom:1px dotted}
-b,strong{font-weight:bold}
-dfn{font-style:italic}
-hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:none}
-p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #ddddd8;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
-abbr{text-transform:none}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
-blockquote cite::before{content:"\2014 \0020"}
-blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
-*:not(pre)>code.nobreak{word-wrap:normal}
-*:not(pre)>code.nowrap{white-space:nowrap}
-pre,pre>code{line-height:1.45;color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;text-rendering:optimizeSpeed}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #ddddd8}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #ddddd8;padding-bottom:8px}
-#header .details{border-bottom:1px solid #ddddd8;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #ddddd8;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #efefed;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background-color:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #efefed;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #efefed;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:100%;background-color:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #efefed}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inherit}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color:rgba(0,0,0,.6)}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock pre:not(.highlight),.listingblock pre[class="highlight"],.listingblock pre[class^="highlight "],.listingblock pre.CodeRay,.listingblock pre.prettyprint{background:#f7f7f8}
-.sidebarblock .literalblock pre,.sidebarblock .listingblock pre:not(.highlight),.sidebarblock .listingblock pre[class="highlight"],.sidebarblock .listingblock pre[class^="highlight "],.sidebarblock .listingblock pre.CodeRay,.sidebarblock .listingblock pre.prettyprint{background:#f2f1f1}
-.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;padding:1em;font-size:.8125em}
-.literalblock pre.nowrap,.literalblock pre[class].nowrap,.listingblock pre.nowrap,.listingblock pre[class].nowrap{overflow-x:auto;white-space:pre;word-wrap:normal}
-@media screen and (min-width:768px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:1em}}
-.literalblock.output pre{color:#f7f7f8;background-color:rgba(0,0,0,.9)}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:#999}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:#999}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-table.pyhltable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.pyhltable td{vertical-align:top;padding-top:0;padding-bottom:0;line-height:1.45}
-table.pyhltable td.code{padding-left:.75em;padding-right:0}
-pre.pygments .lineno,table.pyhltable td:not(.code){color:#999;padding-left:0;padding-right:.5em;border-right:1px solid #ddddd8}
-pre.pygments .lineno{display:inline-block;margin-right:.25em}
-table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock blockquote p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.5em;margin-right:.5ex;text-align:right}
-.quoteblock .quoteblock{margin-left:0;margin-right:0;padding:.5em 0;border-left:3px solid rgba(0,0,0,.6)}
-.quoteblock .quoteblock blockquote{padding:0 0 0 .75em}
-.quoteblock .quoteblock blockquote::before{display:none}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.abstract blockquote,.quoteblock.abstract blockquote p{word-spacing:0;line-height:1.6}
-.quoteblock.abstract blockquote::before,.quoteblock.abstract p::before{display:none}
-table.tableblock{max-width:100%;border-collapse:separate}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content{margin-bottom:-1.25em}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
-table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
-table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
-table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
-table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
-table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
-table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
-table.frame-all{border-width:1px}
-table.frame-sides{border-width:0 1px}
-table.frame-topbot,table.frame-ends{border-width:1px 0}
-table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd){background:#f8f8f7}
-table.stripes-none tr,table.stripes-odd tr:nth-of-type(even){background:none}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-td>div.verse{white-space:pre}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-ul.checklist{margin-left:.625em}
-ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
-ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
-.imageblock.left,.imageblock[style*="float: left"]{margin:.25em .625em 1.25em 0}
-.imageblock.right,.imageblock[style*="float: right"]{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
-.gist .file-data>table td.line-data{width:99%}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background-color:#00fafa}
-.black{color:#000}
-.black-background{background-color:#000}
-.blue{color:#0000bf}
-.blue-background{background-color:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background-color:#fa00fa}
-.gray{color:#606060}
-.gray-background{background-color:#7d7d7d}
-.green{color:#006000}
-.green-background{background-color:#007d00}
-.lime{color:#00bf00}
-.lime-background{background-color:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background-color:#7d0000}
-.navy{color:#000060}
-.navy-background{background-color:#00007d}
-.olive{color:#606000}
-.olive-background{background-color:#7d7d00}
-.purple{color:#600060}
-.purple-background{background-color:#7d007d}
-.red{color:#bf0000}
-.red-background{background-color:#fa0000}
-.silver{color:#909090}
-.silver-background{background-color:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background-color:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background-color:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background-color:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background-color:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background-color:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #ddddd8!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_blocking_pipes</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_new_instructions">New Instructions</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_4">Modifications to the SPIR-V Specification, Version 1.4</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
 <div class="sect1">
@@ -496,7 +107,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2019-07-17</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-21</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -644,7 +255,7 @@ OpWritePipeBlockingINTEL</pre>
 </colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-center valign-top" colspan="5"><p class="tableblock"><strong>OpReadPipeBlockingINTEL</strong><br></p>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><strong>OpReadPipeBlockingINTEL</strong><br></p>
 <p class="tableblock">Read a packet from the pipe object specified by <em>Pipe</em> into <em>Pointer</em>.  This instruction will not return until the read has completed successfully and thus if the pipe is empty it will block until there is data in the pipe.<br></p>
 <p class="tableblock"><em>Pipe</em> must have a type of OpTypePipe with <strong>ReadOnly</strong> access qualifier.<br></p>
 <p class="tableblock"><em>Pointer</em> must have a type of OpTypePointer with the same data type as <em>Pipe</em> and a <strong>Generic</strong> Storage Class.<br></p>
@@ -682,7 +293,7 @@ OpWritePipeBlockingINTEL</pre>
 </colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-center valign-top" colspan="5"><p class="tableblock"><strong>OpWritePipeBlockingINTEL</strong><br></p>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><strong>OpWritePipeBlockingINTEL</strong><br></p>
 <p class="tableblock">Write a packet from <em>Pointer</em> to the pipe object specified by <em>Pipe</em>. This instruction will not return until the write has completed successfully and thus if the pipe is full it will block until there is available capacity in the pipe.<br></p>
 <p class="tableblock"><em>Pipe</em> must have a type of OpTypePipe with <strong>WriteOnly</strong> access qualifier.<br></p>
 <p class="tableblock"><em>Pointer</em> must have a type of OpTypePointer with the same data type as <em>Pipe</em> and a <strong>Generic</strong> Storage Class.<br></p>
@@ -748,11 +359,6 @@ OpWritePipeBlockingINTEL</pre>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2019-07-17 14:39:33 EDT
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_cache_controls.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_cache_controls.asciidoc
@@ -204,9 +204,9 @@ If some cache level does not exist, the decoration is ignored. +
 If the exact _Load Cache Control_ value is unsupported, the consumer may apply
 implementation-specific closest match, but only if it does not change the
 observable effect of the requested _Load Cache Control_.
-| <<Literal, 'Literal'>> +
+| <<Literal, _Literal_>> +
 _Cache Level_
-| <<Load_Cache_Control, 'Load_Cache_Control'>> +
+| <<Load_Cache_Control, _Load_Cache_Control_>> +
 _Cache Control_
 | *{capability_name}*
 | {store_control_decoration_token} | *{store_control_decoration}* +
@@ -226,9 +226,9 @@ some cache level does not exist, the decoration is ignored. +
 If the exact _Store Cache Control_ value is unsupported, the consumer may apply
 implementation-specific closest match, but only if it does not change the
 observable effect of the requested _Store Cache Control_.
-| <<Literal, 'Literal'>> +
+| <<Literal, _Literal_>> +
 _Cache Level_
-| <<Store_Cache_Control, 'Store_Cache_Control'>> +
+| <<Store_Cache_Control, _Store_Cache_Control_>> +
 _Cache Control_
 | *{capability_name}*
 |====

--- a/extensions/INTEL/SPV_INTEL_cache_controls.html
+++ b/extensions/INTEL/SPV_INTEL_cache_controls.html
@@ -1,852 +1,126 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta name="generator" content="AsciiDoc 10.1.2">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_cache_controls</title>
-<style type="text/css">
-/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
-
-/* Default font. */
-body {
-  font-family: Georgia,serif;
-}
-
-/* Title font. */
-h1, h2, h3, h4, h5, h6,
-div.title, caption.title,
-thead, p.table.header,
-#toctitle,
-#author, #revnumber, #revdate, #revremark,
-#footer {
-  font-family: Arial,Helvetica,sans-serif;
-}
-
-body {
-  margin: 1em 5% 1em 5%;
-}
-
-a {
-  color: blue;
-  text-decoration: underline;
-}
-a:visited {
-  color: fuchsia;
-}
-
-em {
-  font-style: italic;
-  color: navy;
-}
-
-strong {
-  font-weight: bold;
-  color: #083194;
-}
-
-h1, h2, h3, h4, h5, h6 {
-  color: #527bbd;
-  margin-top: 1.2em;
-  margin-bottom: 0.5em;
-  line-height: 1.3;
-}
-
-h1, h2, h3 {
-  border-bottom: 2px solid silver;
-}
-h2 {
-  padding-top: 0.5em;
-}
-h3 {
-  float: left;
-}
-h3 + * {
-  clear: left;
-}
-h5 {
-  font-size: 1.0em;
-}
-
-div.sectionbody {
-  margin-left: 0;
-}
-
-hr {
-  border: 1px solid silver;
-}
+<style>
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
 
 p {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
 }
 
-ul, ol, li > p {
-  margin-top: 0;
-}
-ul > li     { color: #aaa; }
-ul > li > * { color: black; }
-
-.monospaced, code, pre {
-  font-family: "Courier New", Courier, monospace;
-  font-size: inherit;
-  color: navy;
-  padding: 0;
-  margin: 0;
-}
-pre {
-  white-space: pre-wrap;
-}
-
-#author {
-  color: #527bbd;
-  font-weight: bold;
-  font-size: 1.1em;
-}
-#email {
-}
-#revnumber, #revdate, #revremark {
-}
-
-#footer {
-  font-size: small;
-  border-top: 2px solid silver;
-  padding-top: 0.5em;
-  margin-top: 4.0em;
-}
-#footer-text {
-  float: left;
-  padding-bottom: 0.5em;
-}
-#footer-badges {
-  float: right;
-  padding-bottom: 0.5em;
-}
-
-#preamble {
-  margin-top: 1.5em;
-  margin-bottom: 1.5em;
-}
-div.imageblock, div.exampleblock, div.verseblock,
-div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
-div.admonitionblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.admonitionblock {
-  margin-top: 2.0em;
-  margin-bottom: 2.0em;
-  margin-right: 10%;
-  color: #606060;
-}
-
-div.content { /* Block element content. */
-  padding: 0;
-}
-
-/* Block element titles. */
-div.title, caption.title {
-  color: #527bbd;
-  font-weight: bold;
-  text-align: left;
-  margin-top: 1.0em;
-  margin-bottom: 0.5em;
-}
-div.title + * {
-  margin-top: 0;
-}
-
-td div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content + div.title {
-  margin-top: 0.0em;
-}
-
-div.sidebarblock > div.content {
-  background: #ffffee;
-  border: 1px solid #dddddd;
-  border-left: 4px solid #f0f0f0;
-  padding: 0.5em;
-}
-
-div.listingblock > div.content {
-  border: 1px solid #dddddd;
-  border-left: 5px solid #f0f0f0;
-  background: #f8f8f8;
-  padding: 0.5em;
-}
-
-div.quoteblock, div.verseblock {
-  padding-left: 1.0em;
-  margin-left: 1.0em;
-  margin-right: 10%;
-  border-left: 5px solid #f0f0f0;
-  color: #888;
-}
-
-div.quoteblock > div.attribution {
-  padding-top: 0.5em;
-  text-align: right;
-}
-
-div.verseblock > pre.content {
-  font-family: inherit;
-  font-size: inherit;
-}
-div.verseblock > div.attribution {
-  padding-top: 0.75em;
-  text-align: left;
-}
-/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
-div.verseblock + div.attribution {
-  text-align: left;
-}
-
-div.admonitionblock .icon {
-  vertical-align: top;
-  font-size: 1.1em;
-  font-weight: bold;
-  text-decoration: underline;
-  color: #527bbd;
-  padding-right: 0.5em;
-}
-div.admonitionblock td.content {
-  padding-left: 0.5em;
-  border-left: 3px solid #dddddd;
-}
-
-div.exampleblock > div.content {
-  border-left: 3px solid #dddddd;
-  padding-left: 0.5em;
-}
-
-div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; vertical-align: text-bottom; }
-a.image:visited { color: white; }
-
-dl {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-dt {
-  margin-top: 0.5em;
-  margin-bottom: 0;
-  font-style: normal;
-  color: navy;
-}
-dd > *:first-child {
-  margin-top: 0.1em;
-}
-
-ul, ol {
-    list-style-position: outside;
-}
-ol.arabic {
-  list-style-type: decimal;
-}
-ol.loweralpha {
-  list-style-type: lower-alpha;
-}
-ol.upperalpha {
-  list-style-type: upper-alpha;
-}
-ol.lowerroman {
-  list-style-type: lower-roman;
-}
-ol.upperroman {
-  list-style-type: upper-roman;
-}
-
-div.compact ul, div.compact ol,
-div.compact p, div.compact p,
-div.compact div, div.compact div {
-  margin-top: 0.1em;
-  margin-bottom: 0.1em;
-}
-
-tfoot {
-  font-weight: bold;
-}
-td > div.verse {
-  white-space: pre;
-}
-
-div.hdlist {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-div.hdlist tr {
-  padding-bottom: 15px;
-}
-dt.hdlist1.strong, td.hdlist1.strong {
-  font-weight: bold;
-}
-td.hdlist1 {
-  vertical-align: top;
-  font-style: normal;
-  padding-right: 0.8em;
-  color: navy;
-}
-td.hdlist2 {
-  vertical-align: top;
-}
-div.hdlist.compact tr {
-  margin: 0;
-  padding-bottom: 0;
-}
-
-.comment {
-  background: yellow;
-}
-
-.footnote, .footnoteref {
-  font-size: 0.8em;
-}
-
-span.footnote, span.footnoteref {
-  vertical-align: super;
-}
-
-#footnotes {
-  margin: 20px 0 20px 0;
-  padding: 7px 0 0 0;
-}
-
-#footnotes div.footnote {
-  margin: 0 0 5px 0;
-}
-
-#footnotes hr {
-  border: none;
-  border-top: 1px solid silver;
-  height: 1px;
-  text-align: left;
-  margin-left: 0;
-  width: 20%;
-  min-width: 100px;
-}
-
-div.colist td {
-  padding-right: 0.5em;
-  padding-bottom: 0.3em;
-  vertical-align: top;
-}
-div.colist td img {
-  margin-top: 0.3em;
-}
-
-@media print {
-  #footer-badges { display: none; }
-}
-
-#toc {
-  margin-bottom: 2.5em;
-}
-
-#toctitle {
-  color: #527bbd;
-  font-size: 1.1em;
-  font-weight: bold;
-  margin-top: 1.0em;
-  margin-bottom: 0.1em;
-}
-
-div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-div.toclevel2 {
-  margin-left: 2em;
-  font-size: 0.9em;
-}
-div.toclevel3 {
-  margin-left: 4em;
-  font-size: 0.9em;
-}
-div.toclevel4 {
-  margin-left: 6em;
-  font-size: 0.9em;
-}
-
-span.aqua { color: aqua; }
-span.black { color: black; }
-span.blue { color: blue; }
-span.fuchsia { color: fuchsia; }
-span.gray { color: gray; }
-span.green { color: green; }
-span.lime { color: lime; }
-span.maroon { color: maroon; }
-span.navy { color: navy; }
-span.olive { color: olive; }
-span.purple { color: purple; }
-span.red { color: red; }
-span.silver { color: silver; }
-span.teal { color: teal; }
-span.white { color: white; }
-span.yellow { color: yellow; }
-
-span.aqua-background { background: aqua; }
-span.black-background { background: black; }
-span.blue-background { background: blue; }
-span.fuchsia-background { background: fuchsia; }
-span.gray-background { background: gray; }
-span.green-background { background: green; }
-span.lime-background { background: lime; }
-span.maroon-background { background: maroon; }
-span.navy-background { background: navy; }
-span.olive-background { background: olive; }
-span.purple-background { background: purple; }
-span.red-background { background: red; }
-span.silver-background { background: silver; }
-span.teal-background { background: teal; }
-span.white-background { background: white; }
-span.yellow-background { background: yellow; }
-
-span.big { font-size: 2em; }
-span.small { font-size: 0.6em; }
-
-span.underline { text-decoration: underline; }
-span.overline { text-decoration: overline; }
-span.line-through { text-decoration: line-through; }
-
-div.unbreakable { page-break-inside: avoid; }
-
-
-/*
- * xhtml11 specific
- *
- * */
-
-div.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.tableblock > table {
-  border: 3px solid #527bbd;
-}
-thead, p.table.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.table {
-  margin-top: 0;
-}
-/* Because the table frame attribute is overridden by CSS in most browsers. */
-div.tableblock > table[frame="void"] {
-  border-style: none;
-}
-div.tableblock > table[frame="hsides"] {
-  border-left-style: none;
-  border-right-style: none;
-}
-div.tableblock > table[frame="vsides"] {
-  border-top-style: none;
-  border-bottom-style: none;
-}
-
-
-/*
- * html5 specific
- *
- * */
-
-table.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-thead, p.tableblock.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.tableblock {
-  margin-top: 0;
-}
-table.tableblock {
-  border-width: 3px;
-  border-spacing: 0px;
-  border-style: solid;
-  border-color: #527bbd;
-  border-collapse: collapse;
-}
-th.tableblock, td.tableblock {
-  border-width: 1px;
-  padding: 4px;
-  border-style: solid;
-  border-color: #527bbd;
-}
-
-table.tableblock.frame-topbot {
-  border-left-style: hidden;
-  border-right-style: hidden;
-}
-table.tableblock.frame-sides {
-  border-top-style: hidden;
-  border-bottom-style: hidden;
-}
-table.tableblock.frame-none {
-  border-style: hidden;
-}
-
-th.tableblock.halign-left, td.tableblock.halign-left {
-  text-align: left;
-}
-th.tableblock.halign-center, td.tableblock.halign-center {
-  text-align: center;
-}
-th.tableblock.halign-right, td.tableblock.halign-right {
-  text-align: right;
-}
-
-th.tableblock.valign-top, td.tableblock.valign-top {
-  vertical-align: top;
-}
-th.tableblock.valign-middle, td.tableblock.valign-middle {
-  vertical-align: middle;
-}
-th.tableblock.valign-bottom, td.tableblock.valign-bottom {
-  vertical-align: bottom;
-}
-
-
-/*
- * manpage specific
- *
- * */
-
-body.manpage h1 {
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
-  border-top: 2px solid silver;
-  border-bottom: 2px solid silver;
-}
-body.manpage h2 {
-  border-style: none;
-}
-body.manpage div.sectionbody {
-  margin-left: 3em;
-}
-
-@media print {
-  body.manpage div#toc { display: none; }
-}
-
-
-@media screen {
-  body {
-    max-width: 50em; /* approximately 80 characters wide */
-    margin-left: 16em;
-  }
-
-  #toc {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 13em;
-    padding: 0.5em;
-    padding-bottom: 1.5em;
-    margin: 0;
-    overflow: auto;
-    border-right: 3px solid #f8f8f8;
-    background-color: white;
-  }
-
-  #toc .toclevel1 {
-    margin-top: 0.5em;
-  }
-
-  #toc .toclevel2 {
-    margin-top: 0.25em;
-    display: list-item;
-    color: #aaaaaa;
-  }
-
-  #toctitle {
-    margin-top: 0.5em;
-  }
-}
 </style>
-<script type="text/javascript">
-/*<![CDATA[*/
-var asciidoc = {  // Namespace.
-
-/////////////////////////////////////////////////////////////////////
-// Table Of Contents generator
-/////////////////////////////////////////////////////////////////////
-
-/* Author: Mihai Bazon, September 2002
- * http://students.infoiasi.ro/~mishoo
- *
- * Table Of Content generator
- * Version: 0.4
- *
- * Feel free to use this script under the terms of the GNU General Public
- * License, as long as you do not remove or alter this notice.
- */
-
- /* modified by Troy D. Hanson, September 2006. License: GPL */
- /* modified by Stuart Rackham, 2006, 2009. License: GPL */
-
-// toclevels = 1..4.
-toc: function (toclevels) {
-
-  function getText(el) {
-    var text = "";
-    for (var i = el.firstChild; i != null; i = i.nextSibling) {
-      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
-        text += i.data;
-      else if (i.firstChild != null)
-        text += getText(i);
-    }
-    return text;
-  }
-
-  function TocEntry(el, text, toclevel) {
-    this.element = el;
-    this.text = text;
-    this.toclevel = toclevel;
-  }
-
-  function tocEntries(el, toclevels) {
-    var result = new Array;
-    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
-    // Function that scans the DOM tree for header elements (the DOM2
-    // nodeIterator API would be a better technique but not supported by all
-    // browsers).
-    var iterate = function (el) {
-      for (var i = el.firstChild; i != null; i = i.nextSibling) {
-        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
-          var mo = re.exec(i.tagName);
-          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
-            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
-          }
-          iterate(i);
-        }
-      }
-    }
-    iterate(el);
-    return result;
-  }
-
-  var toc = document.getElementById("toc");
-  if (!toc) {
-    return;
-  }
-
-  // Delete existing TOC entries in case we're reloading the TOC.
-  var tocEntriesToRemove = [];
-  var i;
-  for (i = 0; i < toc.childNodes.length; i++) {
-    var entry = toc.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div'
-     && entry.getAttribute("class")
-     && entry.getAttribute("class").match(/^toclevel/))
-      tocEntriesToRemove.push(entry);
-  }
-  for (i = 0; i < tocEntriesToRemove.length; i++) {
-    toc.removeChild(tocEntriesToRemove[i]);
-  }
-
-  // Rebuild TOC entries.
-  var entries = tocEntries(document.getElementById("content"), toclevels);
-  for (var i = 0; i < entries.length; ++i) {
-    var entry = entries[i];
-    if (entry.element.id == "")
-      entry.element.id = "_toc_" + i;
-    var a = document.createElement("a");
-    a.href = "#" + entry.element.id;
-    a.appendChild(document.createTextNode(entry.text));
-    var div = document.createElement("div");
-    div.appendChild(a);
-    div.className = "toclevel" + entry.toclevel;
-    toc.appendChild(div);
-  }
-  if (entries.length == 0)
-    toc.parentNode.removeChild(toc);
-},
-
-
-/////////////////////////////////////////////////////////////////////
-// Footnotes generator
-/////////////////////////////////////////////////////////////////////
-
-/* Based on footnote generation code from:
- * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
- */
-
-footnotes: function () {
-  // Delete existing footnote entries in case we're reloading the footnodes.
-  var i;
-  var noteholder = document.getElementById("footnotes");
-  if (!noteholder) {
-    return;
-  }
-  var entriesToRemove = [];
-  for (i = 0; i < noteholder.childNodes.length; i++) {
-    var entry = noteholder.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
-      entriesToRemove.push(entry);
-  }
-  for (i = 0; i < entriesToRemove.length; i++) {
-    noteholder.removeChild(entriesToRemove[i]);
-  }
-
-  // Rebuild footnote entries.
-  var cont = document.getElementById("content");
-  var spans = cont.getElementsByTagName("span");
-  var refs = {};
-  var n = 0;
-  for (i=0; i<spans.length; i++) {
-    if (spans[i].className == "footnote") {
-      n++;
-      var note = spans[i].getAttribute("data-note");
-      if (!note) {
-        // Use [\s\S] in place of . so multi-line matches work.
-        // Because JavaScript has no s (dotall) regex flag.
-        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
-        spans[i].innerHTML =
-          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-        spans[i].setAttribute("data-note", note);
-      }
-      noteholder.innerHTML +=
-        "<div class='footnote' id='_footnote_" + n + "'>" +
-        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
-        n + "</a>. " + note + "</div>";
-      var id =spans[i].getAttribute("id");
-      if (id != null) refs["#"+id] = n;
-    }
-  }
-  if (n == 0)
-    noteholder.parentNode.removeChild(noteholder);
-  else {
-    // Process footnoterefs.
-    for (i=0; i<spans.length; i++) {
-      if (spans[i].className == "footnoteref") {
-        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
-        href = href.match(/#.*/)[0];  // Because IE return full URL.
-        n = refs[href];
-        spans[i].innerHTML =
-          "[<a href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-      }
-    }
-  }
-},
-
-install: function(toclevels) {
-  var timerId;
-
-  function reinstall() {
-    asciidoc.footnotes();
-    if (toclevels) {
-      asciidoc.toc(toclevels);
-    }
-  }
-
-  function reinstallAndRemoveTimer() {
-    clearInterval(timerId);
-    reinstall();
-  }
-
-  timerId = setInterval(reinstall, 500);
-  if (document.addEventListener)
-    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
-  else
-    window.onload = reinstallAndRemoveTimer;
-}
-
-}
-asciidoc.install(1);
-/*]]>*/
-</script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_cache_controls</h1>
-<div id="toc">
-  <div id="toctitle">Table of Contents</div>
-  <noscript><p><b>JavaScript must be enabled in your browser to display the table of contents.</b></p></noscript>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_new_decorations">New Decorations</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_6_revision_2">Modifications to the SPIR-V Specification, Version 1.6, Revision 2</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
 </div>
 </div>
 <div id="content">
 <div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>SPV_INTEL_cache_controls</p></div>
+<div class="paragraph">
+<p>SPV_INTEL_cache_controls</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>To report problems with this extension, please open a new issue at:</p></div>
-<div class="paragraph"><p><a href="https://github.com/KhronosGroup/SPIRV-Registry">https://github.com/KhronosGroup/SPIRV-Registry</a></p></div>
+<div class="paragraph">
+<p>To report problems with this extension, please open a new issue at:</p>
+</div>
+<div class="paragraph">
+<p><a href="https://github.com/KhronosGroup/SPIRV-Registry" class="bare">https://github.com/KhronosGroup/SPIRV-Registry</a></p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Andrzej Ratajewski, Intel<br>
-</p>
+<p>Andrzej Ratajewski, Intel<br></p>
 </li>
 <li>
-<p>
-Ben Ashbaugh, Intel<br>
-</p>
+<p>Ben Ashbaugh, Intel<br></p>
 </li>
 <li>
-<p>
-Dmitry Sidorov, Intel<br>
-</p>
+<p>Dmitry Sidorov, Intel<br></p>
 </li>
 <li>
-<p>
-Gregory Lueck, Intel<br>
-</p>
+<p>Gregory Lueck, Intel<br></p>
 </li>
 <li>
-<p>
-Victor Mustya, Intel<br>
-</p>
+<p>Victor Mustya, Intel<br></p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Copyright (c) 2023 Intel Corporation.  All rights reserved.</p></div>
+<div class="paragraph">
+<p>Copyright (c) 2023 Intel Corporation.  All rights reserved.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Complete.</p></div>
+<div class="paragraph">
+<p>Complete.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all"
-style="
-width:40%;
-">
-<col style="width:50%;">
-<col style="width:50%;">
+<table class="tableblock frame-all grid-all" style="width: 40%;">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2023-08-28</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-08-28</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
 </tr>
 </tbody>
 </table>
@@ -855,75 +129,89 @@ width:40%;
 <div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension is written against the SPIR-V Specification, Version 1.6,
-Revision 2.</p></div>
-<div class="paragraph"><p>This extension requires SPIR-V 1.0</p></div>
+<div class="paragraph">
+<p>This extension is written against the SPIR-V Specification, Version 1.6,
+Revision 2.</p>
+</div>
+<div class="paragraph">
+<p>This extension requires SPIR-V 1.0</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension allows cache control information to be applied to memory access
-instructions.</p></div>
-<div class="paragraph"><p>The cache controls are a strong request that the SPIR-V consumer should use a
+<div class="paragraph">
+<p>This extension allows cache control information to be applied to memory access
+instructions.</p>
+</div>
+<div class="paragraph">
+<p>The cache controls are a strong request that the SPIR-V consumer should use a
 memory operation with the indicated cache controls. However, the SPIR-V consumer
 may choose a different cache control if the requested one is unsupported or for
 any other reason. The cache controls may affect the performance of a program,
-but (with very few exceptions) must not affect the functional correctness.</p></div>
+but (with very few exceptions) must not affect the functional correctness.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_extension_name">Extension Name</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>To use this extension within a SPIR-V module, the appropriate <strong>OpExtension</strong> must
-be present in the module:</p></div>
+<div class="paragraph">
+<p>To use this extension within a SPIR-V module, the appropriate <strong>OpExtension</strong> must
+be present in the module:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpExtension "SPV_INTEL_cache_controls"</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_capabilities">New Capabilities</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension introduces new capabilities:</p></div>
+<div class="paragraph">
+<p>This extension introduces new capabilities:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>CacheControlsINTEL</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_decorations">New Decorations</h2>
 <div class="sectionbody">
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>CacheControlLoadINTEL
 CacheControlStoreINTEL</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:40%;
-">
-<col style="width:70%;">
-<col style="width:30%;">
+<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<colgroup>
+<col style="width: 70%;">
+<col style="width: 30%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6441</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6441</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CacheControlLoadINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6442</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>CacheControlLoadINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6442</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CacheControlStoreINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6443</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>CacheControlStoreINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6443</p></td>
 </tr>
 </tbody>
 </table>
@@ -934,214 +222,208 @@ width:40%;
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_validation_rules">Validation Rules</h3>
-<div class="paragraph"><p>Modify Section 2.16.1, Universal Validation Rules, adding the following statements.</p></div>
-<div class="ulist"><ul>
+<div class="paragraph">
+<p>Modify Section 2.16.1, Universal Validation Rules, adding the following statements.</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Decoration rules
-</p>
-<div class="ulist"><ul>
+<p>Decoration rules</p>
+<div class="ulist">
+<ul>
 <li>
-<p>
-A <strong>CacheControlLoadINTEL</strong> Decoration must be applied only as follows:
-</p>
-<div class="ulist"><ul>
+<p>A <strong>CacheControlLoadINTEL</strong> Decoration must be applied only as follows:</p>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Only <strong>OpTypePointer</strong> values can be decorated.
-</p>
+<p>Only <strong>OpTypePointer</strong> values can be decorated.</p>
 </li>
 <li>
-<p>
-Pointer types of the decorated instructions must have <strong>Function</strong>,
-<strong>UniformConstant</strong>, <strong>CrossWorkgroup</strong> or <strong>Generic</strong> storage class.
-</p>
+<p>Pointer types of the decorated instructions must have <strong>Function</strong>,
+<strong>UniformConstant</strong>, <strong>CrossWorkgroup</strong> or <strong>Generic</strong> storage class.</p>
 </li>
 <li>
-<p>
-It&#8217;s allowed to apply <strong>CacheControlLoadINTEL</strong> multiple times to the same
-<em>Pointer</em>.
-</p>
+<p>It&#8217;s allowed to apply <strong>CacheControlLoadINTEL</strong> multiple times to the same
+<em>Pointer</em>.</p>
 </li>
 <li>
-<p>
-Two <strong>CacheControlLoadINTEL</strong> decorations decorating the same <em>Pointer</em>
-must have different <em>Cache Level</em> values.
-</p>
+<p>Two <strong>CacheControlLoadINTEL</strong> decorations decorating the same <em>Pointer</em>
+must have different <em>Cache Level</em> values.</p>
 </li>
-</ul></div>
-</li>
-<li>
-<p>
-A <strong>CacheControlStoreINTEL</strong> Decoration must be applied only as follows:
-</p>
-<div class="ulist"><ul>
-<li>
-<p>
-Only <strong>OpTypePointer</strong> values can be decorated.
-</p>
+</ul>
+</div>
 </li>
 <li>
-<p>
-Pointer types of the decorated instructions must have <strong>Function</strong>,
-<strong>CrossWorkgroup</strong> or <strong>Generic</strong> storage class.
-</p>
+<p>A <strong>CacheControlStoreINTEL</strong> Decoration must be applied only as follows:</p>
+<div class="ulist">
+<ul>
+<li>
+<p>Only <strong>OpTypePointer</strong> values can be decorated.</p>
 </li>
 <li>
-<p>
-It&#8217;s allowed to apply <strong>CacheControlStoreINTEL</strong> multiple times to the same
-<em>Pointer</em>.
-</p>
+<p>Pointer types of the decorated instructions must have <strong>Function</strong>,
+<strong>CrossWorkgroup</strong> or <strong>Generic</strong> storage class.</p>
 </li>
 <li>
-<p>
-Two <strong>CacheControlStoreINTEL</strong> decorations decorating the same <em>Pointer</em>
-must have different <em>Cache Level</em> values.
-</p>
+<p>It&#8217;s allowed to apply <strong>CacheControlStoreINTEL</strong> multiple times to the same
+<em>Pointer</em>.</p>
 </li>
-</ul></div>
+<li>
+<p>Two <strong>CacheControlStoreINTEL</strong> decorations decorating the same <em>Pointer</em>
+must have different <em>Cache Level</em> values.</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </li>
-</ul></div>
-<div class="paragraph"><p>Modify Section 3, Binary form, add new sub-sections after 3.18 Access Qualifier.</p></div>
+</ul>
+</div>
+</li>
+</ul>
+</div>
+<div class="paragraph">
+<p>Modify Section 3, Binary form, add new sub-sections after 3.18 Access Qualifier.</p>
+</div>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p><a id="Load_Cache_Control"></a><strong>3.XX Load Cache Controls</strong></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:80%;
-">
-<col style="width:1%;">
-<col style="width:24%;">
-<col style="width:24%;">
-<col style="width:49%;">
+<div class="paragraph">
+<p><a id="Load_Cache_Control"></a><strong>3.XX Load Cache Controls</strong></p>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 80%;">
+<colgroup>
+<col style="width: 1.6393%;">
+<col style="width: 24.5901%;">
+<col style="width: 24.5901%;">
+<col style="width: 49.1805%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-center valign-middle" colspan="2" > Cache Control </th>
-<th class="tableblock halign-center valign-top" > Enabling Capabilities </th>
-<th class="tableblock halign-center valign-top" > Description</th>
+<th class="tableblock halign-center valign-middle" colspan="2">Cache Control</th>
+<th class="tableblock halign-center valign-top">Enabling Capabilities</th>
+<th class="tableblock halign-center valign-top">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-center valign-middle" ><p class="tableblock">0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>UncachedINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Hint that the load operation should not cache its data in the given cache
+<td class="tableblock halign-center valign-middle"><p class="tableblock">0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>UncachedINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Hint that the load operation should not cache its data in the given cache
 level.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-center valign-middle" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CachedINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Hint that the load operation should cache its data in the given cache level.</p></td>
+<td class="tableblock halign-center valign-middle"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>CachedINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Hint that the load operation should cache its data in the given cache level.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-center valign-middle" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>StreamingINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Hint that the load operation should cache its data in the specified cache
+<td class="tableblock halign-center valign-middle"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>StreamingINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Hint that the load operation should cache its data in the specified cache
 level, using evict-first policy to minimize cache pollution caused by temporary
 streaming data that may only be accessed once or twice.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-center valign-middle" ><p class="tableblock">3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>InvalidateAfterReadINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">By using this control the SPIR-V generator is asserting that the cache line
+<td class="tableblock halign-center valign-middle"><p class="tableblock">3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>InvalidateAfterReadINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">By using this control the SPIR-V generator is asserting that the cache line
 containing the data will not be read again until it&#8217;s overwritten, therefore
 the load operation can invalidate the cache line and discard "dirty" data. If
 the assertion is violated (the cache line is read again) then behavior is
 undefined.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-center valign-middle" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>ConstCachedINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">By using this control the SPIR-V generator is asserting that the cache line
+<td class="tableblock halign-center valign-middle"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>ConstCachedINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">By using this control the SPIR-V generator is asserting that the cache line
 containing the data will not be written until all invocations of the shader or
 kernel execution are finished. If the assertion is violated (the cache line is
 written), the behavior is undefined.</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><a id="Store_Cache_Control"></a><strong>3.XX Store Cache Controls</strong></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:80%;
-">
-<col style="width:1%;">
-<col style="width:24%;">
-<col style="width:24%;">
-<col style="width:49%;">
+<div class="paragraph">
+<p><a id="Store_Cache_Control"></a><strong>3.XX Store Cache Controls</strong></p>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 80%;">
+<colgroup>
+<col style="width: 1.6393%;">
+<col style="width: 24.5901%;">
+<col style="width: 24.5901%;">
+<col style="width: 49.1805%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-center valign-middle" colspan="2" > Cache Control </th>
-<th class="tableblock halign-center valign-top" > Enabling Capabilities </th>
-<th class="tableblock halign-center valign-top" > Description</th>
+<th class="tableblock halign-center valign-middle" colspan="2">Cache Control</th>
+<th class="tableblock halign-center valign-top">Enabling Capabilities</th>
+<th class="tableblock halign-center valign-top">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-center valign-middle" ><p class="tableblock">0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>UncachedINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Hint that the store or atomic operation should not cache its data in the
+<td class="tableblock halign-center valign-middle"><p class="tableblock">0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>UncachedINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Hint that the store or atomic operation should not cache its data in the
 given cache level.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-center valign-middle" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>WriteThroughINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Hint that the store or atomic operation should immediately write data to the
+<td class="tableblock halign-center valign-middle"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>WriteThroughINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Hint that the store or atomic operation should immediately write data to the
 subsequent furthest cache, marking the cache line in the current cache as
 "not dirty".</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-center valign-middle" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>WriteBackINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Hint that the store or atomic operation should write data into the given
+<td class="tableblock halign-center valign-middle"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>WriteBackINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Hint that the store or atomic operation should write data into the given
 cache level and mark the cache line as "dirty". Upon eviction, "dirty" data
 will be written into the furthest subsequent cache.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-center valign-middle" ><p class="tableblock">3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>StreamingINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Same as <strong>WriteThroughINTEL</strong>, but use evict-first policy to limit cache
+<td class="tableblock halign-center valign-middle"><p class="tableblock">3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>StreamingINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Same as <strong>WriteThroughINTEL</strong>, but use evict-first policy to limit cache
 pollution by streaming output data.</p></td>
 </tr>
 </tbody>
 </table>
-</div></div>
+</div>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_decorations">Decorations</h3>
-<div class="paragraph"><p>Modify Section 3.20, Decoration, adding rows to the Decoration table:</p></div>
+<div class="paragraph">
+<p>Modify Section 3.20, Decoration, adding rows to the Decoration table:</p>
+</div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all"
-style="
-width:80%;
-">
-<col style="width:2%;">
-<col style="width:48%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:24%;">
+<table class="tableblock frame-all grid-all" style="width: 80%;">
+<colgroup>
+<col style="width: 2.439%;">
+<col style="width: 48.7804%;">
+<col style="width: 12.1951%;">
+<col style="width: 12.1951%;">
+<col style="width: 24.3904%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-center valign-top" colspan="2" > Decoration  </th>
-<th class="tableblock halign-left valign-top" colspan="2" > Extra Operands </th>
-<th class="tableblock halign-left valign-top" > Enabling Capabilities</th>
+<th class="tableblock halign-center valign-top" colspan="2">Decoration</th>
+<th class="tableblock halign-left valign-top" colspan="2">Extra Operands</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6442</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CacheControlLoadINTEL</strong><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6442</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>CacheControlLoadINTEL</strong><br>
 Apply the cache controls to a <em>Pointer</em>.
 The pointer must point to the <strong>Function</strong>, <strong>UniformConstant</strong>, <strong>CrossWorkgroup</strong>
 or <strong>Generic</strong> <em>Storage Class</em>.<br>
@@ -1151,22 +433,22 @@ parameter, the decoration is a hint that the load operation should be performed
 with the specified cache semantics.<br>
 <br>
 <em>Cache Level</em> is an unsigned 32-bit integer telling the cache level to which
-the control applies.  The value <span class="monospaced">0</span> indicates the cache level closest to the
-processing unit, the value <span class="monospaced">1</span> indicates the next furthest cache level, etc.
+the control applies.  The value <code>0</code> indicates the cache level closest to the
+processing unit, the value <code>1</code> indicates the next furthest cache level, etc.
 If some cache level does not exist, the decoration is ignored.<br>
 <br>
 If the exact <em>Load Cache Control</em> value is unsupported, the consumer may apply
 implementation-specific closest match, but only if it does not change the
 observable effect of the requested <em>Load Cache Control</em>.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><a href="#Literal"><em>Literal</em></a><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#Literal"><em>Literal</em></a><br>
 <em>Cache Level</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><a href="#Load_Cache_Control"><em>Load_Cache_Control</em></a><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#Load_Cache_Control"><em>Load_Cache_Control</em></a><br>
 <em>Cache Control</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6443</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CacheControlStoreINTEL</strong><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6443</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>CacheControlStoreINTEL</strong><br>
 Apply the cache controls to a <em>Pointer</em>.
 The pointer must point to the <strong>Function</strong>, <strong>CrossWorkgroup</strong> or
 <strong>Generic</strong> <em>Storage Class</em>.<br>
@@ -1176,114 +458,107 @@ its input parameter, the decoration is a hint that the store operation should be
 performed with the specified cache semantics.<br>
 <br>
 <em>Cache Level</em> is an unsigned 32-bit integer telling the cache level to which the
-control applies. The value <span class="monospaced">0</span> indicates the cache level closest to the
-processing unit, the value <span class="monospaced">1</span> indicates the next furthest cache level, etc. If
+control applies. The value <code>0</code> indicates the cache level closest to the
+processing unit, the value <code>1</code> indicates the next furthest cache level, etc. If
 some cache level does not exist, the decoration is ignored.<br>
 <br>
 If the exact <em>Store Cache Control</em> value is unsupported, the consumer may apply
 implementation-specific closest match, but only if it does not change the
 observable effect of the requested <em>Store Cache Control</em>.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><a href="#Literal"><em>Literal</em></a><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#Literal"><em>Literal</em></a><br>
 <em>Cache Level</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><a href="#Store_Cache_Control"><em>Store_Cache_Control</em></a><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#Store_Cache_Control"><em>Store_Cache_Control</em></a><br>
 <em>Cache Control</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
 </tr>
 </tbody>
 </table>
-</div></div>
+</div>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_capabilities">Capabilities</h3>
-<div class="paragraph"><p>Modify Section 3.31, Capability, adding rows to the Capability table:</p></div>
+<div class="paragraph">
+<p>Modify Section 3.31, Capability, adding rows to the Capability table:</p>
+</div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:33%;">
-<col style="width:33%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-center valign-top" colspan="2" > Capability </th>
-<th class="tableblock halign-center valign-top" > Implicitly Declares</th>
+<th class="tableblock halign-center valign-top" colspan="2">Capability</th>
+<th class="tableblock halign-center valign-top">Implicitly Declares</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6441</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6441</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>CacheControlsINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"></td>
 </tr>
 </tbody>
 </table>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="olist arabic"><ol class="arabic">
+<div class="olist arabic">
+<ol class="arabic">
 <li>
-<p>
-How the consumer should work with shareable data with cached controls, if
+<p>How the consumer should work with shareable data with cached controls, if
 some cache level is non-coherent?<br>
 <strong>RESOLVED</strong>: The cache controls defined as "hints" cannot break memory model. The
 consumer must insert extra flush or invalidate operations to maintain the
 memory model in case of non-coherent caches. The cache controls defined as
 "assertions" may break memory model, so users should take care on undefined
-behavior cases.
-</p>
+behavior cases.</p>
 </li>
 <li>
-<p>
-How to mark an operation "uncached" on all the available cache levels?<br>
+<p>How to mark an operation "uncached" on all the available cache levels?<br>
 <strong>RESOLVED</strong>: Use <strong>Nontemporal</strong> <em>Memory Operand</em> defined in core SPIR-V spec
-instead of this extension.
-</p>
+instead of this extension.</p>
 </li>
-</ol></div>
+</ol>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:100%;
-">
-<col style="width:4%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:66%;">
+<table class="tableblock frame-all grid-rows stretch">
+<colgroup>
+<col style="width: 4.7619%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" >Rev</th>
-<th class="tableblock halign-left valign-top" >Date</th>
-<th class="tableblock halign-left valign-top" >Author</th>
-<th class="tableblock halign-left valign-top" >Changes</th>
+<th class="tableblock halign-left valign-top">Rev</th>
+<th class="tableblock halign-left valign-top">Date</th>
+<th class="tableblock halign-left valign-top">Author</th>
+<th class="tableblock halign-left valign-top">Changes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2023-08-28</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Victor Mustya</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Initial public revision</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-08-28</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Victor Mustya</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Initial public revision</p></td>
 </tr>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footnotes"><hr></div>
-<div id="footer">
-<div id="footer-text">
-Last updated
- 2023-08-28 11:36:00 PDT
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_device_side_avc_motion_estimation.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_device_side_avc_motion_estimation.asciidoc
@@ -1056,7 +1056,7 @@ Result Type must be one of the following types:
 
 [cols="1,1,2,2"]
 !====================
-! 3 ! 46 ! <id> Result Type ! Result <id> !
+! 3 ! 46 ! <id> Result Type ! Result <id>
 !====================
 |====================
 
@@ -1075,7 +1075,7 @@ Sampled Image must have type OpTypeSampledImage or [blue]#<<bookmark-OpTypeVmeIm
 
 [cols="1,1,2,2,3"]
 !====================
-! 4 ! 100 ! <id> Result Type ! Result <id> ! <id> VME Image !
+! 4 ! 100 ! <id> Result Type ! Result <id> ! <id> VME Image
 !====================
 |====================
 
@@ -2943,7 +2943,7 @@ The instruction [blue]#<<bookmark-OpSubgroupAvcSicGetMotionVectorMask,OpSubgroup
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
-| 9 | 5792 | <id> Result Type | Result <id> | <id> Skip Block Partition Type | | <id> Skip Motion Vector Mask | <id> Motion Vectors | <id> Bidirectional Weight | <id> Sad Adjustment | <id> Payload
+| 9 | 5792 | <id> Result Type | Result <id> | <id> Skip Block Partition Type | <id> Skip Motion Vector Mask | <id> Motion Vectors | <id> Bidirectional Weight | <id> Sad Adjustment | <id> Payload
 |=====
 
 [[bookmark-OpSubgroupAvcSicConfigureIpeLumaINTEL]]

--- a/extensions/INTEL/SPV_INTEL_device_side_avc_motion_estimation.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_device_side_avc_motion_estimation.asciidoc
@@ -461,7 +461,7 @@ The basic unit of searching. Possible reference search locations are   grouped i
 The path taken during searching in a reference window. The steps taken in a search path are in units of SUs. The search path must lie within the defined search window.
 
 *Luma* +
-Luma refers to either the Y-plane of a NV12 image or a regular image with the 'Image Channel Order' and 'Image Channel Data Type' restricted as R and UnormInt8.
+Luma refers to either the Y-plane of a NV12 image or a regular image with the _Image Channel Order_ and _Image Channel Data Type_ restricted as R and UnormInt8.
 
 *Chroma* +
 Chroma refer to the UV-plane of a NV12 image.
@@ -1122,11 +1122,11 @@ These instructions enable multi-reference image costing. They allow for the conf
  +
 Get the default base multi-reference cost penalty in U4U4 format when HW assisted multi-reference search is used. 
 
-'Result Type' must be an OpTypeInt with 8-bit Width and 0 Signedness in U4U4 format.
+_Result Type_ must be an OpTypeInt with 8-bit Width and 0 Signedness in U4U4 format.
 
-'Slice Type' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Slice Type_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
-'Qp' must be a 8-bit scalar integer type and a valid quantization parameter value between 0 and 51. It is treated as an unsigned value.
+_Qp_ must be a 8-bit scalar integer type and a valid quantization parameter value between 0 and 51. It is treated as an unsigned value.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1139,7 +1139,7 @@ Get the default base multi-reference cost penalty in U4U4 format when HW assiste
  +
 Set the multi-reference base penalty when HW assisted multi-reference search is performed.
 
-Reference major partitions get associated with a penalty based on its distance from the source image. The 'Reference Base Penalty' is scaled using a scaling factor based on the implied distance of the reference image from
+Reference major partitions get associated with a penalty based on its distance from the source image. The _Reference Base Penalty_ is scaled using a scaling factor based on the implied distance of the reference image from
 the source image as shown below.
 
 [cols="1,1",tablepcwidth=50]
@@ -1150,11 +1150,11 @@ the source image as shown below.
 ! [7, 15] !  3x
 !====================
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
-'Reference Base Penalty' must be 8-bit scalar integer type in U4U4 format and the decoded integer value must fit within 12 bits. It is treated as an unsigned value.
+_Reference Base Penalty_ must be 8-bit scalar integer type in U4U4 format and the decoded integer value must fit within 12 bits. It is treated as an unsigned value.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1171,11 +1171,11 @@ These instructions enable shape costing for inter estimation. They allow for the
  +
 Get the default packed shape cost for inter estimation in U4U4 format.
 
-'Result Type' must be an OpTypeInt with 64-bit Width and 0 Signedness.
+_Result Type_ must be an OpTypeInt with 64-bit Width and 0 Signedness.
 
-'Slice Type' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Slice Type_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
-'Qp' must be a 8-bit scalar integer type and a valid quantization parameter value between 0 and 51. It is treated as an unsigned value.
+_Qp_ must be a 8-bit scalar integer type and a valid quantization parameter value between 0 and 51. It is treated as an unsigned value.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1188,9 +1188,9 @@ Get the default packed shape cost for inter estimation in U4U4 format.
  +
 Set the shape penalty for inter motion estimation.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
-'Packed Shape Penalty' must be 64-bit scalar integer type. It is treated as an unsigned value. The following bits specify the shape penalty in U4U4 format:
+_Packed Shape Penalty_ must be 64-bit scalar integer type. It is treated as an unsigned value. The following bits specify the shape penalty in U4U4 format:
 
 [cols="1,3",tablepcwidth=55]
 !====================
@@ -1204,7 +1204,7 @@ Set the shape penalty for inter motion estimation.
 
 The U4U4 decoded integer values for byte 0 and byte 4 must bit fit in 12 bits, while the U4U4 decoded integer values for the other bytes must fit within 10 bits.      
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1217,11 +1217,11 @@ The U4U4 decoded integer values for byte 0 and byte 4 must bit fit in 12 bits, w
  +
 Get the default direction penalty for inter estimation in U4U4 format.     
 
-'Result Type' must be an OpTypeInt with 8-bit Width and 0 Signedness.
+_Result Type_ must be an OpTypeInt with 8-bit Width and 0 Signedness.
 
-'Slice Type' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Slice Type_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
-'Qp' must be a 8-bit scalar integer type and a valid quantization parameter value between 0 and 51. It is treated as an unsigned value.
+_Qp_ must be a 8-bit scalar integer type and a valid quantization parameter value between 0 and 51. It is treated as an unsigned value.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1234,12 +1234,12 @@ Get the default direction penalty for inter estimation in U4U4 format.
  +
 Set the direction penalty for backward images used in inter motion estimation. 
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
-'Direction Cost' must be 8-bit scalar integer type in U4U4 format and
+_Direction Cost_ must be 8-bit scalar integer type in U4U4 format and
 the decoded integer value must fit within 12 bits. It is treated as an unsigned value.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1256,11 +1256,11 @@ These instructions enable shape costing for intra estimation. They allow for the
  +
 Get the default packed luma intra penalty estimation in U4U4 format.     
 
-'Result Type' must be an OpTypeInt with 32-bit Width and 0 Signedness.
+_Result Type_ must be an OpTypeInt with 32-bit Width and 0 Signedness.
 
-'Slice Type' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Slice Type_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
-'Qp' must be a 8-bit scalar integer type and a valid quantization parameter value between 0 and 51. It is treated as an unsigned value.
+_Qp_ must be a 8-bit scalar integer type and a valid quantization parameter value between 0 and 51. It is treated as an unsigned value.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL* +
@@ -1277,11 +1277,11 @@ These instructions enable motion vector costing for inter estimation. The distor
  +
 Get the default inter motion vector cost table for the pre-defined control points in U4U4 format for the input Qp and slice type.
 
-'Result Type' must be a vector(2) of i32 values and 0 Signedness.
+_Result Type_ must be a vector(2) of i32 values and 0 Signedness.
 
-'Slice Type' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Slice Type_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
-'Qp' must be a 8-bit scalar integer type and a valid quantization parameter value between 0 and 51. It is treated as an unsigned value.
+_Qp_ must be a 8-bit scalar integer type and a valid quantization parameter value between 0 and 51. It is treated as an unsigned value.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1294,7 +1294,7 @@ Get the default inter motion vector cost table for the pre-defined control point
  +
 Get the default predefined packed U4U4 format high cost table for high Qp. This may be more appropriate for frame sequences with high motion.
 
-'Result Type' must be a vector(2) of i32 values and 0 Signedness.
+_Result Type_ must be a vector(2) of i32 values and 0 Signedness.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1307,7 +1307,7 @@ Get the default predefined packed U4U4 format high cost table for high Qp. This 
  +
 Get the default predefined packed U4U4 format high cost table for medium Qp. This may be more appropriate for frame sequences with high motion.
 
-'Result Type' must be a vector(2) of i32 values and 0 Signedness.
+_Result Type_ must be a vector(2) of i32 values and 0 Signedness.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1320,7 +1320,7 @@ Get the default predefined packed U4U4 format high cost table for medium Qp. Thi
  +
 Get the default predefined packed U4U4 format low cost table for high Qp. This may be more appropriate for frame sequences with high motion.
 
-'Result Type' must be a vector(2) of i32 values and 0 Signedness.
+_Result Type_ must be a vector(2) of i32 values and 0 Signedness.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1333,13 +1333,13 @@ Get the default predefined packed U4U4 format low cost table for high Qp. This m
  +
 Update the input payload to set the cost precision along with the cost center and cost table and return it.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
-'Packed Cost Center Delta' must be an OpTypeInt with 64-bit Width and 0 Signedness. It is the packed bidirectional cost center delta value relative to the source macroblock, which specifies the 4 bidirectional cost centers of each of the 8x8 partitions of the reference image.  If only unidirectional search is performed then the values of the backward reference cost centers must be zero. Work-item 'n' provides the value of cost center 'n'. It is specified in QPEL units. For 16x16 partitions work-item '0' provides the cost center. For 8x16 partitions work-items '0' and '1' provide the cost centers. For 16x8 partitions work-items '0' and '2' provide the cost centers. The X and Y coordinates of each cost center delta must be in the range [-2048, 2047] and [-512.00 to 511.75] respectively, otherwise the results are undefined.
+_Packed Cost Center Delta_ must be an OpTypeInt with 64-bit Width and 0 Signedness. It is the packed bidirectional cost center delta value relative to the source macroblock, which specifies the 4 bidirectional cost centers of each of the 8x8 partitions of the reference image.  If only unidirectional search is performed then the values of the backward reference cost centers must be zero. Work-item _n_ provides the value of cost center _n_. It is specified in QPEL units. For 16x16 partitions work-item _0_ provides the cost center. For 8x16 partitions work-items _0_ and _1_ provide the cost centers. For 16x8 partitions work-items _0_ and _2_ provide the cost centers. The X and Y coordinates of each cost center delta must be in the range [-2048, 2047] and [-512.00 to 511.75] respectively, otherwise the results are undefined.
 
-'Packed Cost Table' must be a vector(2) of i32 values and 0 Signedness and specifies the cost penalties for pre-defined control points in U4U4 format in the cost function curve. The first 7 bytes specify 7 control points representing consecutive powers-of-two delta units (2^0^ to 2^6^).  Each delta unit, dx, is the distance of a motion vector, mv, from the specified cost center, cc (dx=abs(mv-cc)). The cost penalty values at in-between control points are linearly interpolated. The range of the cost function is defined to be from 2^0^ to 2^6^ delta units. The 8th byte of the packed cost table specifies the penalty base factor (over_cost) for dx distances that are out-of-range. The penalty of out-of-range cost dx distances is computed as min(over_cost + int(dx) - 64, 255).
+_Packed Cost Table_ must be a vector(2) of i32 values and 0 Signedness and specifies the cost penalties for pre-defined control points in U4U4 format in the cost function curve. The first 7 bytes specify 7 control points representing consecutive powers-of-two delta units (2^0^ to 2^6^).  Each delta unit, dx, is the distance of a motion vector, mv, from the specified cost center, cc (dx=abs(mv-cc)). The cost penalty values at in-between control points are linearly interpolated. The range of the cost function is defined to be from 2^0^ to 2^6^ delta units. The 8th byte of the packed cost table specifies the penalty base factor (over_cost) for dx distances that are out-of-range. The penalty of out-of-range cost dx distances is computed as min(over_cost + int(dx) - 64, 255).
 
-'Cost Precision' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid cost precision value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#, and specifies the precision of the delta units from the cost center, dx. This effectively can be used to control the range of the cost function as follows:
+_Cost Precision_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid cost precision value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#, and specifies the precision of the delta units from the cost center, dx. This effectively can be used to control the range of the cost function as follows:
 
 [options="header"]
 [cols="10,15,15",tablepcwidth=55]
@@ -1360,7 +1360,7 @@ Distortion =
     Multi_Reference_Penalty 
 ........................................
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1377,11 +1377,11 @@ These instructions enable mode costing for intra estimation. They allow for the 
  +
 Get the default inter motion vector cost table for the pre-defined control points in U4U4 format for the input Qp and slice type.
 
-'Result Type' must be an OpTypeInt with 8-bit Width and 0 Signedness in U4U4 format.
+_Result Type_ must be an OpTypeInt with 8-bit Width and 0 Signedness in U4U4 format.
 
-'Slice Type' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Slice Type_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
-'Qp' must be a 8-bit scalar integer type and a valid quantization parameter value between 0 and 51. It is treated as an unsigned value.
+_Qp_ must be a 8-bit scalar integer type and a valid quantization parameter value between 0 and 51. It is treated as an unsigned value.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL* +
@@ -1394,7 +1394,7 @@ Get the default inter motion vector cost table for the pre-defined control point
  +
 Get the default intra non-dc cost penalty for intra luma estimation in packed 32-bit integer format.
 
-'Result Type' must be an OpTypeInt with 32-bit Width and 0 Signedness.
+_Result Type_ must be an OpTypeInt with 32-bit Width and 0 Signedness.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL* +
@@ -1407,7 +1407,7 @@ Get the default intra non-dc cost penalty for intra luma estimation in packed 32
  +
 Get the default chroma mode base penalty in U4U4 format.       
 
-'Result Type' must be an OpTypeInt with 8-bit Width and 0 Signedness in U4U4 format.
+_Result Type_ must be an OpTypeInt with 8-bit Width and 0 Signedness in U4U4 format.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationChromaINTEL* +
@@ -1424,9 +1424,9 @@ These instructions enable miscellaneous MCE properties settings.
  +
 Update the input payload to enable an AC only HAAR SAD mode and return it. It overrides any previous setting for sad adjustment. This feature is mainly intended for improved block matching in frame-rate conversion (FRC) kernels.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1439,11 +1439,11 @@ Update the input payload to enable an AC only HAAR SAD mode and return it. It ov
  +
 Update the input payload to specify the field polarities for interlaced source images used for inter or intra operations.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
-'Source Field Polarity' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid field polarity value as per [blue]#<<bookmark-BF,Section 3, Binary Form>># indicating the field polarity for the source image.  
+_Source Field Polarity_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid field polarity value as per [blue]#<<bookmark-BF,Section 3, Binary Form>># indicating the field polarity for the source image.  
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1456,11 +1456,11 @@ Update the input payload to specify the field polarities for interlaced source i
  +
 Update the input payload to specify the field polarities for interlaced reference images used for single reference inter search or check operation.  
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
-'Reference Field Polarity' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid field polarity value as per [blue]#<<bookmark-BF,Section 3, Binary Form>># indicating the field polarity for the reference image.  
+_Reference Field Polarity_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid field polarity value as per [blue]#<<bookmark-BF,Section 3, Binary Form>># indicating the field polarity for the reference image.  
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1473,13 +1473,13 @@ Update the input payload to specify the field polarities for interlaced referenc
  +
 Update the input payload to specify the field polarities for interlaced reference images used for dual reference inter search or check operation.  
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
-'Forward Reference Field Polarity' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid field polarity value as per [blue]#<<bookmark-BF,Section 3, Binary Form>># indicating the field polarity for the forward reference image.
+_Forward Reference Field Polarity_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid field polarity value as per [blue]#<<bookmark-BF,Section 3, Binary Form>># indicating the field polarity for the forward reference image.
 
-'Backward Reference Field Polarity' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid field polarity value as per [blue]#<<bookmark-BF,Section 3, Binary Form>># indicating the field polarity for the forward reference image.  
+_Backward Reference Field Polarity_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid field polarity value as per [blue]#<<bookmark-BF,Section 3, Binary Form>># indicating the field polarity for the forward reference image.  
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1507,8 +1507,8 @@ If the major shape is:
 
 If the range of work-items for the 8x8 major partition is [n, n+3] and the minor shape is:
 
-* 8x8, then work-item 'n' returns the BMV for each minor partition  +
-* 8x4 or 4x8, then work-items 'n' and 'n+2' returns the BMVs for each minor partition  +
+* 8x8, then work-item _n_ returns the BMV for each minor partition  +
+* 8x4 or 4x8, then work-items _n_ and _n+2_ returns the BMVs for each minor partition  +
 * 4x4, then all work-items in [n, n+3] return the BMVs for each minor partition in traditional Z-order  +
 
 [IMPORTANT]
@@ -1521,9 +1521,9 @@ is not important to extract the component BMVs itself, but is needed if the resu
 overlapping with the bottom MBs. 
 ====
 
-'Result Type' must be an OpTypeInt with 64-bit Width and 0 Signedness.
+_Result Type_ must be an OpTypeInt with 64-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1539,9 +1539,9 @@ returned by [blue]#<<bookmark-OpSubgroupAvcMceGetInterDirectionsINTEL,OpSubgroup
 
 The distortions have to be selected by their respective work-items based on the result block major and minor shapes just as for the result MVs as described above.
 
-'Result Type' must be an OpTypeInt with 16-bit Width and 0 Signedness.
+_Result Type_ must be an OpTypeInt with 16-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1554,9 +1554,9 @@ The distortions have to be selected by their respective work-items based on the 
  +
 Get the best inter distortion for the whole MB. 
 
-'Result Type' must be an OpTypeInt with 16-bit Width and 0 Signedness.
+_Result Type_ must be an OpTypeInt with 16-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1574,9 +1574,9 @@ The returned values are as per the inter-MB major shapes values as per [blue]#<<
 
 This can only be called as part of an IME or REF operation evaluation.
 
-'Result Type' must be an OpTypeInt with 8-bit Width and 0 Signedness.
+_Result Type_ must be an OpTypeInt with 8-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1596,9 +1596,9 @@ This instruction returns valid results only if the major shape is 8x8, otherwise
 
 This can only be called as part of an IME or REF operation evaluation.
 
-'Result Type' must be an OpTypeInt with 8-bit Width and 0 Signedness.
+_Result Type_ must be an OpTypeInt with 8-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1625,9 +1625,9 @@ The returned values are as per the inter direction values as per [blue]#<<bookma
 
 This can only be called as part of an IME or REF operation evaluation.
 
-'Result Type' must be an OpTypeInt with 8-bit Width and 0 Signedness.
+_Result Type_ must be an OpTypeInt with 8-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1642,9 +1642,9 @@ Get the count of motion vectors (based on the partitioning decision) returned by
 
 This can only be called as part of an IME or REF operation evaluation.
 
-'Result Type' must be an OpTypeInt with 8-bit Width and 0 Signedness.
+_Result Type_ must be an OpTypeInt with 8-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1685,9 +1685,9 @@ Unless HW assisted multi-reference search was performed using the IME streamin/s
 images). 
 ====
 
-'Result Type' must be an OpTypeInt with 32-bit Width and 0 Signedness.
+_Result Type_ must be an OpTypeInt with 32-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1726,13 +1726,13 @@ operation. In other words, the field polarities for reference image parameters m
 operation.
 ====
 
-'Result Type' must be an OpTypeInt with 8-bit Width and 0 Signedness.
+_Result Type_ must be an OpTypeInt with 8-bit Width and 0 Signedness.
 
-'Packed Reference Ids' must be an OpTypeInt with 32-bit Width and 0 Signedness, and is as defined by the return value of [blue]#<<bookmark-OpSubgroupAvcMceGetInterReferenceIdsINTEL,OpSubgroupAvcMceGetInterReferenceIdsINTEL>>#. 
+_Packed Reference Ids_ must be an OpTypeInt with 32-bit Width and 0 Signedness, and is as defined by the return value of [blue]#<<bookmark-OpSubgroupAvcMceGetInterReferenceIdsINTEL,OpSubgroupAvcMceGetInterReferenceIdsINTEL>>#. 
 
-'Packed Reference Parameter Field Polarities' must be an OpTypeInt with 32-bit Width and 0 Signedness, and specifies the packed bit field of field polarities for each of the (up to 16) forward/backward interleaved pairs of reference images in the same order as specified in the kernel parameter operand list, as used for the inter search operation. If less than 16 pairs are used then the corresponding bit field values are ignored.
+_Packed Reference Parameter Field Polarities_ must be an OpTypeInt with 32-bit Width and 0 Signedness, and specifies the packed bit field of field polarities for each of the (up to 16) forward/backward interleaved pairs of reference images in the same order as specified in the kernel parameter operand list, as used for the inter search operation. If less than 16 pairs are used then the corresponding bit field values are ignored.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1761,17 +1761,17 @@ The payload is initialized for progressive frame operations, and the cost config
 
 [IMPORTANT]
 ====
-If the source image is an interlaced scan image, then the bottom field lines are considered as logically overlapping with the top field lines (i.e. the top field MBs are considered as logically overlapping with the bottom MBs) for the purposes for specifying the Src Coord' value.
+If the source image is an interlaced scan image, then the bottom field lines are considered as logically overlapping with the top field lines (i.e. the top field MBs are considered as logically overlapping with the bottom MBs) for the purposes for specifying the _Src Coord_ value.
 ====
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
-'Src Coord' must be a vector(2) of i16 values and 0 Signedness. It represents the 2D offset of the top left corner of the source MB in pixel units in the source image. Source MBs at the image borders are allowed to be partial, but the top-left corner must be within the image.
+_Src Coord_ must be a vector(2) of i16 values and 0 Signedness. It represents the 2D offset of the top left corner of the source MB in pixel units in the source image. Source MBs at the image borders are allowed to be partial, but the top-left corner must be within the image.
 
 [[bookmark-PartitionMask]]
-'Partition Mask' must be an OpTypeInt with 8-bit Width and 0 Signedness. The legal values can be composed by setting the appropriate bit fields specified by partition mask values as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#  using OpBitwiseAnd.
+_Partition Mask_ must be an OpTypeInt with 8-bit Width and 0 Signedness. The legal values can be composed by setting the appropriate bit fields specified by partition mask values as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#  using OpBitwiseAnd.
 
-'SAD Adjustment' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid SAD adjustment mode as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#. If it is set to [blue]#<<bookmark-HAAR, __AVC_ME_SAD_ADJUST_MODE_HAAR_INTEL__>>#, a simple wavelet transform, Haar transform, is used to refine the distortion measure of SAD. Haar transform here is used as a coarse estimation of the integer transform.  
+_SAD Adjustment_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid SAD adjustment mode as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#. If it is set to [blue]#<<bookmark-HAAR, __AVC_ME_SAD_ADJUST_MODE_HAAR_INTEL__>>#, a simple wavelet transform, Haar transform, is used to refine the distortion measure of SAD. Haar transform here is used as a coarse estimation of the integer transform.  
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1791,17 +1791,17 @@ Update the input payload for a VME single-reference search with the configuratio
 [IMPORTANT]
 ====
 If the reference image is an interlaced scan image, then the top field lines are considered as logically overlapping with the bottom field lines (i.e. the top field MBs are considered as logically overlapping with the bottom MBs) for the purposes for
-specifying the 'Ref Offset' value.
+specifying the _Ref Offset_ value.
 ====
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
-'Ref Offset' specifies the 2D reference window offset, and must be a vector(2) of i16 values and interpreted as signed values. The X and Y coordinates must be in the range [-2048, 2047], otherwise the results are undefined. The reference window is allowed to be partially outside the image. Pixel replication is applied to generate out-of-bound reference pixels. It is specified in PEL units. Results are undefined in the reference region is completely outside the image.
+_Ref Offset_ specifies the 2D reference window offset, and must be a vector(2) of i16 values and interpreted as signed values. The X and Y coordinates must be in the range [-2048, 2047], otherwise the results are undefined. The reference window is allowed to be partially outside the image. Pixel replication is applied to generate out-of-bound reference pixels. It is specified in PEL units. Results are undefined in the reference region is completely outside the image.
 
 [[bookmark-SearchWindow]]
-'Search Window Config' must be an OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid unreserved search window configuration value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Search Window Config_ must be an OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid unreserved search window configuration value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1818,16 +1818,16 @@ reference window search regions, and return it.
 
 [IMPORTANT]
 ====
-If a reference image is an interlaced scan image, then the top field lines are considered as logically overlapping with the bottom field lines (i.e. the top field MBs are considered as logically overlapping with the bottom MBs) for the purposes for specifying the corresponding 'Fwd Ref Offset' and/or 'Bwd Ref Offset' values.
+If a reference image is an interlaced scan image, then the top field lines are considered as logically overlapping with the bottom field lines (i.e. the top field MBs are considered as logically overlapping with the bottom MBs) for the purposes for specifying the corresponding _Fwd Ref Offset_ and/or _Bwd Ref Offset_ values.
 ====
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
-'Fwd Ref Offset'/'Bwd Ref Offset' specify the 2D forward/backward reference window offset, and must be a vector(2) of i16 values and interpreted as signed values. The X and Y coordinates must be in the range [-2048, 2047], otherwise the results are undefined. The reference window is allowed to be partially outside the image. Pixel replication is applied to generate out-of-bound reference pixels. It is specified in PEL units. Results are undefined in the reference region is completely outside the image.
+_Fwd Ref Offset_/_Bwd Ref Offset_ specify the 2D forward/backward reference window offset, and must be a vector(2) of i16 values and interpreted as signed values. The X and Y coordinates must be in the range [-2048, 2047], otherwise the results are undefined. The reference window is allowed to be partially outside the image. Pixel replication is applied to generate out-of-bound reference pixels. It is specified in PEL units. Results are undefined in the reference region is completely outside the image.
 
-'Search Window Config' must be an OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid unreserved search window configuration value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Search Window Config_ must be an OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid unreserved search window configuration value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1840,11 +1840,11 @@ If a reference image is an interlaced scan image, then the top field lines are c
  +
 Get the 2D size of the reference window in pixel units.
             
-'Result Type' must be a vector(2) of i16 values and 0 Signedness.
+_Result Type_ must be a vector(2) of i16 values and 0 Signedness.
 
-'Search Window Config' must be an OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid unreserved search window configuration value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Search Window Config_ must be an OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid unreserved search window configuration value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
-'Dual Ref' must be a 8-bit scalar integer type and must evaluate to zero for a single reference search window and one for a dual-reference search window. It is treated as an unsigned value.
+_Dual Ref_ must be a 8-bit scalar integer type and must evaluate to zero for a single reference search window and one for a dual-reference search window. It is treated as an unsigned value.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1855,7 +1855,7 @@ Get the 2D size of the reference window in pixel units.
 |=====
 7+|*OpSubgroupAvcImeAdjustRefOffsetINTEL* +
  +
-If the input 2D reference window offset, 'Ref Offset', causes the reference window to be fully out-of-bound of the reference image, adjust it such that the reference window is
+If the input 2D reference window offset, _Ref Offset_, causes the reference window to be fully out-of-bound of the reference image, adjust it such that the reference window is
 within bounds of the reference image.
 
 [IMPORTANT]
@@ -1869,16 +1869,16 @@ A call to OpSubgroupAvcImeAdjustRefOffsetINTEL is optional. It is required only 
 [blue]#<<bookmark-OpSubgroupAvcImeSetDualReferenceINTEL,OpSubgroupAvcImeSetDualReferenceINTEL>>#  is potentially out-of-bounds and need to be adjusted.
 ====
             
-'Result Type' must be a vector(2) of i16 values and interpreted as signed values.
+_Result Type_ must be a vector(2) of i16 values and interpreted as signed values.
 
-'Ref Offset' must be a vector(2) of i16 values and interpreted as signed values. It specifies the 2D reference window offset. The X and Y coordinates must be in the range [-2048, 2047], otherwise the results are undefined.         
+_Ref Offset_ must be a vector(2) of i16 values and interpreted as signed values. It specifies the 2D reference window offset. The X and Y coordinates must be in the range [-2048, 2047], otherwise the results are undefined.         
 
-'Src Coord' must be a vector(2) of i16 values and 0 Signedness. It represents the 2D offset of the top left corner of the source MB in pixel units in the source image. Source MBs at the image borders are allowed to be partial, but the top-left corner must be within the image.
+_Src Coord_ must be a vector(2) of i16 values and 0 Signedness. It represents the 2D offset of the top left corner of the source MB in pixel units in the source image. Source MBs at the image borders are allowed to be partial, but the top-left corner must be within the image.
 
-'Ref Window Size' must be a vector(2) of i16 values and 0 Signedness. It specifies
+_Ref Window Size_ must be a vector(2) of i16 values and 0 Signedness. It specifies
 the 2D size of the reference window in pixel units.
 
-'Image Size' must be a vector(2) of i16 values and 0 Signedness. It specifies the 2D
+_Image Size_ must be a vector(2) of i16 values and 0 Signedness. It specifies the 2D
 size of the progressive scan, or top or bottom fields, of the interlaced scan image in pixel units.
 
 | Capability: + 
@@ -1896,9 +1896,9 @@ These are optional instructions that may be called following the search configur
  +
 Convert the IME payload to a generic MCE payload.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1911,9 +1911,9 @@ Convert the IME payload to a generic MCE payload.
  +
 Convert the generic MCE payload to a IME payload.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1936,11 +1936,11 @@ will compute the best allowed partitioning such that the number of sub-block mot
 This can be used to handle the restriction for certain profiles for AVC in that the maximum number of motion vectors allowed for two consecutive MBs can only be 16.
 ====
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
-'Max Motion Vector Count' must be an OpTypeInt with 8-bit Width and 0 Signedness, and specifies the maximum number of motion vectors allowed for the current MB. It must be in the range [1, 32], otherwise the results are undefined.  
+_Max Motion Vector Count_ must be an OpTypeInt with 8-bit Width and 0 Signedness, and specifies the maximum number of motion vectors allowed for the current MB. It must be in the range [1, 32], otherwise the results are undefined.  
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1955,9 +1955,9 @@ Update the input payload to disable a mix of forward and backward MVs in the res
 
 Default is to enable it.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1972,11 +1972,11 @@ Specifies the threshold value of a distortion compute of a 16x16 partition of a 
 single-reference search, below which no more searching is performed for the MB.
 
 The input payload must have been configured for a single-reference search with the 16x16 partition enabled for this threshold to be set, or else the results are undefined. 
-'Result Type' must be an OpTypeInt with 8-bit Width and 0 Signedness.
+_Result Type_ must be an OpTypeInt with 8-bit Width and 0 Signedness.
 
-'Threshold' must be an OpTypeInt with 8-bit Width and 0 Signedness, and is specified in U4U4 format. Additionally, the integer value must fit within 14 bits.
+_Threshold_ must be an OpTypeInt with 8-bit Width and 0 Signedness, and is specified in U4U4 format. Additionally, the integer value must fit within 14 bits.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -1991,7 +1991,7 @@ The input payload must have been configured for a single-reference search with t
 Set the (16) SAD weights for each 4x4 sub-block.
 
 These values are used to decrease the SAD magnitude of each 4x4 sub-block by dividing
-the SAD of 4x4 sub-block of the source MB by its mapped weight. It requires a [blue]#<<bookmark-PartitionMask,'Partition Mask'>># of 16x16 and forward [blue]#<<bookmark-SearchWindow,'Search Window Configuration'>>#.
+the SAD of 4x4 sub-block of the source MB by its mapped weight. It requires a [blue]#<<bookmark-PartitionMask,_Partition Mask_>># of 16x16 and forward [blue]#<<bookmark-SearchWindow,_Search Window Configuration_>>#.
 
 The weighting pattern used is the traditional Z order for each 4x4 block. Weighted-SAD
 Control Mapping:
@@ -2008,9 +2008,9 @@ A prior call to [blue]#<<bookmark-OpSubgroupAvcImeSetSingleReferenceINTEL,OpSubg
 This feature is mainly intended for improved block matching in image-rate conversion (FRC) kernels. 
 ====
 
-'Packed Sad Weights' must be an OpTypeInt with 32-bit Width and 0 Signedness. Each weight is of 2 bits represented in a packed format for each of the 4x4 blocks in Z order.
+_Packed Sad Weights_ must be an OpTypeInt with 32-bit Width and 0 Signedness. Each weight is of 2 bits represented in a packed format for each of the 4x4 blocks in Z order.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2027,13 +2027,13 @@ These instructions perform the evaluation of the IME operation configured in the
  +
 Evaluate the basic IME operation with a single reference and return its results. The IME payload must have been configured with [blue]#<<bookmark-OpSubgroupAvcImeSetSingleReferenceINTEL,OpSubgroupAvcImeSetSingleReferenceINTEL>># .
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
-'Src Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
+_Src Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
 
-'Ref Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.   
+_Ref Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.   
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2046,15 +2046,15 @@ Evaluate the basic IME operation with a single reference and return its results.
  +
 Evaluate the basic IME operation with dual references and return its results. The IME payload must have been configured with [blue]#<<bookmark-OpSubgroupAvcImeSetDualReferenceINTEL,OpSubgroupAvcImeSetDualReferenceINTEL>>#.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
-'Src Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
+_Src Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
 
-'Fwd Ref Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.  
+_Fwd Ref Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.  
 
-'Bwd Ref Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a backward reference image.   
+_Bwd Ref Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a backward reference image.   
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2067,13 +2067,13 @@ Evaluate the basic IME operation with dual references and return its results. Th
  +
 Evaluate the single reference IME operation with streamout and return its results. The IME payload must have been configured with [blue]#<<bookmark-OpSubgroupAvcImeSetSingleReferenceINTEL,OpSubgroupAvcImeSetSingleReferenceINTEL>>#.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL,__OpTypeAvcImeResultSingleReferenceStreamoutINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL,__OpTypeAvcImeResultSingleReferenceStreamoutINTEL__>># type.
 
-'Src Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
+_Src Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
 
-'Ref Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.   
+_Ref Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.   
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2086,15 +2086,15 @@ Evaluate the single reference IME operation with streamout and return its result
  +
 Evaluate the basic IME operation with dual references with streamout and return its results. The IME payload must have been configured with [blue]#<<bookmark-OpSubgroupAvcImeSetDualReferenceINTEL,OpSubgroupAvcImeSetDualReferenceINTEL>>#.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL,__OpTypeAvcImeResultDualReferenceStreamoutINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL,__OpTypeAvcImeResultDualReferenceStreamoutINTEL__>># type.
 
-'Src Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
+_Src Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
 
-'Fwd Ref Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.  
+_Fwd Ref Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.  
 
-'Bwd Ref Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a backward reference image.   
+_Bwd Ref Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a backward reference image.   
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2107,15 +2107,15 @@ Evaluate the basic IME operation with dual references with streamout and return 
  +
 Evaluate the single reference IME operation with streamin and return its results. The IME payload must have been configured with [blue]#<<bookmark-OpSubgroupAvcImeSetSingleReferenceINTEL,OpSubgroupAvcImeSetSingleReferenceINTEL>>#.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
-'Src Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image. +  
+_Src Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image. +  
 
-'Ref Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.   
+_Ref Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.   
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
-'Streamin Components' must be the [blue]#<<bookmark-OpTypeAvcImeSingleReferenceStreaminINTEL,__OpTypeAvcImeSingleReferenceStreaminINTEL__>># type.
+_Streamin Components_ must be the [blue]#<<bookmark-OpTypeAvcImeSingleReferenceStreaminINTEL,__OpTypeAvcImeSingleReferenceStreaminINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2128,17 +2128,17 @@ Evaluate the single reference IME operation with streamin and return its results
  +
 Evaluate the dual reference IME operation with streamin and return its results. The IME payload must have been configured with [blue]#<<bookmark-OpSubgroupAvcImeSetDualReferenceINTEL,OpSubgroupAvcImeSetDualReferenceINTEL>>#.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
-'Src Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image. +  
+_Src Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image. +  
 
-'Fwd Ref Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.   
+_Fwd Ref Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.   
 
-'Bwd Ref Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a backward reference image.  
+_Bwd Ref Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a backward reference image.  
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
-'Streamin Components' must be the [blue]#<<bookmark-OpTypeAvcImeDualReferenceStreaminINTEL,__OpTypeAvcImeDualReferenceStreaminINTEL__>># type.
+_Streamin Components_ must be the [blue]#<<bookmark-OpTypeAvcImeDualReferenceStreaminINTEL,__OpTypeAvcImeDualReferenceStreaminINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2151,15 +2151,15 @@ Evaluate the dual reference IME operation with streamin and return its results. 
  +
 Evaluate the single reference IME operation with streamin/streamout and return its results. The IME payload must have been configured with [blue]#<<bookmark-OpSubgroupAvcImeSetSingleReferenceINTEL,OpSubgroupAvcImeSetSingleReferenceINTEL>>#.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL,__OpTypeAvcImeResultSingleReferenceStreamoutINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL,__OpTypeAvcImeResultSingleReferenceStreamoutINTEL__>># type.
 
-'Src Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image. +  
+_Src Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image. +  
 
-'Ref Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.+
+_Ref Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.+
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
-'Streamin Components' must be the [blue]#<<bookmark-OpTypeAvcImeSingleReferenceStreaminINTEL,__OpTypeAvcImeSingleReferenceStreaminINTEL__>># type.
+_Streamin Components_ must be the [blue]#<<bookmark-OpTypeAvcImeSingleReferenceStreaminINTEL,__OpTypeAvcImeSingleReferenceStreaminINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2172,17 +2172,17 @@ Evaluate the single reference IME operation with streamin/streamout and return i
  +
 Evaluate the dual reference IME operation with streamin/streamout and return its results. The IME payload must have been configured with [blue]#<<bookmark-OpSubgroupAvcImeSetDualReferenceINTEL,OpSubgroupAvcImeSetDualReferenceINTEL>>#.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL,__OpTypeAvcImeResultDualReferenceStreamoutINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL,__OpTypeAvcImeResultDualReferenceStreamoutINTEL__>># type.
 
-'Src Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image. +  
+_Src Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image. +  
 
-'Fwd Ref Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.   
+_Fwd Ref Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.   
 
-'Bwd Ref Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a backward reference image.  
+_Bwd Ref Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a backward reference image.  
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImePayloadINTEL__>># type.
 
-'Streamin Components' must be the [blue]#<<bookmark-OpTypeAvcImeDualReferenceStreaminINTEL,__OpTypeAvcImeDualReferenceStreaminINTEL__>># type.
+_Streamin Components_ must be the [blue]#<<bookmark-OpTypeAvcImeDualReferenceStreaminINTEL,__OpTypeAvcImeDualReferenceStreaminINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2199,9 +2199,9 @@ These are optional instructions that may be called following the evaluation phas
  +
 Convert the IME result to a generic MCE result.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcMceResultINTEL,__OpTypeAvcMceResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcMceResultINTEL,__OpTypeAvcMceResultINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2214,9 +2214,9 @@ Convert the IME result to a generic MCE result.
  +
 Convert the generic MCE result to a IME result.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcMceResultINTEL,__OpTypeAvcMceResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcMceResultINTEL,__OpTypeAvcMceResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2233,9 +2233,9 @@ These instructions are called following the evaluation phase to extract the vari
  +
 Return the streamed out BMVs and distortions from the input result from a single reference streamout IME operation that can be used as streamin input for a subsequent IME operation.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcImeSingleReferenceStreaminINTEL,__OpTypeAvcImeSingleReferenceStreaminINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcImeSingleReferenceStreaminINTEL,__OpTypeAvcImeSingleReferenceStreaminINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL,__OpTypeAvcImeResultSingleReferenceStreamoutINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL,__OpTypeAvcImeResultSingleReferenceStreamoutINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2248,9 +2248,9 @@ Return the streamed out BMVs and distortions from the input result from a single
  +
 Return the streamed out BMVs and distortions from the input result from a dual reference streamout IME operation that can be used as streamin input for a subsequent IME operation.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcImeDualReferenceStreaminINTEL,__OpTypeAvcImeDualReferenceStreaminINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcImeDualReferenceStreaminINTEL,__OpTypeAvcImeDualReferenceStreaminINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL,__OpTypeAvcImeResultDualReferenceStreamoutINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL,__OpTypeAvcImeResultDualReferenceStreamoutINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2263,9 +2263,9 @@ Return the streamed out BMVs and distortions from the input result from a dual r
  +
 Strip out the single reference streamout BMVs and distortions from the streamout results and return the rest.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL,__OpTypeAvcImeResultSingleReferenceStreamoutINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL,__OpTypeAvcImeResultSingleReferenceStreamoutINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2278,9 +2278,9 @@ Strip out the single reference streamout BMVs and distortions from the streamout
  +
 Strip out the dual reference streamout BMVs and distortions from the streamout results and return the rest.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL,__OpTypeAvcImeResultDualReferenceStreamoutINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL,__OpTypeAvcImeResultDualReferenceStreamoutINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2301,11 +2301,11 @@ Up to 4 packed MVs are returned, one per work-item. If the major shape is:
 * 16x8, or 8x16, then two packed MVs are returned by work-items 0 and 1
 * 8x8, then four packed MVs are returned by work-items 0 to 3.   
 
-'Result Type' must be a OpTypeInt with 32-bit Width and 0 Signedness.
+_Result Type_ must be a OpTypeInt with 32-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL,__OpTypeAvcImeResultSingleReferenceStreamoutINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL,__OpTypeAvcImeResultSingleReferenceStreamoutINTEL__>># type.
 
-'Major Shape' must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Major Shape_ must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2322,13 +2322,13 @@ streamout results.
 Up to 4 packed MVs are returned, one per work-item in the same format as for motion
 vectors for single reference streamout as described in [blue]#<<bookmark-singlerefmv,OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL>>#.
 
-'Result Type' must be a OpTypeInt with 32-bit Width and 0 Signedness.
+_Result Type_ must be a OpTypeInt with 32-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL,__OpTypeAvcImeResultDualReferenceStreamoutINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL,__OpTypeAvcImeResultDualReferenceStreamoutINTEL__>># type.
 
-'Major Shape' must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Major Shape_ must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
-'Direction' must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major direction value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Direction_ must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major direction value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
 | Capability: +
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2344,11 +2344,11 @@ Get the distortions for the input major shape from the IME single reference stre
 Up to 4 distortions are returned, one per work-item in the same format as for motion
 vectors as described in [blue]#<<bookmark-singlerefmv,OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL>>#.
 
-'Result Type' must be a OpTypeInt with 16-bit Width and 0 Signedness.
+_Result Type_ must be a OpTypeInt with 16-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL,__OpTypeAvcImeResultSingleReferenceStreamoutINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL,__OpTypeAvcImeResultSingleReferenceStreamoutINTEL__>># type.
 
-'Major Shape' must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Major Shape_ must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2364,13 +2364,13 @@ Get the distortions for the input major shape from the IME dual reference stream
 Up to 4 distortion are returned, one per work-item in the same format as for motion
 vectors for single reference streamout as described in [blue]#<<bookmark-singlerefmv,OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL>>#.
 
-'Result Type' must be a OpTypeInt with 16-bit Width and 0 Signedness.
+_Result Type_ must be a OpTypeInt with 16-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL,__OpTypeAvcImeResultDualReferenceStreamoutINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL,__OpTypeAvcImeResultDualReferenceStreamoutINTEL__>># type.
 
-'Major Shape' must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Major Shape_ must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
-'Direction' must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major direction value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Direction_ must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major direction value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2386,11 +2386,11 @@ Get the reference identifiers for the input major shape and direction from the I
 Up to 4 reference identifiers are returned, one per work-item in the same format as for motion
 vectors as described in [blue]#<<bookmark-singlerefmv,OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL>>#.
 
-'Result Type' must be a OpTypeInt with 8-bit Width and 0 Signedness.
+_Result Type_ must be a OpTypeInt with 8-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL,__OpTypeAvcImeResultSingleReferenceStreamoutINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL,__OpTypeAvcImeResultSingleReferenceStreamoutINTEL__>># type.
 
-'Major Shape' must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Major Shape_ must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2405,13 +2405,13 @@ Get the reference identifiers for the input major shape from the IME dual refere
 
 Up to 4 reference identifiers are returned, one per work-item in the same format as for motion vectors for single reference streamout as described in [blue]#<<bookmark-singlerefmv,OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL>>#.
 
-'Result Type' must be a OpTypeInt with 8-bit Width and 0 Signedness.
+_Result Type_ must be a OpTypeInt with 8-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL,__OpTypeAvcImeResultDualReferenceStreamoutINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL,__OpTypeAvcImeResultDualReferenceStreamoutINTEL__>># type.
 
-'Major Shape' must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Major Shape_ must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
-'Direction' must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major direction value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Direction_ must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major direction value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2427,11 +2427,11 @@ Get the bitmask indicating whether any border of forward/backward reference imag
 The search window must have been configured for a forward reference if image_select is
 set as [blue]#<<bookmark-forward,AVC_ME_FRAME_FORWARD_INTEL>># and with a backward reference if image_select is set as [blue]#<<bookmark-backward,AVC_ME_FRAME_BACKWARD_INTEL>>#.
 
-'Result Type' must be a OpTypeInt with 8-bit Width and 0 Signedness.
+_Result Type_ must be a OpTypeInt with 8-bit Width and 0 Signedness.
 
-'Image Select' must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is either [blue]#<<bookmark-forward,AVC_ME_FRAME_FORWARD_INTEL>># or [blue]#<<bookmark-backward,AVC_ME_FRAME_BACKWARD_INTEL>>#.
+_Image Select_ must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is either [blue]#<<bookmark-forward,AVC_ME_FRAME_FORWARD_INTEL>># or [blue]#<<bookmark-backward,AVC_ME_FRAME_BACKWARD_INTEL>>#.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2446,9 +2446,9 @@ Get the indication that the search operation was prevented from providing the lo
 distortion solution due to the tighter constraints on the maximum number of MB motion
 vectors configured for the search operation.   
 
-'Result Type' must be a OpTypeInt with 8-bit Width and 0 Signedness.
+_Result Type_ must be a OpTypeInt with 8-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2461,9 +2461,9 @@ vectors configured for the search operation.
  +
 Get the indication that unidirectional search operation terminated early because the configured distortion threshold was met.   
 
-'Result Type' must be a OpTypeInt with 8-bit Width and 0 Signedness.
+_Result Type_ must be a OpTypeInt with 8-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2483,9 +2483,9 @@ This can only be called if a SAD weighting pattern was set prior to evaluation u
 [blue]#<<bookmark-weightedsad,OpSubgroupAvcImeSetWeightedSadINTEL>>#.
 ====
 
-'Result Type' must be a OpTypeInt with 32-bit Width and 0 Signedness.
+_Result Type_ must be a OpTypeInt with 32-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2498,9 +2498,9 @@ This can only be called if a SAD weighting pattern was set prior to evaluation u
  +
 Get the minimum 16x16 distortion when applying the traditional Z-order SAD weighting pattern.
 
-'Result Type' must be a OpTypeInt with 16-bit Width and 0 Signedness.
+_Result Type_ must be a OpTypeInt with 16-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcImeResultINTEL,__OpTypeAvcImeResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2527,17 +2527,17 @@ Return an initialized payload for a VME fractional motion estimation operation (
 The payload is initialized for progressive frame operations, and the cost configuration
 values and the miscellaneous property values are all initialized to zero. The cost configuration and the miscellaneous property configuration instructions must be used to override the initial configurations in the payload.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
 
-'Src Coord' must be a vector(2) of i16 values and 0 Signedness, and represents the 2D offset of the top left corner of the source MB in pixel units in the source image.
+_Src Coord_ must be a vector(2) of i16 values and 0 Signedness, and represents the 2D offset of the top left corner of the source MB in pixel units in the source image.
 
 [IMPORTANT]
 ====
 If the source image is an interlaced scan image, then the bottom field lines are considered as logically overlapping with the top field lines (i.e. the top field MBs are considered as logically overlapping with the bottom MBs) for the purposes for specifying
-the 'Src Coord' value.
+the _Src Coord_ value.
 ====
 
-'Motion Vectors' must be an OpTypeInt with 64-bit Width and 0 Signedness. It represents the BMVs returned by an IME in the same format as
+_Motion Vectors_ must be an OpTypeInt with 64-bit Width and 0 Signedness. It represents the BMVs returned by an IME in the same format as
 returned by [blue]#<<bookmark-OpSubgroupAvcMceGetMotionVectorsINTEL,OpSubgroupAvcMceGetMotionVectorsINTEL>>#. The MVs are in QPEL units. The X and Y coordinates of each MV must be in the range [-2048.00, 2047.75), otherwise the results are undefined.
 
 [CAUTION]
@@ -2545,16 +2545,16 @@ returned by [blue]#<<bookmark-OpSubgroupAvcMceGetMotionVectorsINTEL,OpSubgroupAv
 If this operand's value is manually composed, all sub-block MVs must be replicated per its format for each partition.  For example for 16x16 partition, all sub-block MVs must be replicated to the same MV, and for 8x8 partition, each 8x8 must have its respective sub-block MVs replicated.
 ====
 
-'Major Shapes' must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of [blue]#<<bookmark-OpSubgroupAvcMceGetInterMajorShapeINTEL,OpSubgroupAvcMceGetInterMajorShapeINTEL>>#.
+_Major Shapes_ must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of [blue]#<<bookmark-OpSubgroupAvcMceGetInterMajorShapeINTEL,OpSubgroupAvcMceGetInterMajorShapeINTEL>>#.
 
-'Minor Shapes' must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of [blue]#<<bookmark-OpSubgroupAvcMceGetInterMajorShapeINTEL,OpSubgroupAvcMceGetInterMajorShapeINTEL>>#.
+_Minor Shapes_ must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of [blue]#<<bookmark-OpSubgroupAvcMceGetInterMajorShapeINTEL,OpSubgroupAvcMceGetInterMajorShapeINTEL>>#.
 
-'Directions' must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of
+_Directions_ must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of
 [blue]#<<bookmark-OpSubgroupAvcMceGetInterDirectionsINTEL,OpSubgroupAvcMceGetInterDirectionsINTEL>>#.
 
-'Pixel Resolution' must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values for it are either [blue]#<<bookmark-AVC_ME_SUBPIXEL_MODE_HPEL_INTEL,__AVC_ME_SUBPIXEL_MODE_HPEL_INTEL__>># or [blue]#<<bookmark-AVC_ME_SUBPIXEL_MODE_HPEL_INTEL,__AVC_ME_SUBPIXEL_MODE_QPEL_INTEL__>>#.
+_Pixel Resolution_ must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values for it are either [blue]#<<bookmark-AVC_ME_SUBPIXEL_MODE_HPEL_INTEL,__AVC_ME_SUBPIXEL_MODE_HPEL_INTEL__>># or [blue]#<<bookmark-AVC_ME_SUBPIXEL_MODE_HPEL_INTEL,__AVC_ME_SUBPIXEL_MODE_QPEL_INTEL__>>#.
 
-'Sad Adjustment' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid sad adjustment value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Sad Adjustment_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid sad adjustment value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2571,17 +2571,17 @@ Return an initialized payload for a VME bidirectional motion estimation (BME) op
 The payload is initialized for progressive frame operations, and the cost configuration
 values and the miscellaneous property values are all initialized to zero. The cost configuration and the miscellaneous property configuration instructions must be used to override the initial configurations in the payload.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
 
-'Src Coord' must be a vector(2) of i16 values and 0 Signedness, and represents the 2D offset of the top left corner of the source MB in pixel units in the source image.
+_Src Coord_ must be a vector(2) of i16 values and 0 Signedness, and represents the 2D offset of the top left corner of the source MB in pixel units in the source image.
 
 [IMPORTANT]
 ====
 If the source image is an interlaced scan image, then the bottom field lines are considered as logically overlapping with the top field lines (i.e. the top field MBs are considered as logically overlapping with the bottom MBs) for the purposes for specifying
-the 'Src Coord' value.
+the _Src Coord_ value.
 ====
 
-'Motion Vectors' must be an OpTypeInt with 64-bit Width and 0 Signedness. It represents the BMVs returned by an IME in the same format as
+_Motion Vectors_ must be an OpTypeInt with 64-bit Width and 0 Signedness. It represents the BMVs returned by an IME in the same format as
 returned by [blue]#<<bookmark-OpSubgroupAvcMceGetMotionVectorsINTEL,OpSubgroupAvcMceGetMotionVectorsINTEL>>#. The MVs are in QPEL units. The X and Y coordinates of each MV must be in the range [-2048.00, 2047.75), otherwise the results are undefined.
 
 [CAUTION]
@@ -2589,18 +2589,18 @@ returned by [blue]#<<bookmark-OpSubgroupAvcMceGetMotionVectorsINTEL,OpSubgroupAv
 If this operand's value is manually composed, all sub-block MVs must be replicated per its format for each partition.  For example for 16x16 partition, all sub-block MVs must be replicated to the same MV, and for 8x8 partition, each 8x8 must have its respective sub-block MVs replicated.
 ====
 
-'Major Shapes' must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of [blue]#<<bookmark-OpSubgroupAvcMceGetInterMajorShapeINTEL,OpSubgroupAvcMceGetInterMajorShapeINTEL>>#.
+_Major Shapes_ must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of [blue]#<<bookmark-OpSubgroupAvcMceGetInterMajorShapeINTEL,OpSubgroupAvcMceGetInterMajorShapeINTEL>>#.
 
-'Minor Shapes' must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of [blue]#<<bookmark-OpSubgroupAvcMceGetInterMajorShapeINTEL,OpSubgroupAvcMceGetInterMajorShapeINTEL>>#.
+_Minor Shapes_ must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of [blue]#<<bookmark-OpSubgroupAvcMceGetInterMajorShapeINTEL,OpSubgroupAvcMceGetInterMajorShapeINTEL>>#.
 
-'Directions' must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of
+_Directions_ must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of
 [blue]#<<bookmark-OpSubgroupAvcMceGetInterDirectionsINTEL,OpSubgroupAvcMceGetInterDirectionsINTEL>>#.
 
-'Pixel Resolution' must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values for it are either [blue]#<<bookmark-AVC_ME_SUBPIXEL_MODE_HPEL_INTEL,__AVC_ME_SUBPIXEL_MODE_HPEL_INTEL__>># or [blue]#<<bookmark-AVC_ME_SUBPIXEL_MODE_HPEL_INTEL,__AVC_ME_SUBPIXEL_MODE_QPEL_INTEL__>>#.
+_Pixel Resolution_ must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values for it are either [blue]#<<bookmark-AVC_ME_SUBPIXEL_MODE_HPEL_INTEL,__AVC_ME_SUBPIXEL_MODE_HPEL_INTEL__>># or [blue]#<<bookmark-AVC_ME_SUBPIXEL_MODE_HPEL_INTEL,__AVC_ME_SUBPIXEL_MODE_QPEL_INTEL__>>#.
 
-'Bidirectional Weight' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid bidirectional weight value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Bidirectional Weight_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid bidirectional weight value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
-'Sad Adjustment' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid sad adjustment value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Sad Adjustment_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid sad adjustment value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2616,9 +2616,9 @@ These are optional instructions that may be called following the initialization 
  +
 Convert the REF payload to a generic MCE payload.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2631,9 +2631,9 @@ Convert the REF payload to a generic MCE payload.
  +
 Convert the generic MCE payload to a REF payload.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2652,9 +2652,9 @@ Update the input payload to disable a mix of bidirectional and unidirectional MV
 
 Default is to enable it.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2675,9 +2675,9 @@ This should not be called if the payload was initialized with integer pixel reso
 
 Default is to enable it.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2694,13 +2694,13 @@ These instructions perform the evaluation of the REF operation configured in the
  +
 Evaluate the basic REF operation with a single reference and return its results.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcRefResultINTEL,__OpTypeAvcRefResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcRefResultINTEL,__OpTypeAvcRefResultINTEL__>># type.
 
-'Src Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
+_Src Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
 
-'Ref Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.   
+_Ref Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.   
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2714,15 +2714,15 @@ Evaluate the basic REF operation with a single reference and return its results.
  +
 Evaluate the basic REF operation with dual references and return its results.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcRefResultINTEL,__OpTypeAvcRefResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcRefResultINTEL,__OpTypeAvcRefResultINTEL__>># type.
 
-'Src Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
+_Src Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
 
-'Fwd Ref Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.  
+_Fwd Ref Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.  
 
-'Bwd Ref Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a backward reference image.   
+_Bwd Ref Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a backward reference image.   
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2736,11 +2736,11 @@ Evaluate the basic REF operation with dual references and return its results.
  +
 Evaluate the basic REF operation with multi references and return its results.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcRefResultINTEL,__OpTypeAvcRefResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcRefResultINTEL,__OpTypeAvcRefResultINTEL__>># type.
 
-'Src Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
+_Src Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
 
-'Packed Reference Ids' must be an OpTypeInt with 32-bit Width and 0 Signedness, with the following bits specifying the values for the pair of reference images for each major partition.
+_Packed Reference Ids_ must be an OpTypeInt with 32-bit Width and 0 Signedness, with the following bits specifying the values for the pair of reference images for each major partition.
 
 [cols="1,2",tablepcwidth=55]
 !====================
@@ -2754,8 +2754,8 @@ Evaluate the basic REF operation with multi references and return its results.
 ! 31:28 ! Bwd reference block 3
 !====================
 
-A forward[backward] reference identifier value of 'n' indicates the forward[backward]
-image from the 'n'^th^ pair of forward/backward reference images, with the value of 'n'
+A forward[backward] reference identifier value of _n_ indicates the forward[backward]
+image from the _n_^th^ pair of forward/backward reference images, with the value of _n_
 ranging from 0 to 15.
 
 If the REF operation is configured with only forward reference images then, the
@@ -2767,10 +2767,10 @@ for block 0.
 
 [NOTE]
 ====
-The value for the 'Packed Reference Ids' is typically obtained by calling [blue]#<<bookmark-OpSubgroupAvcMceGetInterReferenceIdsINTEL,OpSubgroupAvcMceGetInterReferenceIdsINTEL>># for the preceding IME operation's result.
+The value for the _Packed Reference Ids_ is typically obtained by calling [blue]#<<bookmark-OpSubgroupAvcMceGetInterReferenceIdsINTEL,OpSubgroupAvcMceGetInterReferenceIdsINTEL>># for the preceding IME operation's result.
 ====
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2785,11 +2785,11 @@ The value for the 'Packed Reference Ids' is typically obtained by calling [blue]
 Evaluate the basic REF operation with multi references and return its results. This
 is used for interlaced source and reference images.     
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcRefResultINTEL,__OpTypeAvcRefResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcRefResultINTEL,__OpTypeAvcRefResultINTEL__>># type.
 
-'Src Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
+_Src Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
 
-'Packed Reference Ids' must be an OpTypeInt with 32-bit Width and 0 Signedness, with the following bits specifying the values for the pair of reference images for each major partition.
+_Packed Reference Ids_ must be an OpTypeInt with 32-bit Width and 0 Signedness, with the following bits specifying the values for the pair of reference images for each major partition.
 
 [cols="1,2",tablepcwidth=55]
 !====================
@@ -2803,8 +2803,8 @@ is used for interlaced source and reference images.
 ! 31:28 ! Bwd reference block 3
 !====================
 
-A forward[backward] reference identifier value of 'n' indicates the forward[backward]
-image from the 'n'^th^ pair of forward/backward reference images, with the value of 'n'
+A forward[backward] reference identifier value of _n_ indicates the forward[backward]
+image from the _n_^th^ pair of forward/backward reference images, with the value of _n_
 ranging from 0 to 15.
 
 If the REF operation is configured with only forward reference images then, the
@@ -2816,10 +2816,10 @@ for block 0.
 
 [NOTE]
 ====
-The value for the 'Packed Reference Ids' is typically obtained by calling [blue]#<<bookmark-OpSubgroupAvcMceGetInterReferenceIdsINTEL,OpSubgroupAvcMceGetInterReferenceIdsINTEL>># for the preceding IME operation's result.
+The value for the _Packed Reference Ids_ is typically obtained by calling [blue]#<<bookmark-OpSubgroupAvcMceGetInterReferenceIdsINTEL,OpSubgroupAvcMceGetInterReferenceIdsINTEL>># for the preceding IME operation's result.
 ====
 
-'Packed Reference Field Polarities' must be an OpTypeInt with 8-bit Width and 0 Signedness. Reference field polarities for forward and backward reference images are specified for each of the allowed major partitions using it, with the following bits specifying the reference field polarities for the major partitions.
+_Packed Reference Field Polarities_ must be an OpTypeInt with 8-bit Width and 0 Signedness. Reference field polarities for forward and backward reference images are specified for each of the allowed major partitions using it, with the following bits specifying the reference field polarities for the major partitions.
 
 [cols="1,2",tablepcwidth=50]
 !====================
@@ -2840,7 +2840,7 @@ The blocks are numbered using the traditional Z order. For larger block sizes, t
 sub-block reference field polarities are replicated. For example, for a 16x16 block all
 four pairs of reference field polarities are replicated to the value of the first pair for block 0.   
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcRefPayloadINTEL,__OpTypeAvcRefPayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2857,9 +2857,9 @@ These are optional instructions that may be called following the evaluation phas
  +
 Convert the REF result to a generic MCE result.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcMceResultINTEL,__OpTypeAvcMceResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcMceResultINTEL,__OpTypeAvcMceResultINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcRefResultINTEL,__OpTypeAvcRefResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcRefResultINTEL,__OpTypeAvcRefResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2872,9 +2872,9 @@ Convert the REF result to a generic MCE result.
  +
 Convert the generic MCE result to a REF result.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcRefResultINTEL,__OpTypeAvcRefResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcRefResultINTEL,__OpTypeAvcRefResultINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcMceResultINTEL,__OpTypeAvcMceResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcMceResultINTEL,__OpTypeAvcMceResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2897,17 +2897,17 @@ These instructions create a properly initialized payload that can be used for fu
  +
 Return an initialized payload for a VME SIC operation.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
-'Src Coord' must be a vector(2) of i16 values and 0 Signedness. It represents the 2D offset of the top left corner of the source MB in pixel units in the source image. Source MBs at the image borders are allowed to be partial, but the top-left corner must be within the image.
+_Src Coord_ must be a vector(2) of i16 values and 0 Signedness. It represents the 2D offset of the top left corner of the source MB in pixel units in the source image. Source MBs at the image borders are allowed to be partial, but the top-left corner must be within the image.
 
 [IMPORTANT]
 ====
 . If the source image is an interlaced scan image, then the bottom field lines are
 considered as logically overlapping with the top field lines (i.e. the top field MBs
-are considered as logically overlapping with the bottom MBs) for the purposes for specifying the 'Src Coord' value.
+are considered as logically overlapping with the bottom MBs) for the purposes for specifying the _Src Coord_ value.
 
-. If the SIC operation is being configured for chroma based intra estimation, then the x and y coordinates of 'Src Coord' must be multiples of 2.
+. If the SIC operation is being configured for chroma based intra estimation, then the x and y coordinates of _Src Coord_ must be multiples of 2.
 ====
 
 | Capability: + 
@@ -2924,22 +2924,22 @@ are considered as logically overlapping with the bottom MBs) for the purposes fo
  +
 Configure the SIC payload for (uni or bi-directional) skip checks.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
-'Skip Block Partition Type' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to one of the specified partition mask values as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Skip Block Partition Type_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to one of the specified partition mask values as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
-'Skip Motion Vector Mask' must be an OpTypeInt with 32-bit Width and 0 Signedness. Legal values for it can be composed using the OpBitwiseOr instruction from the values defined for it as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#; both unidirectional and bidirectional skip vectors can be specified uniquely for each major partition (16x16 or 8x8) by an appropriate selection of the skip motion vector mask enumeration values. If the 16x16 'Skip Block Partition Type' is specified, then only the 16x16 enumeration values may be used, else only the 8x8 enumeration values may be used.
+_Skip Motion Vector Mask_ must be an OpTypeInt with 32-bit Width and 0 Signedness. Legal values for it can be composed using the OpBitwiseOr instruction from the values defined for it as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#; both unidirectional and bidirectional skip vectors can be specified uniquely for each major partition (16x16 or 8x8) by an appropriate selection of the skip motion vector mask enumeration values. If the 16x16 _Skip Block Partition Type_ is specified, then only the 16x16 enumeration values may be used, else only the 8x8 enumeration values may be used.
 
 [TIP]
 ====
 The instruction [blue]#<<bookmark-OpSubgroupAvcSicGetMotionVectorMask,OpSubgroupAvcSicGetMotionVectorMask>># may be used to set this operand's value.
 ====
 
-'Motion Vectors' must be an OpTypeInt with 64-bit Width and 0 Signedness, and specifies the input packed BMVs. Either the forward or backward is ignored if the setting in 'Skip Motion Vector Mask' is backward or forward respectively. If the setting is bidirectional, then both the forward and backward motion vectors will be used.  If the 'Skip Block Partition Type' is 16x16, work-item 0 in the subgroup provides the BMV, and if the 'Skip Block Partition Type' is 8x8, work-items 0 to 4 in the subgroup provide the four BMVs. The MVs are in QPEL units. The X and Y coordinates of each MV must be in the range [-2048.00, 2047.75] and [-512.00 to 511.75] respectively, otherwise the results are undefined.
+_Motion Vectors_ must be an OpTypeInt with 64-bit Width and 0 Signedness, and specifies the input packed BMVs. Either the forward or backward is ignored if the setting in _Skip Motion Vector Mask_ is backward or forward respectively. If the setting is bidirectional, then both the forward and backward motion vectors will be used.  If the _Skip Block Partition Type_ is 16x16, work-item 0 in the subgroup provides the BMV, and if the _Skip Block Partition Type_ is 8x8, work-items 0 to 4 in the subgroup provide the four BMVs. The MVs are in QPEL units. The X and Y coordinates of each MV must be in the range [-2048.00, 2047.75] and [-512.00 to 511.75] respectively, otherwise the results are undefined.
 
-'Bidirectional Weight' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid bidirectional weight value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.  If the setting is unidirectional, then the this parameter value is ignored and can be set to the value '0'.
+_Bidirectional Weight_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid bidirectional weight value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.  If the setting is unidirectional, then the this parameter value is ignored and can be set to the value _0_.
 
-'Sad Adjustment' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid sad adjustment value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Sad Adjustment_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid sad adjustment value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -2953,13 +2953,13 @@ The instruction [blue]#<<bookmark-OpSubgroupAvcSicGetMotionVectorMask,OpSubgroup
  +
 Return an initialized payload for a VME luma intra prediction estimation (IPE) operation.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
-'Luma Intra Partition Mask' must be an OpTypeInt with 8-bit Width and 0 Signedness, which can be composed from their respective values as per [blue]#<<bookmark-BF,Section 3, Binary Form>># using the OpBitwiseAnd instruction.
+_Luma Intra Partition Mask_ must be an OpTypeInt with 8-bit Width and 0 Signedness, which can be composed from their respective values as per [blue]#<<bookmark-BF,Section 3, Binary Form>># using the OpBitwiseAnd instruction.
 
-'Intra Neighbour Availabilty' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid intra neighbour availabilty value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Intra Neighbour Availabilty_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid intra neighbour availabilty value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
-'Left Edge Luma Pixels', 'Upper Left Corner Luma Pixel', 'Upper Edge Luma Pixels', 'Upper Right Edge Luma Pixels' must be an OpTypeInt with 8-bit Width and 0 Signedness, and specify the neighbor edge pixels for the left, top-left corner, top
+_Left Edge Luma Pixels_, _Upper Left Corner Luma Pixel_, _Upper Edge Luma Pixels_, _Upper Right Edge Luma Pixels_ must be an OpTypeInt with 8-bit Width and 0 Signedness, and specify the neighbor edge pixels for the left, top-left corner, top
 and top right edges with each work-item providing each pixel value. These pixels values are used to perform the intra mode estimation.
 
 For the left and top edge pixels, successive subgroup work-items 0 to 15 provide the
@@ -2967,7 +2967,7 @@ successive edge pixels. For the top-right edge, successive work-items 0 to 7 pro
 successive edge pixels; the pixel values in work-items 8 to 15 are ignored. The top-left
 corner pixel is a uniform pixel value with each work-item providing the same corner pixel.   
 
-'Sad Adjustment' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid sad adjustment value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Sad Adjustment_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid sad adjustment value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL* +
@@ -2981,13 +2981,13 @@ corner pixel is a uniform pixel value with each work-item providing the same cor
  +
 Return an initialized payload for a VME luma and chroma intra prediction estimation (IPE) operation.  
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
-'Luma Intra Partition Mask' must be an OpTypeInt with 8-bit Width and 0 Signedness, which can be composed from their respective values as per [blue]#<<bookmark-BF,Section 3, Binary Form>># using the OpBitwiseAnd instruction.
+_Luma Intra Partition Mask_ must be an OpTypeInt with 8-bit Width and 0 Signedness, which can be composed from their respective values as per [blue]#<<bookmark-BF,Section 3, Binary Form>># using the OpBitwiseAnd instruction.
 
-'Intra Neighbour Availabilty' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid intra neighbour availabilty value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Intra Neighbour Availabilty_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid intra neighbour availabilty value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
-'Left Edge Luma Pixels', 'Upper Left Corner Luma Pixel', 'Upper Edge Luma Pixels', 'Upper Right Edge Luma Pixels', 'Left Edge Chroma Pixels', 'Upper Left Corner Chroma Pixel', 'Upper Edge Chroma Pixels'  must be an OpTypeInt with 8-bit Width and 0 Signedness, and  specify the neighbor luma and chroma edge pixels for the left, top-left corner, top and top-right (luma only) edges with each work-item providing each pixel value. These pixels values are used to perform the intra mode estimation.  
+_Left Edge Luma Pixels_, _Upper Left Corner Luma Pixel_, _Upper Edge Luma Pixels_, _Upper Right Edge Luma Pixels_, _Left Edge Chroma Pixels_, _Upper Left Corner Chroma Pixel_, _Upper Edge Chroma Pixels_  must be an OpTypeInt with 8-bit Width and 0 Signedness, and  specify the neighbor luma and chroma edge pixels for the left, top-left corner, top and top-right (luma only) edges with each work-item providing each pixel value. These pixels values are used to perform the intra mode estimation.  
 
 For the left and top edge pixels, successive subgroup work-items 0 to 15 provide the
 successive edge pixels. For the top-right edge, successive work-items 0 to 7 provide the
@@ -2996,7 +2996,7 @@ corner pixel is a uniform pixel value with each work-item providing the same cor
 
 For the left and top chroma CbCr pixels, successive subgroup work-items 0 to 7 provide the successive CbCr pixels; the pixel values in work-items 8 to 15 are ignored. The top-left corner pixel is a uniform CbCr pixel value with each work-item providing the same corner CbCr pixel.   
 
-'Sad Adjustment' must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid sad adjustment value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Sad Adjustment_ must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid sad adjustment value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationChromaINTEL* +
@@ -3007,14 +3007,14 @@ For the left and top chroma CbCr pixels, successive subgroup work-items 0 to 7 p
 |=====
 5+|*OpSubgroupAvcSicGetMotionVectorMaskINTEL* +
  +
-Compose the value for the input argument 'Skip Motion Vector Mask' for the
-input 'Skip Block Partition Type' and direction.
+Compose the value for the input argument _Skip Motion Vector Mask_ for the
+input _Skip Block Partition Type_ and direction.
 
-'Result Type' must be an OpTypeInt with 32-bit Width and 0 Signedness.
+_Result Type_ must be an OpTypeInt with 32-bit Width and 0 Signedness.
 
-'Skip Block Partition Type' must be an OpTypeInt with 32-bit Width and 0 Signedness, which must evaluate to valid partition mask values for either 16x16 or 8x8 as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Skip Block Partition Type_ must be an OpTypeInt with 32-bit Width and 0 Signedness, which must evaluate to valid partition mask values for either 16x16 or 8x8 as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
-'Direction' must be an OpTypeInt with 8-bit Width and 0 Signedness. It is a bit field with the directions for the 4 8x8 sub-partitions in traditional Z order, or for only the 16x16 partition. Two bits are reserved for each of the four sub-partitions in row-major order.  The 2-bit values are as per the inter macro-block major direction values. If the 'Skip Block Partition Type' indicates a 16x16 shape, then only the 1^st^ 2 bits contains the direction, and other bits must be zeroed.  
+_Direction_ must be an OpTypeInt with 8-bit Width and 0 Signedness. It is a bit field with the directions for the 4 8x8 sub-partitions in traditional Z order, or for only the 16x16 partition. Two bits are reserved for each of the four sub-partitions in row-major order.  The 2-bit values are as per the inter macro-block major direction values. If the _Skip Block Partition Type_ indicates a 16x16 shape, then only the 1^st^ 2 bits contains the direction, and other bits must be zeroed.  
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -3031,9 +3031,9 @@ These are optional instructions that may be called following the search configur
  +
 Convert the SIC payload to a generic MCE payload.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -3046,9 +3046,9 @@ Convert the SIC payload to a generic MCE payload.
  +
 Convert the generic MCE payload to a SIC payload.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcMcePayloadINTEL,__OpTypeAvcMcePayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -3063,9 +3063,9 @@ Convert the generic MCE payload to a SIC payload.
  +
 Set the shape penalty for inter motion estimation.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
-'Packed Shape Penalty' must be a 32-bit scalar integer type. It is treated as an unsigned value. The following bits specify the shape penalty in U4U4 format:
+_Packed Shape Penalty_ must be a 32-bit scalar integer type. It is treated as an unsigned value. The following bits specify the shape penalty in U4U4 format:
 
 [cols="1,3",tablepcwidth=55]
 !====================
@@ -3077,7 +3077,7 @@ Set the shape penalty for inter motion estimation.
 
 The U4U4 decoded integer values for each of the bytes must fit within 12 bits.      
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -3093,11 +3093,11 @@ The U4U4 decoded integer values for each of the bytes must fit within 12 bits.
  +
 Update the payload to configure the luma mode cost function to be applied to the computed luma mode for SIC intra operations.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
-'Luma Mode Penalty' specifies the penalty to be applied to the estimated luma mode if it differs from its predicted luma mode (based on its neighbor intra modes). It is specified in U4U4 format and must bit in 10 bits.
+_Luma Mode Penalty_ specifies the penalty to be applied to the estimated luma mode if it differs from its predicted luma mode (based on its neighbor intra modes). It is specified in U4U4 format and must bit in 10 bits.
 
-'Luma Packed Neighbor Modes' specifies the values of the already computed top and left neighbor modes for the bordering 4x4 blocks, with the 4x4 blocks numbered in the traditional Z-order as shown
+_Luma Packed Neighbor Modes_ specifies the values of the already computed top and left neighbor modes for the bordering 4x4 blocks, with the 4x4 blocks numbered in the traditional Z-order as shown
 below.
 
     0 1 4 5
@@ -3119,7 +3119,7 @@ The following bits specify the neighbor modes.
 ! 31:28 ! Top neighbor block F
 !====================
 
-'Luma Packed Non Dc Penalty' specifies the penalty to be applied for any computed non-DC luma mode for each of the 16x16, 8x8, and 4x4 shapes, with the following bits specifying the penalties.
+_Luma Packed Non Dc Penalty_ specifies the penalty to be applied for any computed non-DC luma mode for each of the 16x16, 8x8, and 4x4 shapes, with the following bits specifying the penalties.
 
 [cols="1,2",tablepcwidth=55]
 !====================
@@ -3131,7 +3131,7 @@ The following bits specify the neighbor modes.
 
 The component byte values are specified in 8-bit integer format.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
 The intra distortion for each intra luma block can be described by the following formulas:
 
@@ -3166,9 +3166,9 @@ Luma_Non_Dc_16x16_Penalty(if not DC)
  +
 Update the payload to configure the intra chroma mode cost function by specifying the penalty to be applied to the computed chroma mode for SIC intra operations.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
-'Chroma Mode Base Penalty'  is the base penalty to be applied to the computed intra chroma modes. This penalty is in U4U4 format.
+_Chroma Mode Base Penalty_  is the base penalty to be applied to the computed intra chroma modes. This penalty is in U4U4 format.
 
 The U4U4 decoded integer value must fit in 12 bits.
 
@@ -3184,7 +3184,7 @@ The base penalty is scaled based on the computed mode as defined below.
 
 The component byte values are specified in 8-bit integer format.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
 The intra distortion for each intra 8x8 chroma block can be described by the following
 formula:
@@ -3219,9 +3219,9 @@ This should not be called if the payload was initialized with integer pixel reso
 
 Default is to enable it.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -3244,9 +3244,9 @@ emulate quantization's zeroing effect. The user is returned the count of coeffic
 
 This is valid only for SKC operations. 
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
-'Packed Sad Coefficients' must be an OpTypeInt with 64-bit Width and 0 Signedness, and spoecifies the SAD coefficient threshold matrix. The SAD coefficient threshold matrix for a 4x4 transform as shown in the table below is packed into a 64-bit integer. The low 16 bits contains the larger DC threshold. The coefficient thresholds for the remaining 6 AC thresholds in the order of increasing frequency are provided by the successive 8-bit bit ranges.
+_Packed Sad Coefficients_ must be an OpTypeInt with 64-bit Width and 0 Signedness, and spoecifies the SAD coefficient threshold matrix. The SAD coefficient threshold matrix for a 4x4 transform as shown in the table below is packed into a 64-bit integer. The low 16 bits contains the larger DC threshold. The coefficient thresholds for the remaining 6 AC thresholds in the order of increasing frequency are provided by the successive 8-bit bit ranges.
 
 [cols="1,1,1,1",tablepcwidth=70]
 !====================
@@ -3256,7 +3256,7 @@ This is valid only for SKC operations.
 ! 3 (AC) ! 4 (AC) ! 5 (AC) ! 6 (AC)
 !====================
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -3273,11 +3273,11 @@ SADs of the MB.
 It is valid to call this function only if the payload is configured for a skip check
 operation by a prior call to [blue]#<<bookmark-OpSubgroupAvcSicConfigureSkcINTEL,OpSubgroupAvcSicConfigureSkcINTEL>>.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
-'Block Based Skip Type' must be an OpTypeInt with 8-bit Width and 0 Signedness, that must evaluate to a valid block based skip type value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
+_Block Based Skip Type_ must be an OpTypeInt with 8-bit Width and 0 Signedness, that must evaluate to a valid block based skip type value as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -3294,11 +3294,11 @@ These instructions perform the evaluation of the SIC operation configured in the
  +
 Evaluate the SIC IPE operation and return its results. 
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
 
-'Src Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
+_Src Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL* +
@@ -3311,13 +3311,13 @@ Evaluate the SIC IPE operation and return its results.
  +
 Evaluate the SIC operation with single reference and return its results.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
 
-'Src Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
+_Src Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
 
-'Ref Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.   
+_Ref Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.   
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -3330,15 +3330,15 @@ Evaluate the SIC operation with single reference and return its results.
  +
 Evaluate the SIC operation with dual references and return its results.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
 
-'Src Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
+_Src Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
 
-'Fwd Ref Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.
+_Fwd Ref Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a forward reference image.
 
-'Bwd Ref Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a backward reference image.   
+_Bwd Ref Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies a backward reference image.   
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -3352,11 +3352,11 @@ Evaluate the SIC operation with dual references and return its results.
  +
 Evaluate the SIC operation with multi references and return its results.  
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
 
-'Src Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
+_Src Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
 
-'Packed Reference Ids' must be an OpTypeInt with 32-bit Width and 0 Signedness, with the following bits specifying the values for the pair of reference images for each major partition.
+_Packed Reference Ids_ must be an OpTypeInt with 32-bit Width and 0 Signedness, with the following bits specifying the values for the pair of reference images for each major partition.
 
 [cols="1,2",tablepcwidth=55]
 !====================
@@ -3370,8 +3370,8 @@ Evaluate the SIC operation with multi references and return its results.
 ! 31:28 ! Bwd reference block 3
 !====================
 
-A forward[backward] reference identifier value of 'n' indicates the forward[backward]
-image from the 'n'^th^ pair of forward/backward reference images, with the value of 'n'
+A forward[backward] reference identifier value of _n_ indicates the forward[backward]
+image from the _n_^th^ pair of forward/backward reference images, with the value of _n_
 ranging from 0 to 15.
 
 If the SIC operation is configured with only forward reference images then, the
@@ -3381,7 +3381,7 @@ The blocks are numbered using the traditional Z order. For larger block sizes, t
 sub-block reference identifier pairs must be replicated. For example, for a 16x16 block, all four pair of reference identifiers must be replicated to the value of the first pair
 for block 0.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -3395,11 +3395,11 @@ for block 0.
  +
 Evaluate the SIC operation with multi references and return its results. This is used for interlaced source and reference images.     
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
 
-'Src Image' is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
+_Src Image_ is an object whose type is an [blue]#<<bookmark-OpTypeVmeImageINTEL,__OpTypeVmeImageINTEL__>>#, and specifies the source image.  
 
-'Packed Reference Ids' must be an OpTypeInt with 32-bit Width and 0 Signedness, with the following bits specifying the values for the pair of reference images for each major partition.
+_Packed Reference Ids_ must be an OpTypeInt with 32-bit Width and 0 Signedness, with the following bits specifying the values for the pair of reference images for each major partition.
 
 [cols="1,2",tablepcwidth=55]
 !====================
@@ -3413,8 +3413,8 @@ Evaluate the SIC operation with multi references and return its results. This is
 ! 31:28 ! Bwd reference block 3
 !====================
 
-A forward[backward] reference identifier value of 'n' indicates the forward[backward]
-image from the 'n'^th^ pair of forward/backward reference images, with the value of 'n'
+A forward[backward] reference identifier value of _n_ indicates the forward[backward]
+image from the _n_^th^ pair of forward/backward reference images, with the value of _n_
 ranging from 0 to 15.
 
 If the SIC operation is configured with only forward reference images then, the
@@ -3426,10 +3426,10 @@ for block 0.
 
 [NOTE]
 ====
-The value for the 'Packed Reference Ids' is typically obtained by calling [blue]#<<bookmark-OpSubgroupAvcMceGetInterSicerenceIdsINTEL,OpSubgroupAvcMceGetInterSicerenceIdsINTEL>># for the preceding IME operation's result.
+The value for the _Packed Reference Ids_ is typically obtained by calling [blue]#<<bookmark-OpSubgroupAvcMceGetInterSicerenceIdsINTEL,OpSubgroupAvcMceGetInterSicerenceIdsINTEL>># for the preceding IME operation's result.
 ====
 
-'Packed Reference Field Polarities' must be an OpTypeInt with 8-bit Width and 0 Signedness. Reference field polarities for forward and backward reference images are specified for each of the allowed major partitions using it, with the following bits specifying the reference field polarities for the major partitions.
+_Packed Reference Field Polarities_ must be an OpTypeInt with 8-bit Width and 0 Signedness. Reference field polarities for forward and backward reference images are specified for each of the allowed major partitions using it, with the following bits specifying the reference field polarities for the major partitions.
 
 [cols="1,2",tablepcwidth=50]
 !====================
@@ -3450,7 +3450,7 @@ The blocks are numbered using the traditional Z order. For larger block sizes, t
 sub-block reference field polarities are replicated. For example, for a 16x16 block all
 four pairs of reference field polarities are replicated to the value of the first pair for block 0.   
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicPayloadINTEL,__OpTypeAvcSicPayloadINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -3467,9 +3467,9 @@ These are optional instructions that may be called following the evaluation phas
  +
 Convert the SIC result to a generic MCE result.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcMceResultINTEL,__OpTypeAvcMceResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcMceResultINTEL,__OpTypeAvcMceResultINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -3482,9 +3482,9 @@ Convert the SIC result to a generic MCE result.
  +
 Convert the generic MCE result to a SIC result.
 
-'Result Type' must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
+_Result Type_ must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcMceResultINTEL,__OpTypeAvcMceResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcMceResultINTEL,__OpTypeAvcMceResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -3504,9 +3504,9 @@ Return the best intra shape from the SIC result.
 
 The returned values are valid intra-MB shapes as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
-'Result Type' must be a OpTypeInt with 8-bit Width and 0 Signedness.
+_Result Type_ must be a OpTypeInt with 8-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL* +
@@ -3519,9 +3519,9 @@ The returned values are valid intra-MB shapes as per [blue]#<<bookmark-BF,Sectio
  +
 Return the best intra luma distortion for the shape return by [blue]#<<bookmark-OpSubgroupAvcSicGetIpeLumaShapeINTEL,__OpSubgroupAvcSicGetIpeLumaShapeINTEL__>>#  from the SIC result.  
 
-'Result Type' must be a OpTypeInt with 16-bit Width and 0 Signedness.
+_Result Type_ must be a OpTypeInt with 16-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL* +
@@ -3534,9 +3534,9 @@ Return the best intra luma distortion for the shape return by [blue]#<<bookmark-
  +
 Return the best intra chroma distortion for the 8x8 shape from the SIC result.  
 
-'Result Type' must be a OpTypeInt with 16-bit Width and 0 Signedness.
+_Result Type_ must be a OpTypeInt with 16-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
@@ -3566,9 +3566,9 @@ If the luma shape is:
    8 9 C D
    A B E F     
 
-'Result Type' must be a OpTypeInt with 64-bit Width and 0 Signedness.
+_Result Type_ must be a OpTypeInt with 64-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL* +
@@ -3583,9 +3583,9 @@ Return the intra chroma mode for the 8x8 block from the SIC result.
 
 The returned values are valid intra chroma modes as per [blue]#<<bookmark-BF,Section 3, Binary Form>>#.
 
-'Result Type' must be a OpTypeInt with 8-bit Width and 0 Signedness.
+_Result Type_ must be a OpTypeInt with 8-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationChromaINTEL* +
@@ -3607,9 +3607,9 @@ The format of the results is as follows:
 
 The results are only valid if the SIC operation was configured with frequency domain SAD transform coefficients using  [blue]#<<bookmark-OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL,__OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL__>>#  . 
 
-'Result Type' must be a OpTypeInt with 32-bit Width and 0 Signedness.
+_Result Type_ must be a OpTypeInt with 32-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL* +
@@ -3631,9 +3631,9 @@ The format of the results is as follows:
 
 The results are only valid if the SIC operation was configured with frequency domain SAD transform coefficients using  [blue]#<<bookmark-OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL,__OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL__>>#  . 
 
-'Result Type' must be a OpTypeInt with 64-bit Width and 0 Signedness.
+_Result Type_ must be a OpTypeInt with 64-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL* +
@@ -3646,9 +3646,9 @@ The results are only valid if the SIC operation was configured with frequency do
  +
 Return the skip check raw SAD (i.e. without any mode or shape costs included) for the entire MB if the input payload was note configured for block based skip checks, otherwise return the maximal SAD of individual 4x4 (or 8x8, if the block size for block based skip checking was configured as 8x8) blocks with the MB.    
 
-'Result Type' must be a OpTypeInt with 16-bit Width and 0 Signedness.
+_Result Type_ must be a OpTypeInt with 16-bit Width and 0 Signedness.
 
-'Payload' must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
+_Payload_ must be the [blue]#<<bookmark-OpTypeAvcSicResultINTEL,__OpTypeAvcSicResultINTEL__>># type.
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +

--- a/extensions/INTEL/SPV_INTEL_device_side_avc_motion_estimation.html
+++ b/extensions/INTEL/SPV_INTEL_device_side_avc_motion_estimation.html
@@ -1,863 +1,135 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta name="generator" content="AsciiDoc 8.6.9">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_device_side_avc_motion_estimation</title>
-<style type="text/css">
-/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
-
-/* Default font. */
-body {
-  font-family: Georgia,serif;
-}
-
-/* Title font. */
-h1, h2, h3, h4, h5, h6,
-div.title, caption.title,
-thead, p.table.header,
-#toctitle,
-#author, #revnumber, #revdate, #revremark,
-#footer {
-  font-family: Arial,Helvetica,sans-serif;
-}
-
-body {
-  margin: 1em 5% 1em 5%;
-}
-
-a {
-  color: blue;
-  text-decoration: underline;
-}
-a:visited {
-  color: fuchsia;
-}
-
-em {
-  font-style: italic;
-  color: navy;
-}
-
-strong {
-  font-weight: bold;
-  color: #083194;
-}
-
-h1, h2, h3, h4, h5, h6 {
-  color: #527bbd;
-  margin-top: 1.2em;
-  margin-bottom: 0.5em;
-  line-height: 1.3;
-}
-
-h1, h2, h3 {
-  border-bottom: 2px solid silver;
-}
-h2 {
-  padding-top: 0.5em;
-}
-h3 {
-  float: left;
-}
-h3 + * {
-  clear: left;
-}
-h5 {
-  font-size: 1.0em;
-}
-
-div.sectionbody {
-  margin-left: 0;
-}
-
-hr {
-  border: 1px solid silver;
-}
+<style>
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
 
 p {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
 }
 
-ul, ol, li > p {
-  margin-top: 0;
-}
-ul > li     { color: #aaa; }
-ul > li > * { color: black; }
-
-.monospaced, code, pre {
-  font-family: "Courier New", Courier, monospace;
-  font-size: inherit;
-  color: navy;
-  padding: 0;
-  margin: 0;
-}
-pre {
-  white-space: pre-wrap;
-}
-
-#author {
-  color: #527bbd;
-  font-weight: bold;
-  font-size: 1.1em;
-}
-#email {
-}
-#revnumber, #revdate, #revremark {
-}
-
-#footer {
-  font-size: small;
-  border-top: 2px solid silver;
-  padding-top: 0.5em;
-  margin-top: 4.0em;
-}
-#footer-text {
-  float: left;
-  padding-bottom: 0.5em;
-}
-#footer-badges {
-  float: right;
-  padding-bottom: 0.5em;
-}
-
-#preamble {
-  margin-top: 1.5em;
-  margin-bottom: 1.5em;
-}
-div.imageblock, div.exampleblock, div.verseblock,
-div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
-div.admonitionblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.admonitionblock {
-  margin-top: 2.0em;
-  margin-bottom: 2.0em;
-  margin-right: 10%;
-  color: #606060;
-}
-
-div.content { /* Block element content. */
-  padding: 0;
-}
-
-/* Block element titles. */
-div.title, caption.title {
-  color: #527bbd;
-  font-weight: bold;
-  text-align: left;
-  margin-top: 1.0em;
-  margin-bottom: 0.5em;
-}
-div.title + * {
-  margin-top: 0;
-}
-
-td div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content + div.title {
-  margin-top: 0.0em;
-}
-
-div.sidebarblock > div.content {
-  background: #ffffee;
-  border: 1px solid #dddddd;
-  border-left: 4px solid #f0f0f0;
-  padding: 0.5em;
-}
-
-div.listingblock > div.content {
-  border: 1px solid #dddddd;
-  border-left: 5px solid #f0f0f0;
-  background: #f8f8f8;
-  padding: 0.5em;
-}
-
-div.quoteblock, div.verseblock {
-  padding-left: 1.0em;
-  margin-left: 1.0em;
-  margin-right: 10%;
-  border-left: 5px solid #f0f0f0;
-  color: #888;
-}
-
-div.quoteblock > div.attribution {
-  padding-top: 0.5em;
-  text-align: right;
-}
-
-div.verseblock > pre.content {
-  font-family: inherit;
-  font-size: inherit;
-}
-div.verseblock > div.attribution {
-  padding-top: 0.75em;
-  text-align: left;
-}
-/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
-div.verseblock + div.attribution {
-  text-align: left;
-}
-
-div.admonitionblock .icon {
-  vertical-align: top;
-  font-size: 1.1em;
-  font-weight: bold;
-  text-decoration: underline;
-  color: #527bbd;
-  padding-right: 0.5em;
-}
-div.admonitionblock td.content {
-  padding-left: 0.5em;
-  border-left: 3px solid #dddddd;
-}
-
-div.exampleblock > div.content {
-  border-left: 3px solid #dddddd;
-  padding-left: 0.5em;
-}
-
-div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; vertical-align: text-bottom; }
-a.image:visited { color: white; }
-
-dl {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-dt {
-  margin-top: 0.5em;
-  margin-bottom: 0;
-  font-style: normal;
-  color: navy;
-}
-dd > *:first-child {
-  margin-top: 0.1em;
-}
-
-ul, ol {
-    list-style-position: outside;
-}
-ol.arabic {
-  list-style-type: decimal;
-}
-ol.loweralpha {
-  list-style-type: lower-alpha;
-}
-ol.upperalpha {
-  list-style-type: upper-alpha;
-}
-ol.lowerroman {
-  list-style-type: lower-roman;
-}
-ol.upperroman {
-  list-style-type: upper-roman;
-}
-
-div.compact ul, div.compact ol,
-div.compact p, div.compact p,
-div.compact div, div.compact div {
-  margin-top: 0.1em;
-  margin-bottom: 0.1em;
-}
-
-tfoot {
-  font-weight: bold;
-}
-td > div.verse {
-  white-space: pre;
-}
-
-div.hdlist {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-div.hdlist tr {
-  padding-bottom: 15px;
-}
-dt.hdlist1.strong, td.hdlist1.strong {
-  font-weight: bold;
-}
-td.hdlist1 {
-  vertical-align: top;
-  font-style: normal;
-  padding-right: 0.8em;
-  color: navy;
-}
-td.hdlist2 {
-  vertical-align: top;
-}
-div.hdlist.compact tr {
-  margin: 0;
-  padding-bottom: 0;
-}
-
-.comment {
-  background: yellow;
-}
-
-.footnote, .footnoteref {
-  font-size: 0.8em;
-}
-
-span.footnote, span.footnoteref {
-  vertical-align: super;
-}
-
-#footnotes {
-  margin: 20px 0 20px 0;
-  padding: 7px 0 0 0;
-}
-
-#footnotes div.footnote {
-  margin: 0 0 5px 0;
-}
-
-#footnotes hr {
-  border: none;
-  border-top: 1px solid silver;
-  height: 1px;
-  text-align: left;
-  margin-left: 0;
-  width: 20%;
-  min-width: 100px;
-}
-
-div.colist td {
-  padding-right: 0.5em;
-  padding-bottom: 0.3em;
-  vertical-align: top;
-}
-div.colist td img {
-  margin-top: 0.3em;
-}
-
-@media print {
-  #footer-badges { display: none; }
-}
-
-#toc {
-  margin-bottom: 2.5em;
-}
-
-#toctitle {
-  color: #527bbd;
-  font-size: 1.1em;
-  font-weight: bold;
-  margin-top: 1.0em;
-  margin-bottom: 0.1em;
-}
-
-div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-div.toclevel2 {
-  margin-left: 2em;
-  font-size: 0.9em;
-}
-div.toclevel3 {
-  margin-left: 4em;
-  font-size: 0.9em;
-}
-div.toclevel4 {
-  margin-left: 6em;
-  font-size: 0.9em;
-}
-
-span.aqua { color: aqua; }
-span.black { color: black; }
-span.blue { color: blue; }
-span.fuchsia { color: fuchsia; }
-span.gray { color: gray; }
-span.green { color: green; }
-span.lime { color: lime; }
-span.maroon { color: maroon; }
-span.navy { color: navy; }
-span.olive { color: olive; }
-span.purple { color: purple; }
-span.red { color: red; }
-span.silver { color: silver; }
-span.teal { color: teal; }
-span.white { color: white; }
-span.yellow { color: yellow; }
-
-span.aqua-background { background: aqua; }
-span.black-background { background: black; }
-span.blue-background { background: blue; }
-span.fuchsia-background { background: fuchsia; }
-span.gray-background { background: gray; }
-span.green-background { background: green; }
-span.lime-background { background: lime; }
-span.maroon-background { background: maroon; }
-span.navy-background { background: navy; }
-span.olive-background { background: olive; }
-span.purple-background { background: purple; }
-span.red-background { background: red; }
-span.silver-background { background: silver; }
-span.teal-background { background: teal; }
-span.white-background { background: white; }
-span.yellow-background { background: yellow; }
-
-span.big { font-size: 2em; }
-span.small { font-size: 0.6em; }
-
-span.underline { text-decoration: underline; }
-span.overline { text-decoration: overline; }
-span.line-through { text-decoration: line-through; }
-
-div.unbreakable { page-break-inside: avoid; }
-
-
-/*
- * xhtml11 specific
- *
- * */
-
-div.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.tableblock > table {
-  border: 3px solid #527bbd;
-}
-thead, p.table.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.table {
-  margin-top: 0;
-}
-/* Because the table frame attribute is overriden by CSS in most browsers. */
-div.tableblock > table[frame="void"] {
-  border-style: none;
-}
-div.tableblock > table[frame="hsides"] {
-  border-left-style: none;
-  border-right-style: none;
-}
-div.tableblock > table[frame="vsides"] {
-  border-top-style: none;
-  border-bottom-style: none;
-}
-
-
-/*
- * html5 specific
- *
- * */
-
-table.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-thead, p.tableblock.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.tableblock {
-  margin-top: 0;
-}
-table.tableblock {
-  border-width: 3px;
-  border-spacing: 0px;
-  border-style: solid;
-  border-color: #527bbd;
-  border-collapse: collapse;
-}
-th.tableblock, td.tableblock {
-  border-width: 1px;
-  padding: 4px;
-  border-style: solid;
-  border-color: #527bbd;
-}
-
-table.tableblock.frame-topbot {
-  border-left-style: hidden;
-  border-right-style: hidden;
-}
-table.tableblock.frame-sides {
-  border-top-style: hidden;
-  border-bottom-style: hidden;
-}
-table.tableblock.frame-none {
-  border-style: hidden;
-}
-
-th.tableblock.halign-left, td.tableblock.halign-left {
-  text-align: left;
-}
-th.tableblock.halign-center, td.tableblock.halign-center {
-  text-align: center;
-}
-th.tableblock.halign-right, td.tableblock.halign-right {
-  text-align: right;
-}
-
-th.tableblock.valign-top, td.tableblock.valign-top {
-  vertical-align: top;
-}
-th.tableblock.valign-middle, td.tableblock.valign-middle {
-  vertical-align: middle;
-}
-th.tableblock.valign-bottom, td.tableblock.valign-bottom {
-  vertical-align: bottom;
-}
-
-
-/*
- * manpage specific
- *
- * */
-
-body.manpage h1 {
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
-  border-top: 2px solid silver;
-  border-bottom: 2px solid silver;
-}
-body.manpage h2 {
-  border-style: none;
-}
-body.manpage div.sectionbody {
-  margin-left: 3em;
-}
-
-@media print {
-  body.manpage div#toc { display: none; }
-}
-
-
-@media screen {
-  body {
-    max-width: 50em; /* approximately 80 characters wide */
-    margin-left: 16em;
-  }
-
-  #toc {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 13em;
-    padding: 0.5em;
-    padding-bottom: 1.5em;
-    margin: 0;
-    overflow: auto;
-    border-right: 3px solid #f8f8f8;
-    background-color: white;
-  }
-
-  #toc .toclevel1 {
-    margin-top: 0.5em;
-  }
-
-  #toc .toclevel2 {
-    margin-top: 0.25em;
-    display: list-item;
-    color: #aaaaaa;
-  }
-
-  #toctitle {
-    margin-top: 0.5em;
-  }
-}
 </style>
-<script type="text/javascript">
-/*<![CDATA[*/
-var asciidoc = {  // Namespace.
-
-/////////////////////////////////////////////////////////////////////
-// Table Of Contents generator
-/////////////////////////////////////////////////////////////////////
-
-/* Author: Mihai Bazon, September 2002
- * http://students.infoiasi.ro/~mishoo
- *
- * Table Of Content generator
- * Version: 0.4
- *
- * Feel free to use this script under the terms of the GNU General Public
- * License, as long as you do not remove or alter this notice.
- */
-
- /* modified by Troy D. Hanson, September 2006. License: GPL */
- /* modified by Stuart Rackham, 2006, 2009. License: GPL */
-
-// toclevels = 1..4.
-toc: function (toclevels) {
-
-  function getText(el) {
-    var text = "";
-    for (var i = el.firstChild; i != null; i = i.nextSibling) {
-      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
-        text += i.data;
-      else if (i.firstChild != null)
-        text += getText(i);
-    }
-    return text;
-  }
-
-  function TocEntry(el, text, toclevel) {
-    this.element = el;
-    this.text = text;
-    this.toclevel = toclevel;
-  }
-
-  function tocEntries(el, toclevels) {
-    var result = new Array;
-    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
-    // Function that scans the DOM tree for header elements (the DOM2
-    // nodeIterator API would be a better technique but not supported by all
-    // browsers).
-    var iterate = function (el) {
-      for (var i = el.firstChild; i != null; i = i.nextSibling) {
-        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
-          var mo = re.exec(i.tagName);
-          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
-            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
-          }
-          iterate(i);
-        }
-      }
-    }
-    iterate(el);
-    return result;
-  }
-
-  var toc = document.getElementById("toc");
-  if (!toc) {
-    return;
-  }
-
-  // Delete existing TOC entries in case we're reloading the TOC.
-  var tocEntriesToRemove = [];
-  var i;
-  for (i = 0; i < toc.childNodes.length; i++) {
-    var entry = toc.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div'
-     && entry.getAttribute("class")
-     && entry.getAttribute("class").match(/^toclevel/))
-      tocEntriesToRemove.push(entry);
-  }
-  for (i = 0; i < tocEntriesToRemove.length; i++) {
-    toc.removeChild(tocEntriesToRemove[i]);
-  }
-
-  // Rebuild TOC entries.
-  var entries = tocEntries(document.getElementById("content"), toclevels);
-  for (var i = 0; i < entries.length; ++i) {
-    var entry = entries[i];
-    if (entry.element.id == "")
-      entry.element.id = "_toc_" + i;
-    var a = document.createElement("a");
-    a.href = "#" + entry.element.id;
-    a.appendChild(document.createTextNode(entry.text));
-    var div = document.createElement("div");
-    div.appendChild(a);
-    div.className = "toclevel" + entry.toclevel;
-    toc.appendChild(div);
-  }
-  if (entries.length == 0)
-    toc.parentNode.removeChild(toc);
-},
-
-
-/////////////////////////////////////////////////////////////////////
-// Footnotes generator
-/////////////////////////////////////////////////////////////////////
-
-/* Based on footnote generation code from:
- * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
- */
-
-footnotes: function () {
-  // Delete existing footnote entries in case we're reloading the footnodes.
-  var i;
-  var noteholder = document.getElementById("footnotes");
-  if (!noteholder) {
-    return;
-  }
-  var entriesToRemove = [];
-  for (i = 0; i < noteholder.childNodes.length; i++) {
-    var entry = noteholder.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
-      entriesToRemove.push(entry);
-  }
-  for (i = 0; i < entriesToRemove.length; i++) {
-    noteholder.removeChild(entriesToRemove[i]);
-  }
-
-  // Rebuild footnote entries.
-  var cont = document.getElementById("content");
-  var spans = cont.getElementsByTagName("span");
-  var refs = {};
-  var n = 0;
-  for (i=0; i<spans.length; i++) {
-    if (spans[i].className == "footnote") {
-      n++;
-      var note = spans[i].getAttribute("data-note");
-      if (!note) {
-        // Use [\s\S] in place of . so multi-line matches work.
-        // Because JavaScript has no s (dotall) regex flag.
-        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
-        spans[i].innerHTML =
-          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-        spans[i].setAttribute("data-note", note);
-      }
-      noteholder.innerHTML +=
-        "<div class='footnote' id='_footnote_" + n + "'>" +
-        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
-        n + "</a>. " + note + "</div>";
-      var id =spans[i].getAttribute("id");
-      if (id != null) refs["#"+id] = n;
-    }
-  }
-  if (n == 0)
-    noteholder.parentNode.removeChild(noteholder);
-  else {
-    // Process footnoterefs.
-    for (i=0; i<spans.length; i++) {
-      if (spans[i].className == "footnoteref") {
-        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
-        href = href.match(/#.*/)[0];  // Because IE return full URL.
-        n = refs[href];
-        spans[i].innerHTML =
-          "[<a href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-      }
-    }
-  }
-},
-
-install: function(toclevels) {
-  var timerId;
-
-  function reinstall() {
-    asciidoc.footnotes();
-    if (toclevels) {
-      asciidoc.toc(toclevels);
-    }
-  }
-
-  function reinstallAndRemoveTimer() {
-    clearInterval(timerId);
-    reinstall();
-  }
-
-  timerId = setInterval(reinstall, 500);
-  if (document.addEventListener)
-    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
-  else
-    window.onload = reinstallAndRemoveTimer;
-}
-
-}
-asciidoc.install(1);
-/*]]>*/
-</script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_device_side_avc_motion_estimation</h1>
-<div id="toc">
-  <div id="toctitle">Table of Contents</div>
-  <noscript><p><b>JavaScript must be enabled in your browser to display the table of contents.</b></p></noscript>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_new_instructions">New Instructions</a></li>
+<li><a href="#_new_types">New Types</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_2">Modifications to the SPIR-V Specification, Version 1.2</a></li>
+<li><a href="#_validation_rules">Validation Rules</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
 </div>
 </div>
 <div id="content">
 <div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>SPV_INTEL_device_side_avc_motion_estimation</p></div>
+<div class="paragraph">
+<p>SPV_INTEL_device_side_avc_motion_estimation</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>To report problems with this extension, please open a new issue at:</p></div>
-<div class="paragraph"><p><a href="https://github.com/KhronosGroup/SPIRV-Registry">https://github.com/KhronosGroup/SPIRV-Registry</a></p></div>
+<div class="paragraph">
+<p>To report problems with this extension, please open a new issue at:</p>
+</div>
+<div class="paragraph">
+<p><a href="https://github.com/KhronosGroup/SPIRV-Registry" class="bare">https://github.com/KhronosGroup/SPIRV-Registry</a></p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Biju George, Intel<br>
-</p>
+<p>Biju George, Intel<br></p>
 </li>
 <li>
-<p>
-Ben Ashbaugh, Intel<br>
-</p>
+<p>Ben Ashbaugh, Intel<br></p>
 </li>
 <li>
-<p>
-Kristina Bessonova, Intel<br>
-</p>
+<p>Kristina Bessonova, Intel<br></p>
 </li>
 <li>
-<p>
-Pawel Jurek, Intel<br>
-</p>
+<p>Pawel Jurek, Intel<br></p>
 </li>
 <li>
-<p>
-Alexey Sachkov, Intel<br>
-</p>
+<p>Alexey Sachkov, Intel<br></p>
 </li>
 <li>
-<p>
-Alexey Sotkin, Intel<br>
-</p>
+<p>Alexey Sotkin, Intel<br></p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Copyright (c) 2018 Intel Corporation.  All rights reserved.</p></div>
+<div class="paragraph">
+<p>Copyright (c) 2018 Intel Corporation.  All rights reserved.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Final Draft
-</p>
+<p>Final Draft</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all"
-style="
-width:40%;
-">
-<col style="width:50%;">
-<col style="width:50%;">
+<table class="tableblock frame-all grid-all" style="width: 40%;">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2018-11-20</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-21</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
 </tr>
 </tbody>
 </table>
@@ -866,96 +138,106 @@ width:40%;
 <div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension is written against the SPIR-V Specification,
-Version 1.2 Revision 1.</p></div>
-<div class="paragraph"><p>This extension requires SPIR-V 1.0.</p></div>
+<div class="paragraph">
+<p>This extension is written against the SPIR-V Specification,
+Version 1.2 Revision 1.</p>
+</div>
+<div class="paragraph">
+<p>This extension requires SPIR-V 1.0.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Video motion estimation (VME) is defined as of set motion estimation operations that are used to determine the motion vectors, intra estimation angles and macroblock partitioning combination that best describe the transformation to the source macroblock, from blocks in one or more previous reference pictures (inter-prediction), or from other blocks in the same source picture (intra-prediction). It does this by searching for spatial and temporal patterns on the current and various forward and backward reference pictures.</p></div>
-<div class="paragraph"><p>The goal of this extension is to provide programmers with a fine-grained interface to the AVC VME media sampler in Intel graphics processors. It describes the specification of instructions that facilitate the programming of the VME media sampler to evaluate specific AVC motion estimation operations.</p></div>
-<div class="paragraph"><p>Instructions are defined for all the major operations of the VME media sampler. The major operations of the AVC VME media sampler in Intel Graphics Processors can be described as follows:</p></div>
-<div class="olist arabic"><ol class="arabic">
+<div class="paragraph">
+<p>Video motion estimation (VME) is defined as of set motion estimation operations that are used to determine the motion vectors, intra estimation angles and macroblock partitioning combination that best describe the transformation to the source macroblock, from blocks in one or more previous reference pictures (inter-prediction), or from other blocks in the same source picture (intra-prediction). It does this by searching for spatial and temporal patterns on the current and various forward and backward reference pictures.</p>
+</div>
+<div class="paragraph">
+<p>The goal of this extension is to provide programmers with a fine-grained interface to the AVC VME media sampler in Intel graphics processors. It describes the specification of instructions that facilitate the programming of the VME media sampler to evaluate specific AVC motion estimation operations.</p>
+</div>
+<div class="paragraph">
+<p>Instructions are defined for all the major operations of the VME media sampler. The major operations of the AVC VME media sampler in Intel Graphics Processors can be described as follows:</p>
+</div>
+<div class="olist arabic">
+<ol class="arabic">
 <li>
-<p>
-<strong>Integer motion estimation (IME)</strong><br>
-    Perform motion estimation on a given source macroblock in a source image over a single or dual reference window in a reference image, at full-pixel resolution, to determine the best integer motion vectors and their associated distortions, and the best macroblock shape partitioning combination.
-</p>
+<p><strong>Integer motion estimation (IME)</strong><br>
+Perform motion estimation on a given source macroblock in a source image over a single or dual reference window in a reference image, at full-pixel resolution, to determine the best integer motion vectors and their associated distortions, and the best macroblock shape partitioning combination.</p>
 </li>
 <li>
-<p>
-<strong>Motion estimation refinement (REF)</strong><br>
-    Perform refinement operations on the results of IME. The two sub-operations are:
-</p>
-<div class="ulist"><ul>
+<p><strong>Motion estimation refinement (REF)</strong><br>
+Perform refinement operations on the results of IME. The two sub-operations are:</p>
+<div class="ulist">
+<ul>
 <li>
-<p>
-<strong>Fractional motion estimation (FME)</strong><br>
-    Perform sub-pixel refinement on the results of an IME operation. Half-pixel (HPEL) or quarter-pixel (QPEL) refinements are performed to determine the best sub-pixel motion vectors and their associated distortions.
-</p>
+<p><strong>Fractional motion estimation (FME)</strong><br>
+Perform sub-pixel refinement on the results of an IME operation. Half-pixel (HPEL) or quarter-pixel (QPEL) refinements are performed to determine the best sub-pixel motion vectors and their associated distortions.</p>
 </li>
 <li>
-<p>
-<strong>Bidirectional motion estimation (BME)</strong><br>
-    Perform bidirectional refinement on the results of an IME     operation using two reference images to check if the bidirectional mode using two references yields lesser distortions. An FME can optionally be performed implicitly as part of a bidirectional refinement.
-</p>
+<p><strong>Bidirectional motion estimation (BME)</strong><br>
+Perform bidirectional refinement on the results of an IME     operation using two reference images to check if the bidirectional mode using two references yields lesser distortions. An FME can optionally be performed implicitly as part of a bidirectional refinement.</p>
 </li>
-</ul></div>
-</li>
-<li>
-<p>
-<strong>Skip and Intra check (SIC)</strong><br>
-    Performs the following two sub-operations:
-</p>
-<div class="ulist"><ul>
-<li>
-<p>
-<strong>Skip check (SKC)</strong><br>
-    Compute the pixel distortion of a user-specified shape and motion vector combination. The VME media sampler fetches necessary pixels, performs fractional and bidirectional filtering (as necessary), and then computes the distortion between the derived reference and source. The skip decision can optionally be enhanced to include a 4x4 forward transform, the results of which are compared against a user specified threshold to emulate the effects of the forward quantization zeroing effect.
-</p>
+</ul>
+</div>
 </li>
 <li>
-<p>
-<strong>Intra prediction estimation (IPE)</strong><br>
-    Perform intra prediction on a given source macroblock to determine the best intra prediction modes and the best shape partitioning combination.
-</p>
+<p><strong>Skip and Intra check (SIC)</strong><br>
+Performs the following two sub-operations:</p>
+<div class="ulist">
+<ul>
+<li>
+<p><strong>Skip check (SKC)</strong><br>
+Compute the pixel distortion of a user-specified shape and motion vector combination. The VME media sampler fetches necessary pixels, performs fractional and bidirectional filtering (as necessary), and then computes the distortion between the derived reference and source. The skip decision can optionally be enhanced to include a 4x4 forward transform, the results of which are compared against a user specified threshold to emulate the effects of the forward quantization zeroing effect.</p>
 </li>
-</ul></div>
+<li>
+<p><strong>Intra prediction estimation (IPE)</strong><br>
+Perform intra prediction on a given source macroblock to determine the best intra prediction modes and the best shape partitioning combination.</p>
 </li>
-</ol></div>
+</ul>
+</div>
+</li>
+</ol>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_extension_name">Extension Name</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>To use this extension within a SPIR-V module, the appropriate <strong>OpExtension</strong> must be present in the module:</p></div>
+<div class="paragraph">
+<p>To use this extension within a SPIR-V module, the appropriate <strong>OpExtension</strong> must be present in the module:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpExtension "SPV_INTEL_device_side_avc_motion_estimation"</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_capabilities">New Capabilities</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension introduces new capabilities:</p></div>
+<div class="paragraph">
+<p>This extension introduces new capabilities:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>SubgroupAvcMotionEstimationINTEL
 SubgroupAvcMotionEstimationIntraINTEL
 SubgroupAvcMotionEstimationChromaINTEL</pre>
-</div></div>
-<div style="page-break-after:always"></div>
+</div>
+</div>
+<div style="page-break-after: always;"></div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_instructions">New Instructions</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Instructions added under the <strong>SubgroupAvcMotionEstimationINTEL</strong> capability (some are additionally defined under the <strong>SubgroupAvcMotionEstimationIntraINTEL</strong> or <strong>SubgroupAvcMotionEstimationChromaINTEL</strong> capability):</p></div>
+<div class="paragraph">
+<p>Instructions added under the <strong>SubgroupAvcMotionEstimationINTEL</strong> capability (some are additionally defined under the <strong>SubgroupAvcMotionEstimationIntraINTEL</strong> or <strong>SubgroupAvcMotionEstimationChromaINTEL</strong> capability):</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpSubgroupAvcMceGetDefaultInterBaseMultiReferencePenaltyINTEL
 OpSubgroupAvcMceSetInterBaseMultiReferencePenaltyINTEL
 OpSubgroupAvcMceGetDefaultInterShapePenaltyINTEL
@@ -990,9 +272,10 @@ OpSubgroupAvcMceGetInterDirectionsINTEL
 OpSubgroupAvcMceGetInterMotionVectorCountINTEL
 OpSubgroupAvcMceGetInterReferenceIdsINTEL
 OpSubgroupAvcMceGetInterReferenceInterlacedFieldPolaritiesINTEL</pre>
-</div></div>
+</div>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpVmeImageINTEL
 OpSubgroupAvcImeInitializeINTEL
 OpSubgroupAvcImeSetSingleReferenceINTEL
@@ -1026,9 +309,10 @@ OpSubgroupAvcImeGetTruncatedSearchIndicationINTEL
 OpSubgroupAvcImeGetUnidirectionalEarlySearchTerminationINTEL
 OpSubgroupAvcImeGetWeightingPatternMinimumMotionVectorINTEL
 OpSubgroupAvcImeGetWeightingPatternMinimumDistortionINTEL</pre>
-</div></div>
+</div>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpSubgroupAvcFmeInitializeINTEL
 OpSubgroupAvcBmeInitializeINTEL
 OpSubgroupAvcRefConvertToMcePayloadINTEL
@@ -1039,9 +323,10 @@ OpSubgroupAvcRefEvaluateWithDualReferenceINTEL
 OpSubgroupAvcRefEvaluateWithMultiReferenceINTEL
 OpSubgroupAvcRefEvaluateWithMultiReferenceInterlacedINTEL
 OpSubgroupAvcRefConvertToMceResultINTEL</pre>
-</div></div>
+</div>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpSubgroupAvcSicInitializeINTEL
 OpSubgroupAvcSicConfigureSkcINTEL
 OpSubgroupAvcSicConfigureIpeLumaINTEL
@@ -1068,16 +353,19 @@ OpSubgroupAvcSicGetIpeChromaModeINTEL
 OpSubgroupAvcSicGetPackedSkcLumaCountThresholdINTEL
 OpSubgroupAvcSicGetPackedSkcLumaSumThresholdINTEL
 OpSubgroupAvcSicGetInterRawSadsINTEL</pre>
-</div></div>
-<div style="page-break-after:always"></div>
+</div>
+</div>
+<div style="page-break-after: always;"></div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_types">New Types</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Opaque Types added under the <strong>SubgroupAvcMotionEstimationINTEL</strong> capability:</p></div>
+<div class="paragraph">
+<p>Opaque Types added under the <strong>SubgroupAvcMotionEstimationINTEL</strong> capability:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpTypeVmeImageINTEL
 OpTypeAvcMcePayloadINTEL
 OpTypeAvcImePayloadINTEL
@@ -1091,495 +379,497 @@ OpTypeAvcImeSingleReferenceStreaminINTEL
 OpTypeAvcImeDualReferenceStreaminINTEL
 OpTypeAvcRefResultINTEL
 OpTypeAvcSicResultINTEL</pre>
-</div></div>
-<div style="page-break-after:always"></div>
+</div>
+</div>
+<div style="page-break-after: always;"></div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:40%;
-">
-<col style="width:70%;">
-<col style="width:30%;">
+<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<colgroup>
+<col style="width: 70%;">
+<col style="width: 30%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">OpVmeImageINTEL</th>
+<th class="tableblock halign-left valign-top">5699</th>
+</tr>
+</thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpVmeImageINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5699</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpTypeVmeImageINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5700</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpTypeVmeImageINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5700</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpTypeAvcImePayloadINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5701</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpTypeAvcImePayloadINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5701</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpTypeAvcRefPayloadINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5702</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpTypeAvcRefPayloadINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5702</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpTypeAvcSicPayloadINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5703</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpTypeAvcSicPayloadINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5703</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpTypeAvcMcePayloadINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5704</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpTypeAvcMcePayloadINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5704</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpTypeAvcMceResultINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5705</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpTypeAvcMceResultINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5705</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpTypeAvcImeResultINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5706</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpTypeAvcImeResultINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5706</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpTypeAvcImeResultSingleReferenceStreamoutINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5707</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpTypeAvcImeResultSingleReferenceStreamoutINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5707</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpTypeAvcImeResultDualReferenceStreamoutINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5708</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpTypeAvcImeResultDualReferenceStreamoutINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5708</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpTypeAvcImeSingleReferenceStreaminINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5709</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpTypeAvcImeSingleReferenceStreaminINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5709</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpTypeAvcImeDualReferenceStreaminINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5710</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpTypeAvcImeDualReferenceStreaminINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5710</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpTypeAvcRefResultINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5711</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpTypeAvcRefResultINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5711</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpTypeAvcSicResultINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5712</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpTypeAvcSicResultINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5712</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceGetDefaultInterBaseMultiReferencePenaltyINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5713</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceGetDefaultInterBaseMultiReferencePenaltyINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5713</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceSetInterBaseMultiReferencePenaltyINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5714</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceSetInterBaseMultiReferencePenaltyINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5714</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceGetDefaultInterShapePenaltyINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5715</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceGetDefaultInterShapePenaltyINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5715</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceSetInterShapePenaltyINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5716</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceSetInterShapePenaltyINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5716</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceGetDefaultInterDirectionPenaltyINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5717</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceGetDefaultInterDirectionPenaltyINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5717</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceSetInterDirectionPenaltyINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5718</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceSetInterDirectionPenaltyINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5718</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceGetDefaultIntraLumaShapePenaltyINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5719</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceGetDefaultIntraLumaShapePenaltyINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5719</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceGetDefaultInterMotionVectorCostTableINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5720</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceGetDefaultInterMotionVectorCostTableINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5720</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceGetDefaultHighPenaltyCostTableINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5721</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceGetDefaultHighPenaltyCostTableINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5721</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceGetDefaultMediumPenaltyCostTableINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5722</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceGetDefaultMediumPenaltyCostTableINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5722</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceGetDefaultLowPenaltyCostTableINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5723</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceGetDefaultLowPenaltyCostTableINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5723</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceSetMotionVectorCostFunctionINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5724</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceSetMotionVectorCostFunctionINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5724</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceGetDefaultIntraLumaModePenaltyINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5725</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceGetDefaultIntraLumaModePenaltyINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5725</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceGetDefaultNonDcLumaIntraPenaltyINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5726</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceGetDefaultNonDcLumaIntraPenaltyINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5726</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceGetDefaultIntraChromaModeBasePenaltyINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5727</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceGetDefaultIntraChromaModeBasePenaltyINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5727</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceSetAcOnlyHaarINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5728</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceSetAcOnlyHaarINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5728</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceSetSourceInterlacedFieldPolarityINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5729</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceSetSourceInterlacedFieldPolarityINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5729</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceSetSingleReferenceInterlacedFieldPolarityINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5730</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceSetSingleReferenceInterlacedFieldPolarityINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5730</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceSetDualReferenceInterlacedFieldPolaritiesINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5731</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceSetDualReferenceInterlacedFieldPolaritiesINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5731</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceConvertToImePayloadINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5732</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceConvertToImePayloadINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5732</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceConvertToImeResultINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5733</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceConvertToImeResultINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5733</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceConvertToRefPayloadINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5734</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceConvertToRefPayloadINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5734</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceConvertToRefResultINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5735</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceConvertToRefResultINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5735</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceConvertToSicPayloadINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5736</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceConvertToSicPayloadINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5736</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceConvertToSicResultINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5737</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceConvertToSicResultINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5737</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceGetMotionVectorsINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5738</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceGetMotionVectorsINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5738</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceGetInterDistortionsINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5739</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceGetInterDistortionsINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5739</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceGetBestInterDistortionsINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5740</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceGetBestInterDistortionsINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5740</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceGetInterMajorShapeINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5741</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceGetInterMajorShapeINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5741</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceGetInterMinorShapeINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5742</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceGetInterMinorShapeINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5742</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceGetInterDirectionsINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5743</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceGetInterDirectionsINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5743</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceGetInterMotionVectorCountINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5744</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceGetInterMotionVectorCountINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5744</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceGetInterReferenceIdsINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5745</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceGetInterReferenceIdsINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5745</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcMceGetInterReferenceInterlacedFieldPolaritiesINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5746</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcMceGetInterReferenceInterlacedFieldPolaritiesINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5746</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeInitializeINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5747</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeInitializeINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5747</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeSetSingleReferenceINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5748</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeSetSingleReferenceINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5748</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeSetDualReferenceINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5749</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeSetDualReferenceINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5749</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeRefWindowSizeINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5750</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeRefWindowSizeINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5750</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeAdjustRefOffsetINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5751</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeAdjustRefOffsetINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5751</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeConvertToMcePayloadINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5752</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeConvertToMcePayloadINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5752</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeSetMaxMotionVectorCountINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5753</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeSetMaxMotionVectorCountINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5753</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeSetUnidirectionalMixDisableINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5754</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeSetUnidirectionalMixDisableINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5754</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeSetEarlySearchTerminationThresholdINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5755</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeSetEarlySearchTerminationThresholdINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5755</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeSetWeightedSadINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5756</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeSetWeightedSadINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5756</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeEvaluateWithSingleReferenceINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5757</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeEvaluateWithSingleReferenceINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5757</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeEvaluateWithDualReferenceINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5758</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeEvaluateWithDualReferenceINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5758</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeEvaluateWithSingleReferenceStreaminINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5759</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeEvaluateWithSingleReferenceStreaminINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5759</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcImeEvaluateWithDualReferenceStreaminINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5760</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcImeEvaluateWithDualReferenceStreaminINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5760</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeEvaluateWithSingleReferenceStreamoutINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5761</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeEvaluateWithSingleReferenceStreamoutINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5761</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeEvaluateWithDualReferenceStreamoutINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5762</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeEvaluateWithDualReferenceStreamoutINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5762</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeEvaluateWithSingleReferenceStreaminoutINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5763</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeEvaluateWithSingleReferenceStreaminoutINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5763</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeEvaluateWithDualReferenceStreaminoutINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5764</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeEvaluateWithDualReferenceStreaminoutINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5764</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeConvertToMceResultINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5765</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeConvertToMceResultINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5765</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeGetSingleReferenceStreaminINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5766</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeGetSingleReferenceStreaminINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5766</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeGetDualReferenceStreaminINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5767</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeGetDualReferenceStreaminINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5767</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcImeStripSingleReferenceStreamoutINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5768</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcImeStripSingleReferenceStreamoutINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5768</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcImeStripDualReferenceStreamoutINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5769</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcImeStripDualReferenceStreamoutINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5769</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5770</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5770</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeDistortionsINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5771</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeDistortionsINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5771</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeReferenceIdsINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5772</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeReferenceIdsINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5772</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeGetStreamoutDualReferenceMajorShapeMotionVectorsINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5773</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeGetStreamoutDualReferenceMajorShapeMotionVectorsINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5773</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeGetStreamoutDualReferenceMajorShapeDistortionsINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5774</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeGetStreamoutDualReferenceMajorShapeDistortionsINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5774</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeGetStreamoutDualReferenceMajorShapeReferenceIdsINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5775</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeGetStreamoutDualReferenceMajorShapeReferenceIdsINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5775</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeGetBorderReachedINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5776</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeGetBorderReachedINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5776</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeGetTruncatedSearchIndicationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5777</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeGetTruncatedSearchIndicationINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5777</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeGetUnidirectionalEarlySearchTerminationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5778</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeGetUnidirectionalEarlySearchTerminationINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5778</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeGetWeightingPatternMinimumMotionVectorINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5779</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeGetWeightingPatternMinimumMotionVectorINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5779</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcImeGetWeightingPatternMinimumDistortionINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5780</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcImeGetWeightingPatternMinimumDistortionINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5780</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcFmeInitializeINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5781</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcFmeInitializeINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5781</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcBmeInitializeINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5782</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcBmeInitializeINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5782</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcRefConvertToMcePayloadINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5783</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcRefConvertToMcePayloadINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5783</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcRefSetBidirectionalMixDisableINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5784</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcRefSetBidirectionalMixDisableINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5784</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcRefSetBilinearFilterEnableINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5785</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcRefSetBilinearFilterEnableINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5785</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcRefEvaluateWithSingleReferenceINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5786</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcRefEvaluateWithSingleReferenceINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5786</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcRefEvaluateWithDualReferenceINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5787</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcRefEvaluateWithDualReferenceINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5787</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcRefEvaluateWithMultiReferenceINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5788</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcRefEvaluateWithMultiReferenceINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5788</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcRefEvaluateWithMultiReferenceInterlacedINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5789</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcRefEvaluateWithMultiReferenceInterlacedINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5789</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcRefConvertToMceResultINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5790</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcRefConvertToMceResultINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5790</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicInitializeINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5791</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicInitializeINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5791</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicConfigureSkcINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5792</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicConfigureSkcINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5792</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicConfigureIpeLumaINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5793</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicConfigureIpeLumaINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5793</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicConfigureIpeLumaChromaINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5794</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicConfigureIpeLumaChromaINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5794</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicGetMotionVectorMaskINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5795</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicGetMotionVectorMaskINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5795</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicConvertToMcePayloadINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5796</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicConvertToMcePayloadINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5796</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicSetIntraLumaShapePenaltyINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5797</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicSetIntraLumaShapePenaltyINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5797</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicSetIntraLumaModeCostFunctionINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5798</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicSetIntraLumaModeCostFunctionINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5798</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicSetIntraChromaModeCostFunctionINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5799</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicSetIntraChromaModeCostFunctionINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5799</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicSetBilinearFilterEnableINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5800</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicSetBilinearFilterEnableINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5800</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5801</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5801</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicSetBlockBasedRawSkipSadINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5802</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicSetBlockBasedRawSkipSadINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5802</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicEvaluateIpeINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5803</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicEvaluateIpeINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5803</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicEvaluateWithSingleReferenceINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5804</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicEvaluateWithSingleReferenceINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5804</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicEvaluateWithDualReferenceINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5805</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicEvaluateWithDualReferenceINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5805</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicEvaluateWithMultiReferenceINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5806</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicEvaluateWithMultiReferenceINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5806</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicEvaluateWithMultiReferenceInterlacedINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5807</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicEvaluateWithMultiReferenceInterlacedINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5807</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicConvertToMceResultINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5808</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicConvertToMceResultINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5808</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicGetIpeLumaShapeINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5809</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicGetIpeLumaShapeINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5809</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicGetBestIpeLumaDistortionINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5810</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicGetBestIpeLumaDistortionINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5810</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicGetBestIpeChromaDistortionINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5811</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicGetBestIpeChromaDistortionINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5811</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicGetPackedIpeLumaModesINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5812</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicGetPackedIpeLumaModesINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5812</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicGetIpeChromaModeINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5813</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicGetIpeChromaModeINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5813</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicGetPackedSkcLumaCountThresholdINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5814</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicGetPackedSkcLumaCountThresholdINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5814</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicGetPackedSkcLumaSumThresholdINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5815</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicGetPackedSkcLumaSumThresholdINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5815</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupAvcSicGetInterRawSadsINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5816</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupAvcSicGetInterRawSadsINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5816</p></td>
 </tr>
 </tbody>
 </table>
-<div style="page-break-after:always"></div>
+<div style="page-break-after: always;"></div>
 </div>
 </div>
 <div class="sect1">
@@ -1587,3301 +877,3550 @@ width:40%;
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_terms">Terms</h3>
-<div class="paragraph"><p>Modify Section 2.2, Terms, adding to the numbered list a new sub-section 2.2.X "AVC Motion Estimation":</p></div>
-<div class="paragraph"><p>The following terms, acronyms and definitions are used in and provide context for the AVE motion estimation group instructions.</p></div>
-<div class="paragraph"><p><strong>Macro-block (MB)</strong><br>
-An image is partitioned into macro-blocks of size 16x16 pixels. It is the basic unit of processing for AVC video motion estimation operations.</p></div>
-<div class="paragraph"><p><strong>Shape</strong><br>
-A MB may be partitioned into sub-blocks of one of the major shapes. A sub-block with an 8x8 major shape may be further independently partitioned into sub-blocks of one of the minor shapes. It is represented by predefined shape values.</p></div>
-<div class="paragraph"><p><strong>Major Shapes</strong><br>
-Shapes of 16x16, 16x8, 8x16, or 8x8 partitions of a MB. A 16x16 major shape merely indicates that the MB was not further partitioned.</p></div>
-<div class="paragraph"><p><strong>Minor Shapes</strong><br>
-Shapes of 8x8, 8x4, 4x8, or 4x4 sub-partitions of an 8x8 partition. A   8x8 minor shape merely indicates that the 8x8 major partition was not   further sub-partitioned.</p></div>
-<div class="paragraph"><p><strong>Block</strong><br>
-A sub-block of a MB with one of the major or minor shapes.</p></div>
-<div class="paragraph"><p><strong>Reference Image</strong><br>
-An image (typically from the previously decoded buffer in an encoder   pipeline) from which motion estimation predictions are made.</p></div>
-<div class="paragraph"><p><strong>Source Image</strong><br>
-The current image for which motion estimation predictions are made.</p></div>
-<div class="paragraph"><p><strong>Source Macro-block Offset</strong><br>
-The 2D offset of the top left corner of the source MB in pixel units.   It is represented by a pair of unsigned 16-bit integers.</p></div>
-<div class="paragraph"><p><strong>Reference Window Offset</strong><br>
-The 2D offset of the top left corner reference search window w.r.t to   the top left corner of the source MB in pixel units. It is represented   by a pair of signed 16-bit integers in the range [-2048, 2047].</p></div>
-<div class="paragraph"><p><strong>Reference identifier</strong><br>
-Reference identifiers are associated to pairs of forward(L0)/ backward(L1) reference image parameters. Up to 16 pairs of reference pairs of reference image parameters are permitted, with the permitted values of reference identifiers ranging from 0 to 15. The reference identifiers are assigned in increasing order in which the reference image parameter pairs are declared in the kernel parameter operand list.</p></div>
-<div class="paragraph"><p><strong>Motion Vector (MV)</strong><br>
-A 2D vector used for inter motion estimation that provides an offset from the top left corner of a block in the source image to the top left corner an identically sized block in the reference image. Generally it is used to represent the best match of a block in the reference image to a block in the source image. The best match is determined as the block minimizing the distortion. MVs are specified in QPEL resolution with the 2 LSB representing the fractional part of the offset. It is represented by a pair of signed 16-bit signed integers.</p></div>
-<div class="paragraph"><p><strong>Packed Motion Vector</strong><br>
-A motion vector represented as a packed 32-bit unsigned integer. The lower 16 bits contains the X coordinate and the upper 16 bits contains the Y coordinate.</p></div>
-<div class="paragraph"><p><strong>Bidirectional Motion Vector (BMV)</strong><br>
-A pair of MVs for the forward(L0) and backward(L1) images. Depending on how the VME operation is configured only the forward or the backward MV or both may be valid.</p></div>
-<div class="paragraph"><p><strong>Packed Bidirectional Motion Vector</strong><br>
-A bidirectional MV represented as a packed 64-bit unsigned integer. The lower 32-bits contain the forward packed MV, and the upper 32-bits contain the backward packed MV.</p></div>
-<div class="paragraph"><p><strong>Sum Of Absolute Difference (SAD)</strong><br>
-The sum of absolute differences of every full/sub-pixel location in the source block w.r.t every corresponding full/sub pixel in the reference block as specified by a given MV. The sum of absolute differences may be optionally Haar transform adjusted. It is represented by an unsigned 16-bit integer value.</p></div>
-<div class="paragraph"><p><strong>Haar Transform (HAAR)</strong><br>
-A simple wavelet transform that is used to refine the distortion measure of SAD. The per pixel difference goes through a 4x4 Haar transform. Then the SAD is replaced by the sum of the absolute values of the transform domain coefficients in the distortion. Haar transform is used as a coarse estimation of the integer transform.</p></div>
-<div class="paragraph"><p><strong>Motion Vector Cost Center (CC)</strong><br>
-A MV has an associated cost w.r.t a cost center coordinate. The further away from the cost center, the larger will be the cost associated with the MV. Cost centers are specified in QPEL resolution with the 2 LSB representing the fractional part of the offset.</p></div>
-<div class="paragraph"><p><strong>Motion Vector Cost Center Delta (CCD)</strong><br>
-The 2D offset of the cost center relative to the top left corner of the source MB. Cost center deltas are specified in QPEL resolution with the 2 LSB representing the fractional part of the offset. It is represented by a pair of signed 16-bit integers.</p></div>
-<div class="paragraph"><p><strong>Packed Motion Vector Cost Center Delta</strong><br>
-A motion vector cost center delta represented as a packed 32-bit unsigned integer. The lower 16 bits contains the X coordinate and the upper 16 bits contains the Y coordinate.</p></div>
-<div class="paragraph"><p><strong>Bidirectional Motion Vector Cost Center Delta</strong><br>
-A pair of cost center deltas for the forward and backward images.</p></div>
-<div class="paragraph"><p><strong>Packed Bidirectional Motion Vector Cost Center Delta</strong><br>
-A packed bidirectional motion vector cost center delta represented as a 64-bit unsigned integer. The lower 32-bits contain the forward packed CCD, and the upper 32-bits contain the backward packed CCD.</p></div>
-<div class="paragraph"><p><strong>Motion Vector Cost</strong><br>
-The MV cost is determined using a cost function described by a cost table that is indexed based on power-of-two distances from the user specified cost center, with a user specified precision (or unit) of the distances from the cost center.</p></div>
-<div class="paragraph"><p><strong>U4U4 Byte Format</strong><br>
-Represents a value of (B&lt;&lt;S), where B, called base, is the 4 bit LSB of the byte and S, called shift, is the 4 bit MSB of the byte.</p></div>
-<div class="paragraph"><p><strong>Motion Vector Cost Table</strong><br>
-A table which specifies the cost penalties at 8 control points. The first 7 control points represent the distances from cost center at powers-of-two locations (2<sup>0</sup> to 2<sup>6</sup>), and the last control point represents the base penalty for distances that are out of range of the cost function curve. It is represented by a packed array of 8 U4U4 unsigned integer values.</p></div>
-<div class="paragraph"><p><strong>Motion Vector Cost Precision</strong><br>
-The precision (or unit) of the control points in the MV cost table. It can be used to control the precision and range of the cost function. It is represented by pre-defined cost precision  values.</p></div>
-<div class="paragraph"><p><strong>Shape Cost</strong><br>
-The cost associated with encoding a particular partition shape using inter or intra prediction. It is represented by a packed array of 10 U4U4 unsigned integer values.</p></div>
-<div class="paragraph"><p><strong>Distortion</strong><br>
-The distortion is the sum of SAD, MV cost, shape cost and multi-reference cost for inter estimation, and the sum of SAD, mode cost, shape cost and non-dc cost for intra estimation. It is a measure of the cost of encoding a block and is represented by an unsigned 16-bit integer value.</p></div>
-<div class="paragraph"><p><strong>Intra Mode</strong><br>
-An intra-prediction angle which provides a prediction for the current  block from the edge pixels in its neighboring blocks. It is represented by pre-defined intra mode values.</p></div>
-<div class="paragraph"><p><strong>Intra Mode Cost</strong><br>
-The cost associated with a computed intra mode for a block w.r.t a predicted intra mode based on the computed intra modes for itsneighboring blocks.</p></div>
-<div class="paragraph"><p><strong>Mode</strong><br>
-The decision whether the inter-prediction or intra-prediction minimizes distortion of a given MB.</p></div>
-<div class="paragraph"><p><strong>Search unit (SU)</strong><br>
-The basic unit of searching. Possible reference search locations are   grouped in a predefined 4x4 pattern, and all locations within the same group must be completely chosen or completely skipped. These predefined groups are called search units.</p></div>
-<div class="paragraph"><p><strong>Search Path (SP)</strong><br>
-The path taken during searching in a reference window. The steps taken in a search path are in units of SUs. The search path must lie within the defined search window.</p></div>
-<div class="paragraph"><p><strong>Luma</strong><br>
-Luma refers to either the Y-plane of a NV12 image or a regular image with the <em>Image Channel Order</em> and <em>Image Channel Data Type</em> restricted as R and UnormInt8.</p></div>
-<div class="paragraph"><p><strong>Chroma</strong><br>
-Chroma refer to the UV-plane of a NV12 image.</p></div>
-<div class="paragraph"><p><strong>Search Window (SW)</strong><br>
-The search area that will be covered during searching. The area of the search window is limited to 2K luma pixels.</p></div>
-<div class="paragraph"><p><strong>Search Window Configuration</strong><br>
-The configuration of a search window which is a combination of the search path and search window.</p></div>
-<div class="paragraph"><p>The predefined search window configurations are:</p></div>
-<table class="tableblock frame-all grid-rows"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:75%;">
+<div class="paragraph">
+<p>Modify Section 2.2, Terms, adding to the numbered list a new sub-section 2.2.X "AVC Motion Estimation":</p>
+</div>
+<div class="paragraph">
+<p>The following terms, acronyms and definitions are used in and provide context for the AVE motion estimation group instructions.</p>
+</div>
+<div class="paragraph">
+<p><strong>Macro-block (MB)</strong><br>
+An image is partitioned into macro-blocks of size 16x16 pixels. It is the basic unit of processing for AVC video motion estimation operations.</p>
+</div>
+<div class="paragraph">
+<p><strong>Shape</strong><br>
+A MB may be partitioned into sub-blocks of one of the major shapes. A sub-block with an 8x8 major shape may be further independently partitioned into sub-blocks of one of the minor shapes. It is represented by predefined shape values.</p>
+</div>
+<div class="paragraph">
+<p><strong>Major Shapes</strong><br>
+Shapes of 16x16, 16x8, 8x16, or 8x8 partitions of a MB. A 16x16 major shape merely indicates that the MB was not further partitioned.</p>
+</div>
+<div class="paragraph">
+<p><strong>Minor Shapes</strong><br>
+Shapes of 8x8, 8x4, 4x8, or 4x4 sub-partitions of an 8x8 partition. A   8x8 minor shape merely indicates that the 8x8 major partition was not   further sub-partitioned.</p>
+</div>
+<div class="paragraph">
+<p><strong>Block</strong><br>
+A sub-block of a MB with one of the major or minor shapes.</p>
+</div>
+<div class="paragraph">
+<p><strong>Reference Image</strong><br>
+An image (typically from the previously decoded buffer in an encoder   pipeline) from which motion estimation predictions are made.</p>
+</div>
+<div class="paragraph">
+<p><strong>Source Image</strong><br>
+The current image for which motion estimation predictions are made.</p>
+</div>
+<div class="paragraph">
+<p><strong>Source Macro-block Offset</strong><br>
+The 2D offset of the top left corner of the source MB in pixel units.   It is represented by a pair of unsigned 16-bit integers.</p>
+</div>
+<div class="paragraph">
+<p><strong>Reference Window Offset</strong><br>
+The 2D offset of the top left corner reference search window w.r.t to   the top left corner of the source MB in pixel units. It is represented   by a pair of signed 16-bit integers in the range [-2048, 2047].</p>
+</div>
+<div class="paragraph">
+<p><strong>Reference identifier</strong><br>
+Reference identifiers are associated to pairs of forward(L0)/ backward(L1) reference image parameters. Up to 16 pairs of reference pairs of reference image parameters are permitted, with the permitted values of reference identifiers ranging from 0 to 15. The reference identifiers are assigned in increasing order in which the reference image parameter pairs are declared in the kernel parameter operand list.</p>
+</div>
+<div class="paragraph">
+<p><strong>Motion Vector (MV)</strong><br>
+A 2D vector used for inter motion estimation that provides an offset from the top left corner of a block in the source image to the top left corner an identically sized block in the reference image. Generally it is used to represent the best match of a block in the reference image to a block in the source image. The best match is determined as the block minimizing the distortion. MVs are specified in QPEL resolution with the 2 LSB representing the fractional part of the offset. It is represented by a pair of signed 16-bit signed integers.</p>
+</div>
+<div class="paragraph">
+<p><strong>Packed Motion Vector</strong><br>
+A motion vector represented as a packed 32-bit unsigned integer. The lower 16 bits contains the X coordinate and the upper 16 bits contains the Y coordinate.</p>
+</div>
+<div class="paragraph">
+<p><strong>Bidirectional Motion Vector (BMV)</strong><br>
+A pair of MVs for the forward(L0) and backward(L1) images. Depending on how the VME operation is configured only the forward or the backward MV or both may be valid.</p>
+</div>
+<div class="paragraph">
+<p><strong>Packed Bidirectional Motion Vector</strong><br>
+A bidirectional MV represented as a packed 64-bit unsigned integer. The lower 32-bits contain the forward packed MV, and the upper 32-bits contain the backward packed MV.</p>
+</div>
+<div class="paragraph">
+<p><strong>Sum Of Absolute Difference (SAD)</strong><br>
+The sum of absolute differences of every full/sub-pixel location in the source block w.r.t every corresponding full/sub pixel in the reference block as specified by a given MV. The sum of absolute differences may be optionally Haar transform adjusted. It is represented by an unsigned 16-bit integer value.</p>
+</div>
+<div class="paragraph">
+<p><strong>Haar Transform (HAAR)</strong><br>
+A simple wavelet transform that is used to refine the distortion measure of SAD. The per pixel difference goes through a 4x4 Haar transform. Then the SAD is replaced by the sum of the absolute values of the transform domain coefficients in the distortion. Haar transform is used as a coarse estimation of the integer transform.</p>
+</div>
+<div class="paragraph">
+<p><strong>Motion Vector Cost Center (CC)</strong><br>
+A MV has an associated cost w.r.t a cost center coordinate. The further away from the cost center, the larger will be the cost associated with the MV. Cost centers are specified in QPEL resolution with the 2 LSB representing the fractional part of the offset.</p>
+</div>
+<div class="paragraph">
+<p><strong>Motion Vector Cost Center Delta (CCD)</strong><br>
+The 2D offset of the cost center relative to the top left corner of the source MB. Cost center deltas are specified in QPEL resolution with the 2 LSB representing the fractional part of the offset. It is represented by a pair of signed 16-bit integers.</p>
+</div>
+<div class="paragraph">
+<p><strong>Packed Motion Vector Cost Center Delta</strong><br>
+A motion vector cost center delta represented as a packed 32-bit unsigned integer. The lower 16 bits contains the X coordinate and the upper 16 bits contains the Y coordinate.</p>
+</div>
+<div class="paragraph">
+<p><strong>Bidirectional Motion Vector Cost Center Delta</strong><br>
+A pair of cost center deltas for the forward and backward images.</p>
+</div>
+<div class="paragraph">
+<p><strong>Packed Bidirectional Motion Vector Cost Center Delta</strong><br>
+A packed bidirectional motion vector cost center delta represented as a 64-bit unsigned integer. The lower 32-bits contain the forward packed CCD, and the upper 32-bits contain the backward packed CCD.</p>
+</div>
+<div class="paragraph">
+<p><strong>Motion Vector Cost</strong><br>
+The MV cost is determined using a cost function described by a cost table that is indexed based on power-of-two distances from the user specified cost center, with a user specified precision (or unit) of the distances from the cost center.</p>
+</div>
+<div class="paragraph">
+<p><strong>U4U4 Byte Format</strong><br>
+Represents a value of (B&lt;&lt;S), where B, called base, is the 4 bit LSB of the byte and S, called shift, is the 4 bit MSB of the byte.</p>
+</div>
+<div class="paragraph">
+<p><strong>Motion Vector Cost Table</strong><br>
+A table which specifies the cost penalties at 8 control points. The first 7 control points represent the distances from cost center at powers-of-two locations (2<sup>0</sup> to 2<sup>6</sup>), and the last control point represents the base penalty for distances that are out of range of the cost function curve. It is represented by a packed array of 8 U4U4 unsigned integer values.</p>
+</div>
+<div class="paragraph">
+<p><strong>Motion Vector Cost Precision</strong><br>
+The precision (or unit) of the control points in the MV cost table. It can be used to control the precision and range of the cost function. It is represented by pre-defined cost precision  values.</p>
+</div>
+<div class="paragraph">
+<p><strong>Shape Cost</strong><br>
+The cost associated with encoding a particular partition shape using inter or intra prediction. It is represented by a packed array of 10 U4U4 unsigned integer values.</p>
+</div>
+<div class="paragraph">
+<p><strong>Distortion</strong><br>
+The distortion is the sum of SAD, MV cost, shape cost and multi-reference cost for inter estimation, and the sum of SAD, mode cost, shape cost and non-dc cost for intra estimation. It is a measure of the cost of encoding a block and is represented by an unsigned 16-bit integer value.</p>
+</div>
+<div class="paragraph">
+<p><strong>Intra Mode</strong><br>
+An intra-prediction angle which provides a prediction for the current  block from the edge pixels in its neighboring blocks. It is represented by pre-defined intra mode values.</p>
+</div>
+<div class="paragraph">
+<p><strong>Intra Mode Cost</strong><br>
+The cost associated with a computed intra mode for a block w.r.t a predicted intra mode based on the computed intra modes for itsneighboring blocks.</p>
+</div>
+<div class="paragraph">
+<p><strong>Mode</strong><br>
+The decision whether the inter-prediction or intra-prediction minimizes distortion of a given MB.</p>
+</div>
+<div class="paragraph">
+<p><strong>Search unit (SU)</strong><br>
+The basic unit of searching. Possible reference search locations are   grouped in a predefined 4x4 pattern, and all locations within the same group must be completely chosen or completely skipped. These predefined groups are called search units.</p>
+</div>
+<div class="paragraph">
+<p><strong>Search Path (SP)</strong><br>
+The path taken during searching in a reference window. The steps taken in a search path are in units of SUs. The search path must lie within the defined search window.</p>
+</div>
+<div class="paragraph">
+<p><strong>Luma</strong><br>
+Luma refers to either the Y-plane of a NV12 image or a regular image with the <em>Image Channel Order</em> and <em>Image Channel Data Type</em> restricted as R and UnormInt8.</p>
+</div>
+<div class="paragraph">
+<p><strong>Chroma</strong><br>
+Chroma refer to the UV-plane of a NV12 image.</p>
+</div>
+<div class="paragraph">
+<p><strong>Search Window (SW)</strong><br>
+The search area that will be covered during searching. The area of the search window is limited to 2K luma pixels.</p>
+</div>
+<div class="paragraph">
+<p><strong>Search Window Configuration</strong><br>
+The configuration of a search window which is a combination of the search path and search window.</p>
+</div>
+<div class="paragraph">
+<p>The predefined search window configurations are:</p>
+</div>
+<table class="tableblock frame-all grid-rows stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">EXHAUSTIVE</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">48x40 SW with exhaustive single reference search (or 32x32 dual SW for exhaustive dual-reference search); an exhaustive search means that all SU within the search window are searched in a spiral pattern with the search center being the middle of the search window.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">EXHAUSTIVE</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">48x40 SW with exhaustive single reference search (or 32x32 dual SW for exhaustive dual-reference search); an exhaustive search means that all SU within the search window are searched in a spiral pattern with the search center being the middle of the search window.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SMALL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">28x28 SW with exhaustive search</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SMALL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">28x28 SW with exhaustive search</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">TINY</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">24x24 SW with exhaustive search</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">TINY</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">24x24 SW with exhaustive search</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">EXTRA TINY</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">20x20 SW with exhaustive search</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">EXTRA TINY</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">20x20 SW with exhaustive search</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">DIAMOND</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">48x40 SW with diamond single reference search (or 32x32 dual SW for diamond dual-reference search); a diamond pattern search path is used for the first 16 (or 7 per reference for dual reference search) SUs, and then gradient based searching is used for up to a maximum of 57 search unit.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">DIAMOND</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">48x40 SW with diamond single reference search (or 32x32 dual SW for diamond dual-reference search); a diamond pattern search path is used for the first 16 (or 7 per reference for dual reference search) SUs, and then gradient based searching is used for up to a maximum of 57 search unit.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">LARGE DIAMOND</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">48x40 SW with large diamond single reference search(or 32x32 dual SW for large diamond dual-reference search); a diamond pattern search pattern is used for the first 32 (or 10 per reference for dual reference search) SUs, and then gradient based searching is used for up to a maximum of 57 search units.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">LARGE DIAMOND</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">48x40 SW with large diamond single reference search(or 32x32 dual SW for large diamond dual-reference search); a diamond pattern search pattern is used for the first 32 (or 10 per reference for dual reference search) SUs, and then gradient based searching is used for up to a maximum of 57 search units.</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>Inter Estimation</strong><br>
-The process of determining motion vectors and shapes that best describe the transformation from 2D images from previously decoded images in a video sequence to the currently processed image.</p></div>
-<div class="paragraph"><p><strong>Intra-Prediction Estimation (IPE)</strong><br>
-The process of determining prediction angles and shapes that best describe the transformation from neighboring MBs in an image to the currently processed MB in the same image.</p></div>
-<div class="paragraph"><p><strong>Luma Mode</strong><br>
-The prediction angle returned by IPE for the luma component for a block. It is represented by an unsigned 8-bit integer with the upper 4 bits set to zero.</p></div>
-<div class="paragraph"><p><strong>Integer Motion Estimation (IME)</strong><br>
-Inter-motion estimation in integer pixel resolution.</p></div>
-<div class="paragraph"><p><strong>Fractional Motion Estimation (FME)</strong><br>
-Inter-motion estimation in sub-pixel resolution. The result of integer motion estimation on a reference image is used to perform fractional refinement.</p></div>
-<div class="paragraph"><p><strong>Bidirectional Motion Estimation (BME)</strong><br>
-The process of determining if the bi-directional prediction minimizes the distortion w.r.t to unidirectional prediction. The results of IME on forward(L0) and backward(L1) reference images are used to perform bi-directional refinement. BME can be performed in integer or sub-pixel resolution. If performed in sub-pixel resolution an implicit FME operation is done before performing the BME.</p></div>
-<div class="paragraph"><p><strong>Refinement (REF)</strong><br>
-A FME and/or BME refinement operation.</p></div>
-<div class="paragraph"><p><strong>Skip/Spot Check (SKC)</strong><br>
-The operation determining the distortion associated with a given (uni or bidirectional) MV in a reference image(s) w.r.t a source image.</p></div>
-<div class="paragraph"><p><strong>Skip and Intra Check (SIC)</strong><br>
-The process of performing both SKC and IPE in the same operation.</p></div>
-<div class="paragraph"><p><strong>Motion Check or Estimation (MCE)</strong><br>
-A generic IME, REF, or SIC operation.</p></div>
-<div class="paragraph"><p><strong>Forward Transform (FT)</strong><br>
-An 8x8 or 4x4 integer transform used to transform the residual to the frequency domain.</p></div>
-<div style="page-break-after:always"></div>
+<div class="paragraph">
+<p><strong>Inter Estimation</strong><br>
+The process of determining motion vectors and shapes that best describe the transformation from 2D images from previously decoded images in a video sequence to the currently processed image.</p>
+</div>
+<div class="paragraph">
+<p><strong>Intra-Prediction Estimation (IPE)</strong><br>
+The process of determining prediction angles and shapes that best describe the transformation from neighboring MBs in an image to the currently processed MB in the same image.</p>
+</div>
+<div class="paragraph">
+<p><strong>Luma Mode</strong><br>
+The prediction angle returned by IPE for the luma component for a block. It is represented by an unsigned 8-bit integer with the upper 4 bits set to zero.</p>
+</div>
+<div class="paragraph">
+<p><strong>Integer Motion Estimation (IME)</strong><br>
+Inter-motion estimation in integer pixel resolution.</p>
+</div>
+<div class="paragraph">
+<p><strong>Fractional Motion Estimation (FME)</strong><br>
+Inter-motion estimation in sub-pixel resolution. The result of integer motion estimation on a reference image is used to perform fractional refinement.</p>
+</div>
+<div class="paragraph">
+<p><strong>Bidirectional Motion Estimation (BME)</strong><br>
+The process of determining if the bi-directional prediction minimizes the distortion w.r.t to unidirectional prediction. The results of IME on forward(L0) and backward(L1) reference images are used to perform bi-directional refinement. BME can be performed in integer or sub-pixel resolution. If performed in sub-pixel resolution an implicit FME operation is done before performing the BME.</p>
+</div>
+<div class="paragraph">
+<p><strong>Refinement (REF)</strong><br>
+A FME and/or BME refinement operation.</p>
+</div>
+<div class="paragraph">
+<p><strong>Skip/Spot Check (SKC)</strong><br>
+The operation determining the distortion associated with a given (uni or bidirectional) MV in a reference image(s) w.r.t a source image.</p>
+</div>
+<div class="paragraph">
+<p><strong>Skip and Intra Check (SIC)</strong><br>
+The process of performing both SKC and IPE in the same operation.</p>
+</div>
+<div class="paragraph">
+<p><strong>Motion Check or Estimation (MCE)</strong><br>
+A generic IME, REF, or SIC operation.</p>
+</div>
+<div class="paragraph">
+<p><strong>Forward Transform (FT)</strong><br>
+An 8x8 or 4x4 integer transform used to transform the residual to the frequency domain.</p>
+</div>
+<div style="page-break-after: always;"></div>
 </div>
 <div class="sect2">
 <h3 id="_capabilities">Capabilities</h3>
-<div class="paragraph"><p>Modify Section 3.31, Capability, adding rows to the Capability table:</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:25%;">
+<div class="paragraph">
+<p>Modify Section 3.31, Capability, adding rows to the Capability table:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5696</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Groups</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SPV_INTEL_device_side_motion_estimation</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5696</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Groups</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SPV_INTEL_device_side_motion_estimation</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5697</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationIntraINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupImageMediaBlockIOINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SPV_INTEL_device_side_motion_estimation</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5697</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationIntraINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupImageMediaBlockIOINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SPV_INTEL_device_side_motion_estimation</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5698</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationChromaINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationIntraINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SPV_INTEL_device_side_motion_estimation</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5698</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationChromaINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationIntraINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SPV_INTEL_device_side_motion_estimation</p></td>
 </tr>
 </tbody>
 </table>
-<div style="page-break-after:always"></div>
+<div style="page-break-after: always;"></div>
 </div>
 <div class="sect2">
 <h3 id="_types">Types</h3>
-<div class="paragraph"><p>Modify Section <strong>2.2.2</strong>, <strong>Types</strong>, adding "VME image" type after the definition of <em>Sampler</em> as follows:<br></p></div>
-<div class="paragraph"><p><strong><em>Sampler</em></strong>:  There are essentially two categories of samplers: texture and media samplers. Texture samplers essentially describe settings how to access, filter, or sample on an image, that come either from literal declarations of settings or be an opaque reference to externally bound settings. Media samplers essentially settings for motion estimation on an image, that come only from literal declarations of settings. Refer to section <span class="blue"><a href="#bookmark-InstructionsGroup">3.32.21 Group Instructions</a></span> for a detailed description the instructions that use of this type. In general, the use of the word "sampler" by itself refers to a texture sampler. A media sampler will be explicitly referred to as "media sampler". A sampler does not include an image.</p></div>
-<div class="paragraph"><p>Modify Section <strong>2.2.2</strong>, <strong>Types</strong>, adding "VME image" type after the definition of <em>Sampled Image</em> as follows:<br></p></div>
-<div class="paragraph"><p><strong><em>VME Image</em></strong>: An image combined with a sampler, enabling VME accesses of the image’s contents.</p></div>
-<div class="paragraph"><p>Modify Section <strong>2.2.2</strong>, <strong>Types</strong>, adding the following to the Opaque types:<br></p></div>
-<div class="ulist" id="bookmark-OpTypesVME"><ul>
+<div class="paragraph">
+<p>Modify Section <strong>2.2.2</strong>, <strong>Types</strong>, adding "VME image" type after the definition of <em>Sampler</em> as follows:<br></p>
+</div>
+<div class="paragraph">
+<p><strong><em>Sampler</em></strong>:  There are essentially two categories of samplers: texture and media samplers. Texture samplers essentially describe settings how to access, filter, or sample on an image, that come either from literal declarations of settings or be an opaque reference to externally bound settings. Media samplers essentially settings for motion estimation on an image, that come only from literal declarations of settings. Refer to section <span class="blue"><a href="#bookmark-InstructionsGroup">3.32.21 Group Instructions</a></span> for a detailed description the instructions that use of this type. In general, the use of the word "sampler" by itself refers to a texture sampler. A media sampler will be explicitly referred to as "media sampler". A sampler does not include an image.</p>
+</div>
+<div class="paragraph">
+<p>Modify Section <strong>2.2.2</strong>, <strong>Types</strong>, adding "VME image" type after the definition of <em>Sampled Image</em> as follows:<br></p>
+</div>
+<div class="paragraph">
+<p><strong><em>VME Image</em></strong>: An image combined with a sampler, enabling VME accesses of the image’s contents.</p>
+</div>
+<div class="paragraph">
+<p>Modify Section <strong>2.2.2</strong>, <strong>Types</strong>, adding the following to the Opaque types:<br></p>
+</div>
+<div id="bookmark-OpTypesVME" class="ulist">
+<ul>
 <li>
-<p>
-OpTypeVmeImageINTEL<br>
-</p>
+<p>OpTypeVmeImageINTEL<br></p>
 </li>
 <li>
-<p>
-OpTypeAvcMcePayloadINTEL<br>
-</p>
+<p>OpTypeAvcMcePayloadINTEL<br></p>
 </li>
 <li>
-<p>
-OpTypeAvcImePayloadINTEL<br>
-</p>
+<p>OpTypeAvcImePayloadINTEL<br></p>
 </li>
 <li>
-<p>
-OpTypeAvcRefPayloadINTEL<br>
-</p>
+<p>OpTypeAvcRefPayloadINTEL<br></p>
 </li>
 <li>
-<p>
-OpTypeAvcSicPayloadINTEL<br>
-</p>
+<p>OpTypeAvcSicPayloadINTEL<br></p>
 </li>
 <li>
-<p>
-OpTypeAvcMceResultINTEL<br>
-</p>
+<p>OpTypeAvcMceResultINTEL<br></p>
 </li>
 <li>
-<p>
-OpTypeAvcImeResultINTEL<br>
-</p>
+<p>OpTypeAvcImeResultINTEL<br></p>
 </li>
 <li>
-<p>
-OpTypeAvcImeResultSingleReferenceStreamoutINTEL<br>
-</p>
+<p>OpTypeAvcImeResultSingleReferenceStreamoutINTEL<br></p>
 </li>
 <li>
-<p>
-OpTypeAvcImeResultDualReferenceStreamoutINTEL<br>
-</p>
+<p>OpTypeAvcImeResultDualReferenceStreamoutINTEL<br></p>
 </li>
 <li>
-<p>
-OpTypeAvcImeSingleReferenceStreaminINTEL<br>
-</p>
+<p>OpTypeAvcImeSingleReferenceStreaminINTEL<br></p>
 </li>
 <li>
-<p>
-OpTypeAvcImeDualReferenceStreaminINTEL<br>
-</p>
+<p>OpTypeAvcImeDualReferenceStreaminINTEL<br></p>
 </li>
 <li>
-<p>
-OpTypeAvcRefResultINTEL<br>
-</p>
+<p>OpTypeAvcRefResultINTEL<br></p>
 </li>
 <li>
-<p>
-OpTypeAvcSicResultINTEL
-</p>
+<p>OpTypeAvcSicResultINTEL</p>
 </li>
-</ul></div>
-<div class="paragraph"><p>Modify Section <strong>2.8</strong>, <strong>Types and Variables</strong>, adding the following to the third paragraph:<br></p></div>
-<div class="paragraph"><p>To do motion estimation operations, a type from <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span> is used that contains both an image and a media sampler. Such an image can be set only in a SPIR-V module from an independent image and an independent sampler. Furthermore its OpTypeImage must have a Dim of 2D.</p></div>
-<div class="paragraph"><p>Modify Section <strong>3.32.6</strong>, <strong>Type Declaration Instructions</strong>, amending the description of OpTypeSampler as follows:</p></div>
-<table class="tableblock frame-all grid-all" id="bookmark-OpTypeSampler"
-style="
-width:100%;
-">
-<col style="width:100%;">
+</ul>
+</div>
+<div class="paragraph">
+<p>Modify Section <strong>2.8</strong>, <strong>Types and Variables</strong>, adding the following to the third paragraph:<br></p>
+</div>
+<div class="paragraph">
+<p>To do motion estimation operations, a type from <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span> is used that contains both an image and a media sampler. Such an image can be set only in a SPIR-V module from an independent image and an independent sampler. Furthermore its OpTypeImage must have a Dim of 2D.</p>
+</div>
+<div class="paragraph">
+<p>Modify Section <strong>3.32.6</strong>, <strong>Type Declaration Instructions</strong>, amending the description of OpTypeSampler as follows:</p>
+</div>
+<table id="bookmark-OpTypeSampler" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="paragraph"><p><strong>OpTypeSampler</strong><br>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong>OpTypeSampler</strong><br>
 <br>
-Declare the sampler type. Consumed by OpSampledImage or <span class="blue"><a href="#bookmark-OpVmeImageINTEL">OpVmeImageINTEL</a></span>. This type is opaque: values of this type have no defined physical size or bit pattern.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:50%;">
+Declare the sampler type. Consumed by OpSampledImage or <span class="blue"><a href="#bookmark-OpVmeImageINTEL">OpVmeImageINTEL</a></span>. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">26</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">26</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
 </tr>
 </tbody>
 </table></div></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>Modify Section <strong>3.32.6</strong>, <strong>Type Declaration Instructions</strong>, adding the description of OpTypeSampledImage as follows:</p></div>
-<table class="tableblock frame-all grid-all" id="bookmark-OpTypeVmeImageINTEL"
-style="
-width:100%;
-">
-<col style="width:100%;">
+<div class="paragraph">
+<p>Modify Section <strong>3.32.6</strong>, <strong>Type Declaration Instructions</strong>, adding the description of OpTypeSampledImage as follows:</p>
+</div>
+<table id="bookmark-OpTypeVmeImageINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="paragraph"><p><strong>OpTypeVmeImageINTEL</strong><br>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong>OpTypeVmeImageINTEL</strong><br>
 <br>
-Declare a VME image type, the <em>Result Type</em> of <span class="blue"><a href="#bookmark-OpVmeImageINTEL">OpVmeImageINTEL</a></span>. This type is opaque: values of this type have no defined physical size or bit pattern.</p></div>
-<div class="paragraph"><p>Image Type must be an OpTypeImage. It is the type of the image in the combined sampler and image type.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:33%;">
-<col style="width:33%;">
+Declare a VME image type, the <em>Result Type</em> of <span class="blue"><a href="#bookmark-OpVmeImageINTEL">OpVmeImageINTEL</a></span>. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
+</div>
+<div class="paragraph">
+<p>Image Type must be an OpTypeImage. It is the type of the image in the combined sampler and image type.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3335%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5700</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Image Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5700</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Image Type</p></td>
 </tr>
 </tbody>
 </table></div></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>Modify Section <strong>3.32.6</strong>, <strong>Type Declaration Instructions</strong>, adding to the end of the list of type declarations:<br></p></div>
-<table class="tableblock frame-all grid-all" id="bookmark-OpTypeAvcMcePayloadINTEL"
-style="
-width:100%;
-">
-<col style="width:100%;">
+<div class="paragraph">
+<p>Modify Section <strong>3.32.6</strong>, <strong>Type Declaration Instructions</strong>, adding to the end of the list of type declarations:<br></p>
+</div>
+<table id="bookmark-OpTypeAvcMcePayloadINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="paragraph"><p><strong>OpTypeAvcMcePayloadINTEL</strong><br>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong>OpTypeAvcMcePayloadINTEL</strong><br>
 <br>
-Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupMCEInstructions">AVC MCE Group Instruction</a></span>. Consumed by AVC MCE Group Instruction and represents the payload for a basic IME/REF/SIC operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:50%;">
+Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupMCEInstructions">AVC MCE Group Instruction</a></span>. Consumed by AVC MCE Group Instruction and represents the payload for a basic IME/REF/SIC operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5704</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5704</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
 </tr>
 </tbody>
 </table></div></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpTypeAvcImePayloadINTEL"
-style="
-width:100%;
-">
-<col style="width:100%;">
+<table id="bookmark-OpTypeAvcImePayloadINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="paragraph"><p><strong>OpTypeAvcImePayloadINTEL</strong><br>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong>OpTypeAvcImePayloadINTEL</strong><br>
 <br>
-Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupIMEInstructions">AVC IME Group Instruction</a></span>. Consumed by AVC MCE Group Instruction and represents the payload for a basic IME operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:50%;">
+Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupIMEInstructions">AVC IME Group Instruction</a></span>. Consumed by AVC MCE Group Instruction and represents the payload for a basic IME operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5701</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5701</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
 </tr>
 </tbody>
 </table></div></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpTypeAvcRefPayloadINTEL"
-style="
-width:100%;
-">
-<col style="width:100%;">
+<table id="bookmark-OpTypeAvcRefPayloadINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="paragraph"><p><strong>OpTypeAvcRefPayloadINTEL</strong><br>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong>OpTypeAvcRefPayloadINTEL</strong><br>
 <br>
-Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupREFInstructions">AVC REF Group Instruction</a></span>. Consumed by AVC REF Group Instruction and represents the payload for a basic REF operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:50%;">
+Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupREFInstructions">AVC REF Group Instruction</a></span>. Consumed by AVC REF Group Instruction and represents the payload for a basic REF operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5702</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5702</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
 </tr>
 </tbody>
 </table></div></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpTypeAvcSicPayloadINTEL"
-style="
-width:100%;
-">
-<col style="width:100%;">
+<table id="bookmark-OpTypeAvcSicPayloadINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="paragraph"><p><strong>OpTypeAvcSicPayloadINTEL</strong><br>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong>OpTypeAvcSicPayloadINTEL</strong><br>
 <br>
-Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupSICGroupInstructions">AVC SIC Group Instruction</a></span>. Consumed by AVC SIC Group Instruction and represents the payload for a basic SIC operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:50%;">
+Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupSICGroupInstructions">AVC SIC Group Instruction</a></span>. Consumed by AVC SIC Group Instruction and represents the payload for a basic SIC operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5703</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5703</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
 </tr>
 </tbody>
 </table></div></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpTypeAvcMceResultINTEL"
-style="
-width:100%;
-">
-<col style="width:100%;">
+<table id="bookmark-OpTypeAvcMceResultINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="paragraph"><p><strong>OpTypeAvcMceResultINTEL</strong><br>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong>OpTypeAvcMceResultINTEL</strong><br>
 <br>
-Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupMCEInstructions">AVC MCE Group Instruction</a></span>. Consumed by AVC MCE Group Instruction and represents the evluation results of a basic IME/REF/SIC operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:50%;">
+Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupMCEInstructions">AVC MCE Group Instruction</a></span>. Consumed by AVC MCE Group Instruction and represents the evluation results of a basic IME/REF/SIC operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5705</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5705</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
 </tr>
 </tbody>
 </table></div></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpTypeAvcImeResultINTEL"
-style="
-width:100%;
-">
-<col style="width:100%;">
+<table id="bookmark-OpTypeAvcImeResultINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="paragraph"><p><strong>OpTypeAvcImeResultINTEL</strong><br>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong>OpTypeAvcImeResultINTEL</strong><br>
 <br>
-Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupIMEInstructions">AVC IME Group Instruction</a></span>. Consumed by AVC IME Group Instruction and represents the evaluation of a basic IME operation not using the stream-in/streamout functionality. This type is opaque: values of this type have no defined physical size or bit pattern.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:50%;">
+Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupIMEInstructions">AVC IME Group Instruction</a></span>. Consumed by AVC IME Group Instruction and represents the evaluation of a basic IME operation not using the stream-in/streamout functionality. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5706</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5706</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
 </tr>
 </tbody>
 </table></div></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL"
-style="
-width:100%;
-">
-<col style="width:100%;">
+<table id="bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="paragraph"><p><strong>OpTypeAvcImeResultSingleReferenceStreamoutINTEL</strong><br>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong>OpTypeAvcImeResultSingleReferenceStreamoutINTEL</strong><br>
 <br>
-Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupIMEInstructions">AVC IME Group Instruction</a></span>. Consumed by AVC IME Group Instruction and represents the additional results from the result of an IME evaluation using the streamout functionality that may be streamed-in in a subsequent IME streamin call. This type is opaque: values of this type have no defined physical size or bit pattern.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:50%;">
+Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupIMEInstructions">AVC IME Group Instruction</a></span>. Consumed by AVC IME Group Instruction and represents the additional results from the result of an IME evaluation using the streamout functionality that may be streamed-in in a subsequent IME streamin call. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5707</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5707</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
 </tr>
 </tbody>
 </table></div></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL"
-style="
-width:100%;
-">
-<col style="width:100%;">
+<table id="bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="paragraph"><p><strong>OpTypeAvcImeResultDualReferenceStreamoutINTEL</strong><br>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong>OpTypeAvcImeResultDualReferenceStreamoutINTEL</strong><br>
 <br>
-Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupIMEInstructions">AVC IME Group Instruction</a></span>. Consumed by AVC IME Group Instruction and represents the additional results from the result of an IME evaluation using the streamout functionality that may be streamed-in in a subsequent IME streamin call. This type is opaque: values of this type have no defined physical size or bit pattern.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:50%;">
+Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupIMEInstructions">AVC IME Group Instruction</a></span>. Consumed by AVC IME Group Instruction and represents the additional results from the result of an IME evaluation using the streamout functionality that may be streamed-in in a subsequent IME streamin call. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5708</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5708</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
 </tr>
 </tbody>
 </table></div></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpTypeAvcImeSingleReferenceStreaminINTEL"
-style="
-width:100%;
-">
-<col style="width:100%;">
+<table id="bookmark-OpTypeAvcImeSingleReferenceStreaminINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="paragraph"><p><strong>OpTypeAvcImeSingleReferenceStreaminINTEL</strong><br>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong>OpTypeAvcImeSingleReferenceStreaminINTEL</strong><br>
 <br>
-Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupIMEInstructions">AVC IME Group Instruction</a></span>. Consumed by AVC IME Group Instruction and represents the additional results from the result of an IME evaluation using the streamout functionality that may be streamed-in in a subsequent IME streamin call. This type is opaque: values of this type have no defined physical size or bit pattern.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:50%;">
+Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupIMEInstructions">AVC IME Group Instruction</a></span>. Consumed by AVC IME Group Instruction and represents the additional results from the result of an IME evaluation using the streamout functionality that may be streamed-in in a subsequent IME streamin call. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5709</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5709</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
 </tr>
 </tbody>
 </table></div></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpTypeAvcImeDualReferenceStreaminINTEL"
-style="
-width:100%;
-">
-<col style="width:100%;">
+<table id="bookmark-OpTypeAvcImeDualReferenceStreaminINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="paragraph"><p><strong>OpTypeAvcImeDualReferenceStreaminINTEL</strong><br>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong>OpTypeAvcImeDualReferenceStreaminINTEL</strong><br>
 <br>
-Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupIMEInstructions">AVC IME Group Instruction</a></span>. Consumed by AVC IME Group Instruction and represents the additional results from the result of an IME evaluation using the streamout functionality that may be streamed-in in a subsequent IME streamin call. This type is opaque: values of this type have no defined physical size or bit pattern.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:50%;">
+Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupIMEInstructions">AVC IME Group Instruction</a></span>. Consumed by AVC IME Group Instruction and represents the additional results from the result of an IME evaluation using the streamout functionality that may be streamed-in in a subsequent IME streamin call. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5710</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5710</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
 </tr>
 </tbody>
 </table></div></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpTypeAvcRefResultINTEL"
-style="
-width:100%;
-">
-<col style="width:100%;">
+<table id="bookmark-OpTypeAvcRefResultINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="paragraph"><p><strong>OpTypeAvcRefResultINTEL</strong><br>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong>OpTypeAvcRefResultINTEL</strong><br>
 <br>
-Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupREFInstructions">AVC REF Group Instruction</a></span>. Consumed by AVC REF Group Instruction and represents the evaluation of a basic REF operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:50%;">
+Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupREFInstructions">AVC REF Group Instruction</a></span>. Consumed by AVC REF Group Instruction and represents the evaluation of a basic REF operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5711</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5711</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
 </tr>
 </tbody>
 </table></div></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpTypeAvcSicResultINTEL"
-style="
-width:100%;
-">
-<col style="width:100%;">
+<table id="bookmark-OpTypeAvcSicResultINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="paragraph"><p><strong>OpTypeAvcSicResultINTEL</strong><br>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong>OpTypeAvcSicResultINTEL</strong><br>
 <br>
-Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupSICGroupInstructions">AVC SIC Group Instruction</a></span>. Consumed by AVC SIC Group Instruction and represents the evaluation of a basic SIC operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:50%;">
+Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupSICGroupInstructions">AVC SIC Group Instruction</a></span>. Consumed by AVC SIC Group Instruction and represents the evaluation of a basic SIC operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5712</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5712</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
 </tr>
 </tbody>
 </table></div></td>
 </tr>
 </tbody>
 </table>
-<div style="page-break-after:always"></div>
+<div style="page-break-after: always;"></div>
 </div>
 <div class="sect2">
 <h3 id="bookmark-BF">Binary Form</h3>
-<div class="paragraph"><p>Modify Section <strong>3</strong>, <strong>Binary Form</strong>, adding to the numbered list the following sub-sections:<br></p></div>
-<div class="paragraph"><p><strong>Interlaced image field polarity values:</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p>Modify Section <strong>3</strong>, <strong>Binary Form</strong>, adding to the numbered list the following sub-sections:<br></p>
+</div>
+<div class="paragraph">
+<p><strong>Interlaced image field polarity values:</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > Field polarity values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">Field polarity values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_INTERLACED_SCAN_TOP_FIELD_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_INTERLACED_SCAN_TOP_FIELD_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_INTERLACED_SCAN_BOTTOM_FIELD_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_INTERLACED_SCAN_BOTTOM_FIELD_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>Inter macro-block major shape values:</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p><strong>Inter macro-block major shape values:</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > Major shape values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">Major shape values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_MAJOR_16x16_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_MAJOR_16x16_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_MAJOR_16x8_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_MAJOR_16x8_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_MAJOR_8x16_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_MAJOR_8x16_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_MAJOR_8x8_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_MAJOR_8x8_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>Inter macro-block minor shape values:</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p><strong>Inter macro-block minor shape values:</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > Minor shape values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">Minor shape values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_MINOR_8x8_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_MINOR_8x8_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_MINOR_8x4_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_MINOR_8x4_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_MINOR_4x8_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_MINOR_4x8_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_MINOR_4x4_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_MINOR_4x4_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>Inter macro-block major direction values:</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p><strong>Inter macro-block major direction values:</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > Major direction values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">Major direction values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_MAJOR_FORWARD_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_MAJOR_FORWARD_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_MAJOR_BACKWARD_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_MAJOR_BACKWARD_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_MAJOR_BIDIRECTIONAL_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_MAJOR_BIDIRECTIONAL_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>Inter (IME) partition mask values:</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p><strong>Inter (IME) partition mask values:</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > Partition mask values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">Partition mask values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_PARTITION_MASK_ALL_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_PARTITION_MASK_ALL_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x7E</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_PARTITION_MASK_16x16_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x7E</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_PARTITION_MASK_16x16_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x7D</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_PARTITION_MASK_16x8_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x7D</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_PARTITION_MASK_16x8_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x7B</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_PARTITION_MASK_8x16_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x7B</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_PARTITION_MASK_8x16_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x77</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_PARTITION_MASK_8x8_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x77</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_PARTITION_MASK_8x8_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x6F</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_PARTITION_MASK_8x4_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x6F</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_PARTITION_MASK_8x4_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x5F</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_PARTITION_MASK_4x8_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x5F</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_PARTITION_MASK_4x8_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x3F</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_PARTITION_MASK_4x4_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x3F</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_PARTITION_MASK_4x4_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>Slice type values:</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p><strong>Slice type values:</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > Polarity values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">Polarity values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SLICE_TYPE_PRED_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SLICE_TYPE_PRED_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SLICE_TYPE_BPRED_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SLICE_TYPE_BPRED_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SLICE_TYPE_INTRA_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SLICE_TYPE_INTRA_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>Search window configuration:</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p><strong>Search window configuration:</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > Search window configuration values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">Search window configuration values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SEARCH_WINDOW_EXHAUSTIVE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SEARCH_WINDOW_EXHAUSTIVE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SEARCH_WINDOW_SMALL_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SEARCH_WINDOW_SMALL_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SEARCH_WINDOW_TINY_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SEARCH_WINDOW_TINY_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SEARCH_WINDOW_EXTRA_TINY_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SEARCH_WINDOW_EXTRA_TINY_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SEARCH_WINDOW_DIAMOND_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SEARCH_WINDOW_DIAMOND_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SEARCH_WINDOW_LARGE_DIAMOND_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SEARCH_WINDOW_LARGE_DIAMOND_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x6</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SEARCH_WINDOW_RESERVED0_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x6</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SEARCH_WINDOW_RESERVED0_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x7</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SEARCH_WINDOW_RESERVED1_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x7</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SEARCH_WINDOW_RESERVED1_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>SAD adjustment mode:</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p><strong>SAD adjustment mode:</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > SAD adjustment values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">SAD adjustment values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SAD_ADJUST_MODE_NONE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SAD_ADJUST_MODE_NONE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL
 <a id="bookmark-HAAR"></a></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SAD_ADJUST_MODE_HAAR_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SAD_ADJUST_MODE_HAAR_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>Pixel resolution values:</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p><strong>Pixel resolution values:</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > Pixel resolution values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">Pixel resolution values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SUBPIXEL_MODE_INTEGER_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SUBPIXEL_MODE_INTEGER_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><a id="bookmark-AVC_ME_SUBPIXEL_MODE_HPEL_INTEL"></a>AVC_ME_SUBPIXEL_MODE_HPEL_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a id="bookmark-AVC_ME_SUBPIXEL_MODE_HPEL_INTEL"></a>AVC_ME_SUBPIXEL_MODE_HPEL_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><a id="bookmark-AVC_ME_SUBPIXEL_MODE_QPEL_INTEL"></a>AVC_ME_SUBPIXEL_MODE_QPEL_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a id="bookmark-AVC_ME_SUBPIXEL_MODE_QPEL_INTEL"></a>AVC_ME_SUBPIXEL_MODE_QPEL_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>Cost precision values:</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p><strong>Cost precision values:</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > Cost precision values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">Cost precision values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_COST_PRECISION_QPEL_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_COST_PRECISION_QPEL_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_COST_PRECISION_HPEL_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_COST_PRECISION_HPEL_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_COST_PRECISION_PEL_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_COST_PRECISION_PEL_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_COST_PRECISION_DPEL_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_COST_PRECISION_DPEL_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>Inter bidirectional weights:</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p><strong>Inter bidirectional weights:</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > Inter bidirectional weight values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">Inter bidirectional weight values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x10</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_BIDIR_WEIGHT_QUARTER_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x10</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_BIDIR_WEIGHT_QUARTER_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x15</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_BIDIR_WEIGHT_THIRD_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x15</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_BIDIR_WEIGHT_THIRD_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x20</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_BIDIR_WEIGHT_HALF_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x20</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_BIDIR_WEIGHT_HALF_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x2B</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_BIDIR_WEIGHT_TWO_THIRD_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x2B</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_BIDIR_WEIGHT_TWO_THIRD_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x30</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_BIDIR_WEIGHT_THREE_QUARTER_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x30</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_BIDIR_WEIGHT_THREE_QUARTER_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>Inter border reached values</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p><strong>Inter border reached values</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > Inter border reached values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">Inter border reached values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_BORDER_REACHED_LEFT_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_BORDER_REACHED_LEFT_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_BORDER_REACHED_RIGHT_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_BORDER_REACHED_RIGHT_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_BORDER_REACHED_TOP_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_BORDER_REACHED_TOP_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x8</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_BORDER_REACHED_BOTTOM_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_BORDER_REACHED_BOTTOM_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>Intra macro-block shape values</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p><strong>Intra macro-block shape values</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > Intra macro-block shape values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">Intra macro-block shape values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_INTRA_16x16_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_INTRA_16x16_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_INTRA_8x8_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_INTRA_8x8_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_INTRA_4x4_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_INTRA_4x4_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>Inter skip block partition type:</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p><strong>Inter skip block partition type:</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > Intra macro-block shape values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">Intra macro-block shape values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SKIP_BLOCK_PARTITION_16x16_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SKIP_BLOCK_PARTITION_16x16_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x04000</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SKIP_BLOCK_PARTITION_8x8_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x04000</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SKIP_BLOCK_PARTITION_8x8_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>Inter skip motion vector mask:</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p><strong>Inter skip motion vector mask:</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > Inter skip motion vector values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">Inter skip motion vector values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">(0x1&lt;&lt;24)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SKIP_BLOCK_16x16_FORWARD_ENABLE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">(0x1&lt;&lt;24)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SKIP_BLOCK_16x16_FORWARD_ENABLE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">(0x2&lt;&lt;24)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SKIP_BLOCK_16x16_BACKWARD_ ENABLE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">(0x2&lt;&lt;24)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SKIP_BLOCK_16x16_BACKWARD_ ENABLE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">(0x3&lt;&lt;24)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SKIP_BLOCK_16x16_DUAL_ENABLE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">(0x3&lt;&lt;24)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SKIP_BLOCK_16x16_DUAL_ENABLE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">(0x55&lt;&lt;24)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_FORWARD_ENABLE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">(0x55&lt;&lt;24)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_FORWARD_ENABLE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">(0xAA&lt;&lt;24)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_BACKWARD_ENABLE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">(0xAA&lt;&lt;24)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_BACKWARD_ENABLE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">(0xFF&lt;&lt;24)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_DUAL_ENABLE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">(0xFF&lt;&lt;24)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_DUAL_ENABLE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">(0x1&lt;&lt;24)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_0_FORWARD_ENABLE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">(0x1&lt;&lt;24)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_0_FORWARD_ENABLE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">(0x2&lt;&lt;24)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_0_BACKWARD_ENABLE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">(0x2&lt;&lt;24)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_0_BACKWARD_ENABLE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">(0x1&lt;&lt;26)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_1_FORWARD_ENABLE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">(0x1&lt;&lt;26)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_1_FORWARD_ENABLE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">(0x2&lt;&lt;26)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_1_BACKWARD_ENABLE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">(0x2&lt;&lt;26)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_1_BACKWARD_ENABLE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">(0x1&lt;&lt;28)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_2_FORWARD_ENABLE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">(0x1&lt;&lt;28)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_2_FORWARD_ENABLE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">(0x2&lt;&lt;28)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_2_BACKWARD_ENABLE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">(0x2&lt;&lt;28)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_2_BACKWARD_ENABLE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">(0x1&lt;&lt;30)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_3_FORWARD_ENABLE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">(0x1&lt;&lt;30)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_3_FORWARD_ENABLE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">(0x2&lt;&lt;30)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_3_BACKWARD_ENABLE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">(0x2&lt;&lt;30)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_SKIP_BLOCK_8x8_3_BACKWARD_ENABLE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>Block based skip type values:</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p><strong>Block based skip type values:</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > Block based skip type values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">Block based skip type values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_BLOCK_BASED_SKIP_4x4_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_BLOCK_BASED_SKIP_4x4_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x80</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_BLOCK_BASED_SKIP_8x8_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x80</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_BLOCK_BASED_SKIP_8x8_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>Luma intra partition mask values:</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p><strong>Luma intra partition mask values:</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > Luma intra partition mask values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">Luma intra partition mask values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_INTRA_LUMA_PARTITION_MASK_ALL_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_INTRA_LUMA_PARTITION_MASK_ALL_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x6</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_INTRA_LUMA_PARTITION_MASK_16x16_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x6</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_INTRA_LUMA_PARTITION_MASK_16x16_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_INTRA_LUMA_PARTITION_MASK_8x8_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_INTRA_LUMA_PARTITION_MASK_8x8_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_INTRA_LUMA_PARTITION_MASK_4x4_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_INTRA_LUMA_PARTITION_MASK_4x4_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>Intra neighbor availability mask values:</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p><strong>Intra neighbor availability mask values:</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > Intra neighbor availability mask values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">Intra neighbor availability mask values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x60</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_INTRA_NEIGHBOR_LEFT_MASK_ENABLE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x60</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_INTRA_NEIGHBOR_LEFT_MASK_ENABLE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x10</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_INTRA_NEIGHBOR_UPPER_MASK_ENABLE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x10</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_INTRA_NEIGHBOR_UPPER_MASK_ENABLE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x8</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_INTRA_NEIGHBOR_UPPER_RIGHT_MASK_ENABLE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_INTRA_NEIGHBOR_UPPER_RIGHT_MASK_ENABLE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_INTRA_NEIGHBOR_UPPER_LEFT_MASK_ENABLE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_INTRA_NEIGHBOR_UPPER_LEFT_MASK_ENABLE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>Luma intra modes:</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p><strong>Luma intra modes:</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > Luma intra mode values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">Luma intra mode values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_LUMA_PREDICTOR_MODE_VERTICAL_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_LUMA_PREDICTOR_MODE_VERTICAL_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_LUMA_PREDICTOR_MODE_HORIZONTAL_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_LUMA_PREDICTOR_MODE_HORIZONTAL_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_LUMA_PREDICTOR_MODE_DC_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_LUMA_PREDICTOR_MODE_DC_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_LUMA_PREDICTOR_MODE_DIAGONAL_DOWN_LEFT_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_LUMA_PREDICTOR_MODE_DIAGONAL_DOWN_LEFT_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_LUMA_PREDICTOR_MODE_DIAGONAL_DOWN_RIGHT_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_LUMA_PREDICTOR_MODE_DIAGONAL_DOWN_RIGHT_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_LUMA_PREDICTOR_MODE_PLANE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_LUMA_PREDICTOR_MODE_PLANE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_LUMA_PREDICTOR_MODE_VERTICAL_RIGHT_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_LUMA_PREDICTOR_MODE_VERTICAL_RIGHT_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x6</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_LUMA_PREDICTOR_MODE_HORIZONTAL_DOWN_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x6</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_LUMA_PREDICTOR_MODE_HORIZONTAL_DOWN_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x7</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_LUMA_PREDICTOR_MODE_VERTICAL_LEFT_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x7</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_LUMA_PREDICTOR_MODE_VERTICAL_LEFT_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x8</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_LUMA_PREDICTOR_MODE_HORIZONTAL_UP_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_LUMA_PREDICTOR_MODE_HORIZONTAL_UP_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>Chroma intra modes:</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p><strong>Chroma intra modes:</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > Chroma intra mode values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">Chroma intra mode values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_CHROMA_PREDICTOR_MODE_DC_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL,  SubgroupAvcMotionEstimationChromaINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_CHROMA_PREDICTOR_MODE_DC_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL,  SubgroupAvcMotionEstimationChromaINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_CHROMA_PREDICTOR_MODE_HORIZONTAL_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationChromaINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_CHROMA_PREDICTOR_MODE_HORIZONTAL_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationChromaINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_CHROMA_PREDICTOR_MODE_VERTICAL_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationChromaINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_CHROMA_PREDICTOR_MODE_VERTICAL_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationChromaINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">AVC_ME_CHROMA_PREDICTOR_MODE_PLANE_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationChromaINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">AVC_ME_CHROMA_PREDICTOR_MODE_PLANE_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationChromaINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><strong>Reference image select values:</strong><br></p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:55%;">
-<col style="width:35%;">
+<div class="paragraph">
+<p><strong>Reference image select values:</strong><br></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 55%;">
+<col style="width: 35%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > </th>
-<th class="tableblock halign-left valign-top" > Reference image select values </th>
-<th class="tableblock halign-left valign-top" >  Enabling Capabilities</th>
+<th class="tableblock halign-left valign-top"></th>
+<th class="tableblock halign-left valign-top">Reference image select values</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><a id="bookmark-forward"></a>AVC_ME_FRAME_FORWARD_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a id="bookmark-forward"></a>AVC_ME_FRAME_FORWARD_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><a id="bookmark-backward"></a>AVC_ME_FRAME_BACKWARD_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a id="bookmark-backward"></a>AVC_ME_FRAME_BACKWARD_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><a id="bookmark-dual"></a>AVC_ME_FRAME_DUAL_INTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><a id="bookmark-dual"></a>AVC_ME_FRAME_DUAL_INTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupAvcMotionEstimationINTEL</p></td>
 </tr>
 </tbody>
 </table>
-<div style="page-break-after:always"></div>
+<div style="page-break-after: always;"></div>
 </div>
 <div class="sect2">
 <h3 id="bookmark-Instructions">Instructions</h3>
-<div class="paragraph"><p>Modify Section <strong>3.32.7</strong>, <strong>Constant-Creation Instructions</strong>, amending the desciption of OpConstantNull as follow:</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:100%;">
+<div class="paragraph">
+<p>Modify Section <strong>3.32.7</strong>, <strong>Constant-Creation Instructions</strong>, amending the desciption of OpConstantNull as follow:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="paragraph"><p><strong>OpConstantNull</strong><br>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong>OpConstantNull</strong><br>
 <br>
-Declare a new null constant value.</p></div>
-<div class="paragraph"><p>The null value is type dependent, defined as follows:</p></div>
-<div class="ulist"><ul>
+Declare a new null constant value.</p>
+</div>
+<div class="paragraph">
+<p>The null value is type dependent, defined as follows:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Scalar Boolean: false
-</p>
+<p>Scalar Boolean: false</p>
 </li>
 <li>
-<p>
-Scalar integer: 0
-</p>
+<p>Scalar integer: 0</p>
 </li>
 <li>
-<p>
-Scalar floating point: +0.0 (all bits 0)
-</p>
+<p>Scalar floating point: +0.0 (all bits 0)</p>
 </li>
 <li>
-<p>
-All other scalars: Abstract
-</p>
+<p>All other scalars: Abstract</p>
 </li>
 <li>
-<p>
-Composites: Members are set recursively to the null constant according to the null value of their constituent types.
-</p>
+<p>Composites: Members are set recursively to the null constant according to the null value of their constituent types.</p>
 </li>
 <li>
-<p>
-<span class="blue"><a href="#bookmark-OpTypesVME">IME/REF/SIC payload &amp; result types</a></span>: Abstract
-</p>
+<p><span class="blue"><a href="#bookmark-OpTypesVME">IME/REF/SIC payload &amp; result types</a></span>: Abstract</p>
 </li>
-</ul></div>
-<div class="paragraph"><p>Result Type must be one of the following types:</p></div>
-<div class="ulist"><ul>
+</ul>
+</div>
+<div class="paragraph">
+<p>Result Type must be one of the following types:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Scalar or vector Boolean type
-</p>
-</li>
-<li>
-<p>
-Scalar or vector integer type
-</p>
+<p>Scalar or vector Boolean type</p>
 </li>
 <li>
-<p>
-Scalar or vector floating-point type
-</p>
+<p>Scalar or vector integer type</p>
 </li>
 <li>
-<p>
-Pointer type
-</p>
+<p>Scalar or vector floating-point type</p>
 </li>
 <li>
-<p>
-Event type
-</p>
+<p>Pointer type</p>
 </li>
 <li>
-<p>
-Device side event type
-</p>
+<p>Event type</p>
 </li>
 <li>
-<p>
-Reservation id type
-</p>
+<p>Device side event type</p>
 </li>
 <li>
-<p>
-Queue type
-</p>
+<p>Reservation id type</p>
 </li>
 <li>
-<p>
-Composite type
-</p>
+<p>Queue type</p>
 </li>
 <li>
-<p>
-<span class="blue"><a href="#bookmark-OpTypesVME">IME/REF/SIC payload or result type</a></span>
-</p>
+<p>Composite type</p>
 </li>
-</ul></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:33%;">
-<col style="width:33%;">
+<li>
+<p><span class="blue"><a href="#bookmark-OpTypesVME">IME/REF/SIC payload or result type</a></span></p>
+</li>
+</ul>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3335%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">46</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">46</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
 </tr>
 </tbody>
 </table></div></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>Modify Section <strong>3.32.10</strong>, <strong>Image Instructions</strong>, amending the description of OpImage as follows:</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:100%;">
+<div class="paragraph">
+<p>Modify Section <strong>3.32.10</strong>, <strong>Image Instructions</strong>, amending the description of OpImage as follows:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="paragraph"><p><strong>OpImage</strong><br>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong>OpImage</strong><br>
 <br>
-Extract the image from a sampled or VME image.</p></div>
-<div class="paragraph"><p>Result Type must be OpTypeImage.</p></div>
-<div class="paragraph"><p>Sampled Image must have type OpTypeSampledImage or <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span> whose Image Type is the same as Result Type.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:11%;">
-<col style="width:11%;">
-<col style="width:22%;">
-<col style="width:22%;">
-<col style="width:33%;">
+Extract the image from a sampled or VME image.</p>
+</div>
+<div class="paragraph">
+<p>Result Type must be OpTypeImage.</p>
+</div>
+<div class="paragraph">
+<p>Sampled Image must have type OpTypeSampledImage or <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span> whose Image Type is the same as Result Type.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 11.1111%;">
+<col style="width: 11.1111%;">
+<col style="width: 22.2222%;">
+<col style="width: 22.2222%;">
+<col style="width: 33.3334%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">100</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; VME Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">100</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; VME Image</p></td>
 </tr>
 </tbody>
 </table></div></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>Modify Section <strong>3.32.10</strong>, <strong>Image Instructions</strong>, adding the description of OpVmeImageINTEL as follows:</p></div>
-<table class="tableblock frame-all grid-all" id="bookmark-OpVmeImageINTEL"
-style="
-width:100%;
-">
-<col style="width:100%;">
+<div class="paragraph">
+<p>Modify Section <strong>3.32.10</strong>, <strong>Image Instructions</strong>, adding the description of OpVmeImageINTEL as follows:</p>
+</div>
+<table id="bookmark-OpVmeImageINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 100%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="paragraph"><p><strong>OpVmeImageINTEL</strong><br>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p><strong>OpVmeImageINTEL</strong><br>
 <br>
-Create a VME image, containing both a (media) sampler and an image.</p></div>
-<div class="paragraph"><p>Result Type must be the <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p>Image is an object whose type is an OpTypeImage, whose Sampled operand is 0 or 1, and whose Dim operand is not SubpassData.</p></div>
-<div class="paragraph"><p>Sampler must be an object whose type is <span class="blue"><a href="#bookmark-OpTypeSampler"><em>OpTypeSampler</em></a></span>.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+Create a VME image, containing both a (media) sampler and an image.</p>
+</div>
+<div class="paragraph">
+<p>Result Type must be the <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p>Image is an object whose type is an OpTypeImage, whose Sampled operand is 0 or 1, and whose Dim operand is not SubpassData.</p>
+</div>
+<div class="paragraph">
+<p>Sampler must be an object whose type is <span class="blue"><a href="#bookmark-OpTypeSampler"><em>OpTypeSampler</em></a></span>.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5699</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Image Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Sampler</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5699</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Image Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Sampler</p></td>
 </tr>
 </tbody>
 </table></div></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph" id="bookmark-InstructionsGroup"><p>Modify Section 3.32.21, <strong>Group Instructions</strong>, adding to the end of the list of instructions the following MCE instructions:</p></div>
-<div style="page-break-after:always"></div>
+<div id="bookmark-InstructionsGroup" class="paragraph">
+<p>Modify Section 3.32.21, <strong>Group Instructions</strong>, adding to the end of the list of instructions the following MCE instructions:</p>
+</div>
+<div style="page-break-after: always;"></div>
 <div class="sect3">
 <h4 id="bookmark-GroupMCEInstructions">MCE instructions</h4>
-<div class="paragraph"><p>A set of generic MCE operations which may be called for IME, REF, or SIC operations with the restrictions as stated in their descriptions. They can be called only during specific phases of these operations as indicated in the description of the instructions.</p></div>
-<div class="paragraph"><p>These instruction are only guaranteed to work correctly if placed strictly within uniform control flow within the Subgroup execution scope. This ensures that if any invocation executes it, all invocations will execute it. If placed elsewhere, the results are undefined.</p></div>
+<div class="paragraph">
+<p>A set of generic MCE operations which may be called for IME, REF, or SIC operations with the restrictions as stated in their descriptions. They can be called only during specific phases of these operations as indicated in the description of the instructions.</p>
+</div>
+<div class="paragraph">
+<p>These instruction are only guaranteed to work correctly if placed strictly within uniform control flow within the Subgroup execution scope. This ensures that if any invocation executes it, all invocations will execute it. If placed elsewhere, the results are undefined.</p>
+</div>
 <div class="sect4">
 <h5 id="_multi_reference_cost_configuration_instructions">Multi-reference cost configuration instructions:</h5>
-<div class="paragraph"><p>These instructions enable multi-reference image costing. They allow for the configuration of the payloads to favorably bias the major partitions coming from reference images that are closer to the source image, than the ones coming from reference images that are further away. The distance of the reference images, in the timing order, from the source image is implied based on the order in which the reference images are declared in the kernel parameter operand list.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<div class="paragraph">
+<p>These instructions enable multi-reference image costing. They allow for the configuration of the payloads to favorably bias the major partitions coming from reference images that are closer to the source image, than the ones coming from reference images that are further away. The distance of the reference images, in the timing order, from the source image is implied based on the order in which the reference images are declared in the kernel parameter operand list.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultInterBaseMultiReferencePenaltyINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultInterBaseMultiReferencePenaltyINTEL</strong><br>
 <br>
 Get the default base multi-reference cost penalty in U4U4 format when HW assisted multi-reference search is used.</p>
 <p class="tableblock"><em>Result Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness in U4U4 format.</p>
-<p class="tableblock"><em>Slice Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p>
+<p class="tableblock"><em>Slice Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
 <p class="tableblock"><em>Qp</em> must be a 8-bit scalar integer type and a valid quantization parameter value between 0 and 51. It is treated as an unsigned value.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5713</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Slice Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Qp</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5713</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Slice Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Qp</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><div><div class="paragraph"><p><strong>OpSubgroupAvcMceSetInterBaseMultiReferencePenaltyINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcMceSetInterBaseMultiReferencePenaltyINTEL</strong><br>
 <br>
-Set the multi-reference base penalty when HW assisted multi-reference search is performed.</p></div>
-<div class="paragraph"><p>Reference major partitions get associated with a penalty based on its distance from the source image. The <em>Reference Base Penalty</em> is scaled using a scaling factor based on the implied distance of the reference image from
-the source image as shown below.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:50%;">
-<col style="width:50%;">
+Set the multi-reference base penalty when HW assisted multi-reference search is performed.</p>
+</div>
+<div class="paragraph">
+<p>Reference major partitions get associated with a penalty based on its distance from the source image. The <em>Reference Base Penalty</em> is scaled using a scaling factor based on the implied distance of the reference image from
+the source image as shown below.</p>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 50%;">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">[1, 2]</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1x</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[1, 2]</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1x</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">[3, 6]</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2x</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[3, 6]</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2x</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">[7, 15]</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3x</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">[7, 15]</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3x</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Reference Base Penalty</em> must be 8-bit scalar integer type in U4U4 format and the decoded integer value must fit within 12 bits. It is treated as an unsigned value.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Reference Base Penalty</em> must be 8-bit scalar integer type in U4U4 format and the decoded integer value must fit within 12 bits. It is treated as an unsigned value.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>5</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5714</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Reference Base Penalty</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>5</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5714</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Reference Base Penalty</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_inter_shape_and_direction_cost_configuration_instructions">Inter shape and direction cost configuration instructions</h5>
-<div class="paragraph"><p>These instructions enable shape costing for inter estimation. They allow for the configuration of payloads for the biasing of certain shapes over others based on the configured parameters.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<div class="paragraph">
+<p>These instructions enable shape costing for inter estimation. They allow for the configuration of payloads for the biasing of certain shapes over others based on the configured parameters.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultInterShapePenaltyINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultInterShapePenaltyINTEL</strong><br>
 <br>
 Get the default packed shape cost for inter estimation in U4U4 format.</p>
 <p class="tableblock"><em>Result Type</em> must be an OpTypeInt with 64-bit Width and 0 Signedness.</p>
-<p class="tableblock"><em>Slice Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p>
+<p class="tableblock"><em>Slice Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
 <p class="tableblock"><em>Qp</em> must be a 8-bit scalar integer type and a valid quantization parameter value between 0 and 51. It is treated as an unsigned value.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5715</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Slice Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Qp</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5715</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Slice Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Qp</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><div><div class="paragraph"><p><strong>OpSubgroupAvcMceSetInterShapePenaltyINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcMceSetInterShapePenaltyINTEL</strong><br>
 <br>
-Set the shape penalty for inter motion estimation.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Packed Shape Penalty</em> must be 64-bit scalar integer type. It is treated as an unsigned value. The following bits specify the shape penalty in U4U4 format:</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:75%;">
+Set the shape penalty for inter motion estimation.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Packed Shape Penalty</em> must be 64-bit scalar integer type. It is treated as an unsigned value. The following bits specify the shape penalty in U4U4 format:</p>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 55%;">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7:0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">16x8 and 8x16</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7:0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">16x8 and 8x16</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">15:8</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">8x8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">15:8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">8x8</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">23:16</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">8x4 and 4x8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">23:16</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">8x4 and 4x8</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">31:24</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4x4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">31:24</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4x4</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">39:32</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">16x16</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">39:32</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">16x16</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">63:40</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Must be zero</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">63:40</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Must be zero</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>The U4U4 decoded integer values for byte 0 and byte 4 must bit fit in 12 bits, while the U4U4 decoded integer values for the other bytes must fit within 10 bits.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<div class="paragraph">
+<p>The U4U4 decoded integer values for byte 0 and byte 4 must bit fit in 12 bits, while the U4U4 decoded integer values for the other bytes must fit within 10 bits.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>5</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5716</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Packed Shape Penalty</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>5</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5716</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Packed Shape Penalty</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultInterDirectionPenaltyINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultInterDirectionPenaltyINTEL</strong><br>
 <br>
 Get the default direction penalty for inter estimation in U4U4 format.</p>
 <p class="tableblock"><em>Result Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness.</p>
-<p class="tableblock"><em>Slice Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p>
+<p class="tableblock"><em>Slice Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
 <p class="tableblock"><em>Qp</em> must be a 8-bit scalar integer type and a valid quantization parameter value between 0 and 51. It is treated as an unsigned value.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5717</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Slice Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Qp</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5717</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Slice Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Qp</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><p class="tableblock"><strong>OpSubgroupAvcMceSetInterDirectionPenaltyINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><strong>OpSubgroupAvcMceSetInterDirectionPenaltyINTEL</strong><br>
 <br>
 Set the direction penalty for backward images used in inter motion estimation.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Direction Cost</em> must be 8-bit scalar integer type in U4U4 format and
 the decoded integer value must fit within 12 bits. It is treated as an unsigned value.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5718</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Direction Cost</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5718</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Direction Cost</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_intra_shape_cost_configuration_phase_instructions">Intra shape cost configuration phase instructions</h5>
-<div class="paragraph"><p>These instructions enable shape costing for intra estimation. They allow for the configuration of payloads for biasing of certain shapes over others based on the configured parameters. Only the instruction providing the default shape penalty is specified as an MCE instruction. The instruction which actually configures the payload for the intra estimation operation is specified as a SIC instruction.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<div class="paragraph">
+<p>These instructions enable shape costing for intra estimation. They allow for the configuration of payloads for biasing of certain shapes over others based on the configured parameters. Only the instruction providing the default shape penalty is specified as an MCE instruction. The instruction which actually configures the payload for the intra estimation operation is specified as a SIC instruction.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultIntraLumaShapePenaltyINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultIntraLumaShapePenaltyINTEL</strong><br>
 <br>
 Get the default packed luma intra penalty estimation in U4U4 format.</p>
 <p class="tableblock"><em>Result Type</em> must be an OpTypeInt with 32-bit Width and 0 Signedness.</p>
-<p class="tableblock"><em>Slice Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p>
+<p class="tableblock"><em>Slice Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
 <p class="tableblock"><em>Qp</em> must be a 8-bit scalar integer type and a valid quantization parameter value between 0 and 51. It is treated as an unsigned value.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5719</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Slice Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Qp</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5719</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Slice Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Qp</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_inter_motion_vector_cost_configuration_phase_instructions">Inter motion vector cost configuration phase instructions</h5>
-<div class="paragraph"><p>These instructions enable motion vector costing for inter estimation. The distortion measure is augmented to favor motion vectors closer to the cost-center considered in conjunction with the primary objective of minimizing the SAD between the source and reference blocks.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<div class="paragraph">
+<p>These instructions enable motion vector costing for inter estimation. The distortion measure is augmented to favor motion vectors closer to the cost-center considered in conjunction with the primary objective of minimizing the SAD between the source and reference blocks.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultInterMotionVectorCostTableINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultInterMotionVectorCostTableINTEL</strong><br>
 <br>
 Get the default inter motion vector cost table for the pre-defined control points in U4U4 format for the input Qp and slice type.</p>
 <p class="tableblock"><em>Result Type</em> must be a vector(2) of i32 values and 0 Signedness.</p>
-<p class="tableblock"><em>Slice Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p>
+<p class="tableblock"><em>Slice Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
 <p class="tableblock"><em>Qp</em> must be a 8-bit scalar integer type and a valid quantization parameter value between 0 and 51. It is treated as an unsigned value.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5720</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Slice Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Qp</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5720</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Slice Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Qp</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:25%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="3" ><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultHighPenaltyCostTableINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="3"><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultHighPenaltyCostTableINTEL</strong><br>
 <br>
 Get the default predefined packed U4U4 format high cost table for high Qp. This may be more appropriate for frame sequences with high motion.</p>
 <p class="tableblock"><em>Result Type</em> must be a vector(2) of i32 values and 0 Signedness.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5721</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5721</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:25%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="3" ><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultMediumPenaltyCostTableINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="3"><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultMediumPenaltyCostTableINTEL</strong><br>
 <br>
 Get the default predefined packed U4U4 format high cost table for medium Qp. This may be more appropriate for frame sequences with high motion.</p>
 <p class="tableblock"><em>Result Type</em> must be a vector(2) of i32 values and 0 Signedness.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5722</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5722</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:25%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="3" ><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultLowPenaltyCostTableINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="3"><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultLowPenaltyCostTableINTEL</strong><br>
 <br>
 Get the default predefined packed U4U4 format low cost table for high Qp. This may be more appropriate for frame sequences with high motion.</p>
 <p class="tableblock"><em>Result Type</em> must be a vector(2) of i32 values and 0 Signedness.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5723</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5723</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="7" ><div><div class="paragraph"><p><strong>OpSubgroupAvcMceSetMotionVectorCostFunctionINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="7"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcMceSetMotionVectorCostFunctionINTEL</strong><br>
 <br>
-Update the input payload to set the cost precision along with the cost center and cost table and return it.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Packed Cost Center Delta</em> must be an OpTypeInt with 64-bit Width and 0 Signedness. It is the packed bidirectional cost center delta value relative to the source macroblock, which specifies the 4 bidirectional cost centers of each of the 8x8 partitions of the reference image.  If only unidirectional search is performed then the values of the backward reference cost centers must be zero. Work-item <em>n</em> provides the value of cost center <em>n</em>. It is specified in QPEL units. For 16x16 partitions work-item <em>0</em> provides the cost center. For 8x16 partitions work-items <em>0</em> and <em>1</em> provide the cost centers. For 16x8 partitions work-items <em>0</em> and <em>2</em> provide the cost centers. The X and Y coordinates of each cost center delta must be in the range [-2048, 2047] and [-512.00 to 511.75] respectively, otherwise the results are undefined.</p></div>
-<div class="paragraph"><p><em>Packed Cost Table</em> must be a vector(2) of i32 values and 0 Signedness and specifies the cost penalties for pre-defined control points in U4U4 format in the cost function curve. The first 7 bytes specify 7 control points representing consecutive powers-of-two delta units (2<sup>0</sup> to 2<sup>6</sup>).  Each delta unit, dx, is the distance of a motion vector, mv, from the specified cost center, cc (dx=abs(mv-cc)). The cost penalty values at in-between control points are linearly interpolated. The range of the cost function is defined to be from 2<sup>0</sup> to 2<sup>6</sup> delta units. The 8th byte of the packed cost table specifies the penalty base factor (over_cost) for dx distances that are out-of-range. The penalty of out-of-range cost dx distances is computed as min(over_cost + int(dx) - 64, 255).</p></div>
-<div class="paragraph"><p><em>Cost Precision</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid cost precision value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>, and specifies the precision of the delta units from the cost center, dx. This effectively can be used to control the range of the cost function as follows:</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:37%;">
-<col style="width:37%;">
+Update the input payload to set the cost precision along with the cost center and cost table and return it.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Packed Cost Center Delta</em> must be an OpTypeInt with 64-bit Width and 0 Signedness. It is the packed bidirectional cost center delta value relative to the source macroblock, which specifies the 4 bidirectional cost centers of each of the 8x8 partitions of the reference image.  If only unidirectional search is performed then the values of the backward reference cost centers must be zero. Work-item <em>n</em> provides the value of cost center <em>n</em>. It is specified in QPEL units. For 16x16 partitions work-item <em>0</em> provides the cost center. For 8x16 partitions work-items <em>0</em> and <em>1</em> provide the cost centers. For 16x8 partitions work-items <em>0</em> and <em>2</em> provide the cost centers. The X and Y coordinates of each cost center delta must be in the range [-2048, 2047] and [-512.00 to 511.75] respectively, otherwise the results are undefined.</p>
+</div>
+<div class="paragraph">
+<p><em>Packed Cost Table</em> must be a vector(2) of i32 values and 0 Signedness and specifies the cost penalties for pre-defined control points in U4U4 format in the cost function curve. The first 7 bytes specify 7 control points representing consecutive powers-of-two delta units (2<sup>0</sup> to 2<sup>6</sup>).  Each delta unit, dx, is the distance of a motion vector, mv, from the specified cost center, cc (dx=abs(mv-cc)). The cost penalty values at in-between control points are linearly interpolated. The range of the cost function is defined to be from 2<sup>0</sup> to 2<sup>6</sup> delta units. The 8th byte of the packed cost table specifies the penalty base factor (over_cost) for dx distances that are out-of-range. The penalty of out-of-range cost dx distances is computed as min(over_cost + int(dx) - 64, 255).</p>
+</div>
+<div class="paragraph">
+<p><em>Cost Precision</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid cost precision value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>, and specifies the precision of the delta units from the cost center, dx. This effectively can be used to control the range of the cost function as follows:</p>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 55%;">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 37.5%;">
+<col style="width: 37.5%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" >Precision </th>
-<th class="tableblock halign-left valign-top" > Deltas </th>
-<th class="tableblock halign-left valign-top" > Pixel Range</th>
+<th class="tableblock halign-left valign-top">Precision</th>
+<th class="tableblock halign-left valign-top">Deltas</th>
+<th class="tableblock halign-left valign-top">Pixel Range</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">PEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">pixel</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0-64</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">pixel</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0-64</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">DPEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">dual pixel</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0-127</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">DPEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">dual pixel</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0-127</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">HALF</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">half pixel</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0-31</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">HALF</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">half pixel</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0-31</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">QUARTER</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">quarter pixel</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0-15</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">QUARTER</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">quarter pixel</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0-15</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>The inter distortion for a block can be described by the following formula:</p></div>
+<div class="paragraph">
+<p>The inter distortion for a block can be described by the following formula:</p>
+</div>
 <div class="literalblock">
-<div class="content monospaced">
+<div class="content">
 <pre>Distortion =
     SAD(or HAAR) + MV_Cost_Penalty +
     Shape_Penalty + Direction_Cost +
     Multi_Reference_Penalty</pre>
-</div></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</div>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>7</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5724</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Packed Cost Center Delta</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Packed Cost Table</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Cost Precision</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>7</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5724</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Packed Cost Center Delta</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Packed Cost Table</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Cost Precision</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_intra_mode_cost_configuration_phase_instructions">Intra mode cost configuration phase instructions</h5>
-<div class="paragraph"><p>These instructions enable mode costing for intra estimation. They allow for the configuration of payloads to bias the computed intra modes to be closer to their configured neighbor modes. This form of costing is similar to the inter motion vector costing. Only the instructions providing the defaults mode costs are specified as MCE instructions. The remaining instructions which actually configure the payload for the intra estimation operation is specified as SIC instruction.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<div class="paragraph">
+<p>These instructions enable mode costing for intra estimation. They allow for the configuration of payloads to bias the computed intra modes to be closer to their configured neighbor modes. This form of costing is similar to the inter motion vector costing. Only the instructions providing the defaults mode costs are specified as MCE instructions. The remaining instructions which actually configure the payload for the intra estimation operation is specified as SIC instruction.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultIntraLumaModePenaltyINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultIntraLumaModePenaltyINTEL</strong><br>
 <br>
 Get the default inter motion vector cost table for the pre-defined control points in U4U4 format for the input Qp and slice type.</p>
 <p class="tableblock"><em>Result Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness in U4U4 format.</p>
-<p class="tableblock"><em>Slice Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p>
+<p class="tableblock"><em>Slice Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid slice type value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
 <p class="tableblock"><em>Qp</em> must be a 8-bit scalar integer type and a valid quantization parameter value between 0 and 51. It is treated as an unsigned value.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5725</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Slice Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Qp</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5725</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Slice Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Qp</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:25%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="3" ><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultNonDcLumaIntraPenaltyINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="3"><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultNonDcLumaIntraPenaltyINTEL</strong><br>
 <br>
 Get the default intra non-dc cost penalty for intra luma estimation in packed 32-bit integer format.</p>
 <p class="tableblock"><em>Result Type</em> must be an OpTypeInt with 32-bit Width and 0 Signedness.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5726</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5726</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:25%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="3" ><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultIntraChromaModeBasePenaltyINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="3"><p class="tableblock"><strong>OpSubgroupAvcMceGetDefaultIntraChromaModeBasePenaltyINTEL</strong><br>
 <br>
 Get the default chroma mode base penalty in U4U4 format.</p>
 <p class="tableblock"><em>Result Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness in U4U4 format.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationChromaINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5727</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5727</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_miscellaneous_property_configuration_phase_instructions">Miscellaneous property configuration phase instructions</h5>
-<div class="paragraph"><p>These instructions enable miscellaneous MCE properties settings.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<div class="paragraph">
+<p>These instructions enable miscellaneous MCE properties settings.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcMceSetAcOnlyHaarINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcMceSetAcOnlyHaarINTEL</strong><br>
 <br>
 Update the input payload to enable an AC only HAAR SAD mode and return it. It overrides any previous setting for sad adjustment. This feature is mainly intended for improved block matching in frame-rate conversion (FRC) kernels.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5728</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5728</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><p class="tableblock"><strong>OpSubgroupAvcMceSetSourceInterlacedFieldPolarityINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><strong>OpSubgroupAvcMceSetSourceInterlacedFieldPolarityINTEL</strong><br>
 <br>
 Update the input payload to specify the field polarities for interlaced source images used for inter or intra operations.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p>
-<p class="tableblock"><em>Source Field Polarity</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid field polarity value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span> indicating the field polarity for the source image.</p>
+<p class="tableblock"><em>Source Field Polarity</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid field polarity value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span> indicating the field polarity for the source image.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5729</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Source Field Polarity</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5729</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Source Field Polarity</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><p class="tableblock"><strong>OpSubgroupAvcMceSetSingleReferenceInterlacedFieldPolarityINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><strong>OpSubgroupAvcMceSetSingleReferenceInterlacedFieldPolarityINTEL</strong><br>
 <br>
 Update the input payload to specify the field polarities for interlaced reference images used for single reference inter search or check operation.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p>
-<p class="tableblock"><em>Reference Field Polarity</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid field polarity value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span> indicating the field polarity for the reference image.</p>
+<p class="tableblock"><em>Reference Field Polarity</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid field polarity value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span> indicating the field polarity for the reference image.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5730</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Reference Field Polarity</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5730</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Reference Field Polarity</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2858%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><strong>OpSubgroupAvcMceSetDualReferenceInterlacedFieldPolaritiesINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><strong>OpSubgroupAvcMceSetDualReferenceInterlacedFieldPolaritiesINTEL</strong><br>
 <br>
 Update the input payload to specify the field polarities for interlaced reference images used for dual reference inter search or check operation.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p>
-<p class="tableblock"><em>Forward Reference Field Polarity</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid field polarity value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span> indicating the field polarity for the forward reference image.</p>
-<p class="tableblock"><em>Backward Reference Field Polarity</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid field polarity value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span> indicating the field polarity for the forward reference image.</p>
+<p class="tableblock"><em>Forward Reference Field Polarity</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid field polarity value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span> indicating the field polarity for the forward reference image.</p>
+<p class="tableblock"><em>Backward Reference Field Polarity</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid field polarity value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span> indicating the field polarity for the forward reference image.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5731</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Forward Reference Field Polarity</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Backward Reference Field Polarity</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5731</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Forward Reference Field Polarity</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Backward Reference Field Polarity</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_result_processing_phase_instructions">Result processing phase instructions</h5>
-<div class="paragraph"><p>These instructions facilitate the extraction of components of the result from VME unit.</p></div>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcMceGetMotionVectorsINTEL"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<div class="paragraph">
+<p>These instructions facilitate the extraction of components of the result from VME unit.</p>
+</div>
+<table id="bookmark-OpSubgroupAvcMceGetMotionVectorsINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><div><div class="paragraph"><p><strong>OpSubgroupAvcMceGetMotionVectorsINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcMceGetMotionVectorsINTEL</strong><br>
 <br>
-Get the MCE packed BMVs result.<br></p></div>
-<div class="paragraph"><p>Up to 16 packed BMVs are returned, one per work-item. If the MCE search operation&#8217;s payload was setup for unidirectional search then only the forward packed MV will be valid in each BMV, otherwise both packed MVs will be valid. The BMVs have to be selected by their respective work-items based on the result block major and minor shapes. <br></p></div>
-<div class="paragraph"><p>If the major shape is:</p></div>
-<div class="ulist"><ul>
+Get the MCE packed BMVs result.<br></p>
+</div>
+<div class="paragraph">
+<p>Up to 16 packed BMVs are returned, one per work-item. If the MCE search operation&#8217;s payload was setup for unidirectional search then only the forward packed MV will be valid in each BMV, otherwise both packed MVs will be valid. The BMVs have to be selected by their respective work-items based on the result block major and minor shapes. <br></p>
+</div>
+<div class="paragraph">
+<p>If the major shape is:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-16x16, then one BMV is returned by work-item 0 <br>
-</p>
+<p>16x16, then one BMV is returned by work-item 0 <br></p>
 </li>
 <li>
-<p>
-16x8, or 8x16, then two BMVs are returned by work-items 0 and 8 <br>
-</p>
+<p>16x8, or 8x16, then two BMVs are returned by work-items 0 and 8 <br></p>
 </li>
 <li>
-<p>
-8x8, then four sets of BMVs corresponding to the four partitions in traditional Z-order are returned by work-items in the ranges [0, 3], [4, 7], [8, 11], and [12, 15]; the minor shape will determine exactly which work-items in the reserved inclusive range for the partition returns the BMVs for that partition <br>
-</p>
+<p>8x8, then four sets of BMVs corresponding to the four partitions in traditional Z-order are returned by work-items in the ranges [0, 3], [4, 7], [8, 11], and [12, 15]; the minor shape will determine exactly which work-items in the reserved inclusive range for the partition returns the BMVs for that partition <br></p>
 </li>
-</ul></div>
-<div class="paragraph"><p>If the range of work-items for the 8x8 major partition is [n, n+3] and the minor shape is:</p></div>
-<div class="ulist"><ul>
+</ul>
+</div>
+<div class="paragraph">
+<p>If the range of work-items for the 8x8 major partition is [n, n+3] and the minor shape is:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-8x8, then work-item <em>n</em> returns the BMV for each minor partition <br>
-</p>
-</li>
-<li>
-<p>
-8x4 or 4x8, then work-items <em>n</em> and <em>n+2</em> returns the BMVs for each minor partition <br>
-</p>
+<p>8x8, then work-item <em>n</em> returns the BMV for each minor partition <br></p>
 </li>
 <li>
-<p>
-4x4, then all work-items in [n, n+3] return the BMVs for each minor partition in traditional Z-order <br>
-</p>
+<p>8x4 or 4x8, then work-items <em>n</em> and <em>n+2</em> returns the BMVs for each minor partition <br></p>
 </li>
-</ul></div>
-<div class="admonitionblock">
-<table><tr>
+<li>
+<p>4x4, then all work-items in [n, n+3] return the BMVs for each minor partition in traditional Z-order <br></p>
+</li>
+</ul>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/important.png" alt="Important">
+<i class="fa icon-important" title="Important"></i>
 </td>
 <td class="content">
-<div class="olist arabic"><ol class="arabic">
+<div class="olist arabic">
+<ol class="arabic">
 <li>
-<p>
-All sub-block BMVs get replicated for each partition. For example, for a 16x16
+<p>All sub-block BMVs get replicated for each partition. For example, for a 16x16
 partition, all smaller sub-block BMVs are replicated to the same BMV, and for 8x8 partition, each 8x8 must have its respective sub-block BMVs replicated. This
-is not important to extract the component BMVs itself, but is needed if the result of this instruction is used to initialize the input motion vectors of a REF initialization instruction.
-</p>
+is not important to extract the component BMVs itself, but is needed if the result of this instruction is used to initialize the input motion vectors of a REF initialization instruction.</p>
 </li>
 <li>
-<p>
-With interlaced images, the MBs for the top field MBs are considered as logically
-overlapping with the bottom MBs.
-</p>
+<p>With interlaced images, the MBs for the top field MBs are considered as logically
+overlapping with the bottom MBs.</p>
 </li>
-</ol></div>
-</td>
-</tr></table>
+</ol>
 </div>
-<div class="paragraph"><p><em>Result Type</em> must be an OpTypeInt with 64-bit Width and 0 Signedness.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be an OpTypeInt with 64-bit Width and 0 Signedness.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>4</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5738</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>4</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5738</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcMceGetInterDistortionsINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcMceGetInterDistortionsINTEL</strong><br>
 <br>
 Get the MCE inter distortions result corresponding to the BMVs returned by <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetMotionVectorsINTEL">OpSubgroupAvcMceGetMotionVectorsINTEL</a></span>. The MCE inter directions result
 returned by <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterDirectionsINTEL">OpSubgroupAvcMceGetInterDirectionsINTEL</a></span> will specify if the distortion corresponds to the forward MV, backward MV, or the bidirectional MV in the BMV. Up to 16 distortions are returned, one per work-item.</p>
 <p class="tableblock">The distortions have to be selected by their respective work-items based on the result block major and minor shapes just as for the result MVs as described above.</p>
 <p class="tableblock"><em>Result Type</em> must be an OpTypeInt with 16-bit Width and 0 Signedness.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5739</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5739</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcMceGetBestInterDistortionsINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcMceGetBestInterDistortionsINTEL</strong><br>
 <br>
 Get the best inter distortion for the whole MB.</p>
 <p class="tableblock"><em>Result Type</em> must be an OpTypeInt with 16-bit Width and 0 Signedness.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5740</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5740</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcMceGetInterMajorShapeINTEL"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table id="bookmark-OpSubgroupAvcMceGetInterMajorShapeINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcMceGetInterMajorShapeINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcMceGetInterMajorShapeINTEL</strong><br>
 <br>
 Get the MCE inter MB major partition shape.</p>
-<p class="tableblock">The returned values are as per the inter-MB major shapes values as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p>
+<p class="tableblock">The returned values are as per the inter-MB major shapes values as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
 <p class="tableblock">This can only be called as part of an IME or REF operation evaluation.</p>
 <p class="tableblock"><em>Result Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5741</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5741</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcMceGetInterMinorShapeINTEL"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table id="bookmark-OpSubgroupAvcMceGetInterMinorShapeINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcMceGetInterMinorShapeINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcMceGetInterMinorShapeINTEL</strong><br>
 <br>
 Get the MCE inter MB minor partition shapes.</p>
-<p class="tableblock">It returns a bit field with the minor shapes for the 4 8x8 sub-partitions in traditional Z order. Two bits are reserved for each of the four sub-partitions in row-major order.  The returned 2-bit values are as per the inter-MB minor shapes values as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p>
+<p class="tableblock">It returns a bit field with the minor shapes for the 4 8x8 sub-partitions in traditional Z order. Two bits are reserved for each of the four sub-partitions in row-major order.  The returned 2-bit values are as per the inter-MB minor shapes values as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
 <p class="tableblock">This instruction returns valid results only if the major shape is 8x8, otherwise the results are undefined.</p>
 <p class="tableblock">This can only be called as part of an IME or REF operation evaluation.</p>
 <p class="tableblock"><em>Result Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5742</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5742</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcMceGetInterDirectionsINTEL"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table id="bookmark-OpSubgroupAvcMceGetInterDirectionsINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><div><div class="paragraph"><p><strong>OpSubgroupAvcMceGetInterDirectionsINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcMceGetInterDirectionsINTEL</strong><br>
 <br>
-Get the MCE inter MB major partition directions.</p></div>
-<div class="paragraph"><p>It returns a bit field with the direction for up to 4 major sub-partitions in traditional Z order. Two bits are reserved for each of the four sub-partitions. The returned 2-bit values are as per the inter-MB major shape direction values as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div>
-<div class="paragraph"><p>If the major partition is:</p></div>
-<div class="ulist"><ul>
+Get the MCE inter MB major partition directions.</p>
+</div>
+<div class="paragraph">
+<p>It returns a bit field with the direction for up to 4 major sub-partitions in traditional Z order. Two bits are reserved for each of the four sub-partitions. The returned 2-bit values are as per the inter-MB major shape direction values as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div>
+<div class="paragraph">
+<p>If the major partition is:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-16x16, then bits in the range [0, 1] contains the direction
-</p>
+<p>16x16, then bits in the range [0, 1] contains the direction</p>
 </li>
 <li>
-<p>
-16x8 or 8x16, then bits in the ranges [0, 1] and [2,3] contains the two partitions
-  directions
-</p>
+<p>16x8 or 8x16, then bits in the ranges [0, 1] and [2,3] contains the two partitions
+directions</p>
 </li>
 <li>
-<p>
-8x8, then bits in the ranges [0, 1], [2, 3], [4,5], and [6, 7] contains the four  partitions directions
-</p>
+<p>8x8, then bits in the ranges [0, 1], [2, 3], [4,5], and [6, 7] contains the four  partitions directions</p>
 </li>
-</ul></div>
-<div class="paragraph"><p>The returned values are as per the inter direction values as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div>
-<div class="paragraph"><p>This can only be called as part of an IME or REF operation evaluation.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</ul>
+</div>
+<div class="paragraph">
+<p>The returned values are as per the inter direction values as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div>
+<div class="paragraph">
+<p>This can only be called as part of an IME or REF operation evaluation.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>4</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5743</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>4</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5743</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcMceGetInterMotionVectorCountINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcMceGetInterMotionVectorCountINTEL</strong><br>
 <br>
 Get the count of motion vectors (based on the partitioning decision) returned by the search operation.</p>
 <p class="tableblock">This can only be called as part of an IME or REF operation evaluation.</p>
 <p class="tableblock"><em>Result Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5744</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5744</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcMceGetInterReferenceIdsINTEL"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table id="bookmark-OpSubgroupAvcMceGetInterReferenceIdsINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><div><div class="paragraph"><p><strong>OpSubgroupAvcMceGetInterReferenceIdsINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcMceGetInterReferenceIdsINTEL</strong><br>
 <br>
-Get the MCE inter MB reference identifiers in a packed integer format, with the following bits specifying the reference identifiers for the major partitions.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:27%;">
-<col style="width:72%;">
+Get the MCE inter MB reference identifiers in a packed integer format, with the following bits specifying the reference identifiers for the major partitions.</p>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 55%;">
+<colgroup>
+<col style="width: 27.2727%;">
+<col style="width: 72.7273%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3:0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3:0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 0</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7:4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7:4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 0</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">11:8</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">11:8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">15:12</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">15:12</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">19:16</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">19:16</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 2</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">23:20</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">23:20</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 2</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">27:24</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">27:24</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 3</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">31:28</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">31:28</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 3</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>The values of each individual 4-bit reference identifier range from 0 to 15, with each value identifying the distance of ordered pair of forward/backward reference images as declared in the VME kernel parameter operand list.</p></div>
-<div class="paragraph"><p>If the dual-reference evaluation instructions are not used, then the values of the backward reference identifiers are undefined.</p></div>
-<div class="paragraph"><p>The blocks are numbered using the traditional Z order. For larger block sizes, the
+<div class="paragraph">
+<p>The values of each individual 4-bit reference identifier range from 0 to 15, with each value identifying the distance of ordered pair of forward/backward reference images as declared in the VME kernel parameter operand list.</p>
+</div>
+<div class="paragraph">
+<p>If the dual-reference evaluation instructions are not used, then the values of the backward reference identifiers are undefined.</p>
+</div>
+<div class="paragraph">
+<p>The blocks are numbered using the traditional Z order. For larger block sizes, the
 sub-block reference identifier pairs are replicated. For example, for a 16x16 block all
 four pairs of reference identifiers are replicated to the value of the first pair for
-block 0.</p></div>
-<div class="admonitionblock">
-<table><tr>
+block 0.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/note.png" alt="Note">
+<i class="fa icon-note" title="Note"></i>
 </td>
 <td class="content">
-<div class="paragraph"><p>Unless HW assisted multi-reference search was performed using the IME streamin/streamout evaluation instructions, the individual 4-bit reference identifier pair values will all be the same (pointing to the same pair for forward/backward reference
-images).</p></div>
-</td>
-</tr></table>
+<div class="paragraph">
+<p>Unless HW assisted multi-reference search was performed using the IME streamin/streamout evaluation instructions, the individual 4-bit reference identifier pair values will all be the same (pointing to the same pair for forward/backward reference
+images).</p>
 </div>
-<div class="paragraph"><p><em>Result Type</em> must be an OpTypeInt with 32-bit Width and 0 Signedness.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be an OpTypeInt with 32-bit Width and 0 Signedness.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>4</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5745</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>4</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5745</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2858%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><div><div class="paragraph"><p><strong>OpSubgroupAvcMceGetInterReferenceInterlacedFieldPolaritiesINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcMceGetInterReferenceInterlacedFieldPolaritiesINTEL</strong><br>
 <br>
 Get the MCE inter MB reference field polarities for the corresponding reference identifiers returned by <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterReferenceIdsINTEL">OpSubgroupAvcMceGetInterReferenceIdsINTEL</a></span> in a packed integer format, with the following bits specifying the reference field polarities
-for the major partitions.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:27%;">
-<col style="width:72%;">
+for the major partitions.</p>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 55%;">
+<colgroup>
+<col style="width: 27.2727%;">
+<col style="width: 72.7273%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 0</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 2</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 3</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 4</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 5</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 6</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 6</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 7</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 7</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>If the dual-reference evaluation instructions are not used, then the values of the backward reference field polarities are undefined.</p></div>
-<div class="paragraph"><p>The blocks are numbered using the traditional Z order. For larger block sizes, the sub-block reference field polarities are replicated. For example, for a 16x16 block all
-four pairs of reference field polarities are replicated to the value of the first pair for block 0.</p></div>
-<div class="admonitionblock">
-<table><tr>
+<div class="paragraph">
+<p>If the dual-reference evaluation instructions are not used, then the values of the backward reference field polarities are undefined.</p>
+</div>
+<div class="paragraph">
+<p>The blocks are numbered using the traditional Z order. For larger block sizes, the sub-block reference field polarities are replicated. For example, for a 16x16 block all
+four pairs of reference field polarities are replicated to the value of the first pair for block 0.</p>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/important.png" alt="Important">
+<i class="fa icon-important" title="Important"></i>
 </td>
 <td class="content">
-<div class="paragraph"><p>An important restriction is that when multiple IME operations are performed for a
+<div class="paragraph">
+<p>An important restriction is that when multiple IME operations are performed for a
 HW multi-assisted multi-reference search operation using the streamin/streamout capabilities, the same reference image parameter cannot be used with different polarities in the sequence of IME operations used for a HW-assisted search
 operation. In other words, the field polarities for reference image parameters must be used consistently across IME operations used in a HW assisted multi-reference search
-operation.</p></div>
-</td>
-</tr></table>
+operation.</p>
 </div>
-<div class="paragraph"><p><em>Result Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness.</p></div>
-<div class="paragraph"><p><em>Packed Reference Ids</em> must be an OpTypeInt with 32-bit Width and 0 Signedness, and is as defined by the return value of <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterReferenceIdsINTEL">OpSubgroupAvcMceGetInterReferenceIdsINTEL</a></span>.</p></div>
-<div class="paragraph"><p><em>Packed Reference Parameter Field Polarities</em> must be an OpTypeInt with 32-bit Width and 0 Signedness, and specifies the packed bit field of field polarities for each of the (up to 16) forward/backward interleaved pairs of reference images in the same order as specified in the kernel parameter operand list, as used for the inter search operation. If less than 16 pairs are used then the corresponding bit field values are ignored.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness.</p>
+</div>
+<div class="paragraph">
+<p><em>Packed Reference Ids</em> must be an OpTypeInt with 32-bit Width and 0 Signedness, and is as defined by the return value of <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterReferenceIdsINTEL">OpSubgroupAvcMceGetInterReferenceIdsINTEL</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Packed Reference Parameter Field Polarities</em> must be an OpTypeInt with 32-bit Width and 0 Signedness, and specifies the packed bit field of field polarities for each of the (up to 16) forward/backward interleaved pairs of reference images in the same order as specified in the kernel parameter operand list, as used for the inter search operation. If less than 16 pairs are used then the corresponding bit field values are ignored.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>6</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5746</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Packed Reference Ids</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Packed Reference Parameter Field Polarities</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>6</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5746</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Packed Reference Ids</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Packed Reference Parameter Field Polarities</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<div style="page-break-after:always"></div>
+<div style="page-break-after: always;"></div>
 </div>
 </div>
 <div class="sect3">
 <h4 id="bookmark-GroupIMEInstructions">IME instructions</h4>
-<div class="paragraph"><p>A set of ordered phases of instructions are required to be called to evaluate an integer motion estimation result.</p></div>
-<div class="paragraph"><p>These instruction are only guaranteed to work correctly if placed strictly within uniform control flow within the Subgroup execution scope. This ensures that if any invocation executes it, all invocations will execute it. If placed elsewhere, the results are undefined.</p></div>
+<div class="paragraph">
+<p>A set of ordered phases of instructions are required to be called to evaluate an integer motion estimation result.</p>
+</div>
+<div class="paragraph">
+<p>These instruction are only guaranteed to work correctly if placed strictly within uniform control flow within the Subgroup execution scope. This ensures that if any invocation executes it, all invocations will execute it. If placed elsewhere, the results are undefined.</p>
+</div>
 <div class="sect4">
 <h5 id="_initialization_instructions">Initialization instructions</h5>
-<div class="paragraph"><p>These instructions create a properly initialized payload that can be used for further configured for evaluating IME operations. This is a required initial phase.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
+<div class="paragraph">
+<p>These instructions create a properly initialized payload that can be used for further configured for evaluating IME operations. This is a required initial phase.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2858%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><div><div class="paragraph"><p><strong>OpSubgroupAvcImeInitializeINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcImeInitializeINTEL</strong><br>
 <br>
-Return an initialized payload for a VME integer search (IME) operation.</p></div>
-<div class="paragraph"><p>The payload is initialized for progressive frame operations, and the cost configuration values and the miscellaneous property values are all initialized to zero. The cost configuration and the miscellaneous property configuration instructions must be used to override the initial configurations in the payload.</p></div>
-<div class="admonitionblock">
-<table><tr>
+Return an initialized payload for a VME integer search (IME) operation.</p>
+</div>
+<div class="paragraph">
+<p>The payload is initialized for progressive frame operations, and the cost configuration values and the miscellaneous property values are all initialized to zero. The cost configuration and the miscellaneous property configuration instructions must be used to override the initial configurations in the payload.</p>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/important.png" alt="Important">
+<i class="fa icon-important" title="Important"></i>
 </td>
 <td class="content">
-<div class="paragraph"><p>If the source image is an interlaced scan image, then the bottom field lines are considered as logically overlapping with the top field lines (i.e. the top field MBs are considered as logically overlapping with the bottom MBs) for the purposes for specifying the Src Coord' value.</p></div>
-</td>
-</tr></table>
+<div class="paragraph">
+<p>If the source image is an interlaced scan image, then the bottom field lines are considered as logically overlapping with the top field lines (i.e. the top field MBs are considered as logically overlapping with the bottom MBs) for the purposes for specifying the <em>Src Coord</em> value.</p>
 </div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Src Coord</em> must be a vector(2) of i16 values and 0 Signedness. It represents the 2D offset of the top left corner of the source MB in pixel units in the source image. Source MBs at the image borders are allowed to be partial, but the top-left corner must be within the image.</p></div>
-<div class="paragraph" id="bookmark-PartitionMask"><p><em>Partition Mask</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. The legal values can be composed by setting the appropriate bit fields specified by partition mask values as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>  using OpBitwiseAnd.</p></div>
-<div class="paragraph"><p><em>SAD Adjustment</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid SAD adjustment mode as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>. If it is set to <span class="blue"><a href="#bookmark-HAAR"><em>AVC_ME_SAD_ADJUST_MODE_HAAR_INTEL</em></a></span>, a simple wavelet transform, Haar transform, is used to refine the distortion measure of SAD. Haar transform here is used as a coarse estimation of the integer transform.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Src Coord</em> must be a vector(2) of i16 values and 0 Signedness. It represents the 2D offset of the top left corner of the source MB in pixel units in the source image. Source MBs at the image borders are allowed to be partial, but the top-left corner must be within the image.</p>
+</div>
+<div id="bookmark-PartitionMask" class="paragraph">
+<p><em>Partition Mask</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. The legal values can be composed by setting the appropriate bit fields specified by partition mask values as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>  using OpBitwiseAnd.</p>
+</div>
+<div class="paragraph">
+<p><em>SAD Adjustment</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid SAD adjustment mode as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>. If it is set to <span class="blue"><a href="#bookmark-HAAR"><em>AVC_ME_SAD_ADJUST_MODE_HAAR_INTEL</em></a></span>, a simple wavelet transform, Haar transform, is used to refine the distortion measure of SAD. Haar transform here is used as a coarse estimation of the integer transform.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>6</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5747</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Coord</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Partition Mask</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; SAD Adjustment</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>6</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5747</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Coord</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Partition Mask</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; SAD Adjustment</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_configuration_instructions">Configuration instructions</h5>
-<div class="paragraph"><p>These instructions allow for configuration of the search window. A call to either <span class="blue"><a href="#bookmark-OpSubgroupAvcImeSetSingleReferenceINTEL">OpSubgroupAvcImeSetSingleReferenceINTEL</a></span> or <span class="blue"><a href="#bookmark-OpSubgroupAvcImeSetDualReferenceINTEL">OpSubgroupAvcImeSetDualReferenceINTEL</a></span> is required. This is a required phase immediately following the initialization phase.</p></div>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcImeSetSingleReferenceINTEL"
-style="
-width:100%;
-">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
+<div class="paragraph">
+<p>These instructions allow for configuration of the search window. A call to either <span class="blue"><a href="#bookmark-OpSubgroupAvcImeSetSingleReferenceINTEL">OpSubgroupAvcImeSetSingleReferenceINTEL</a></span> or <span class="blue"><a href="#bookmark-OpSubgroupAvcImeSetDualReferenceINTEL">OpSubgroupAvcImeSetDualReferenceINTEL</a></span> is required. This is a required phase immediately following the initialization phase.</p>
+</div>
+<table id="bookmark-OpSubgroupAvcImeSetSingleReferenceINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2858%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><div><div class="paragraph"><p><strong>OpSubgroupAvcImeSetSingleReferenceINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcImeSetSingleReferenceINTEL</strong><br>
 <br>
-Update the input payload for a VME single-reference search with the configuration for the reference window search region, and return it.</p></div>
-<div class="admonitionblock">
-<table><tr>
+Update the input payload for a VME single-reference search with the configuration for the reference window search region, and return it.</p>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/important.png" alt="Important">
+<i class="fa icon-important" title="Important"></i>
 </td>
 <td class="content">
-<div class="paragraph"><p>If the reference image is an interlaced scan image, then the top field lines are considered as logically overlapping with the bottom field lines (i.e. the top field MBs are considered as logically overlapping with the bottom MBs) for the purposes for
-specifying the <em>Ref Offset</em> value.</p></div>
-</td>
-</tr></table>
+<div class="paragraph">
+<p>If the reference image is an interlaced scan image, then the top field lines are considered as logically overlapping with the bottom field lines (i.e. the top field MBs are considered as logically overlapping with the bottom MBs) for the purposes for
+specifying the <em>Ref Offset</em> value.</p>
 </div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Ref Offset</em> specifies the 2D reference window offset, and must be a vector(2) of i16 values and interpreted as signed values. The X and Y coordinates must be in the range [-2048, 2047], otherwise the results are undefined. The reference window is allowed to be partially outside the image. Pixel replication is applied to generate out-of-bound reference pixels. It is specified in PEL units. Results are undefined in the reference region is completely outside the image.</p></div>
-<div class="paragraph" id="bookmark-SearchWindow"><p><em>Search Window Config</em> must be an OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid unreserved search window configuration value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Ref Offset</em> specifies the 2D reference window offset, and must be a vector(2) of i16 values and interpreted as signed values. The X and Y coordinates must be in the range [-2048, 2047], otherwise the results are undefined. The reference window is allowed to be partially outside the image. Pixel replication is applied to generate out-of-bound reference pixels. It is specified in PEL units. Results are undefined in the reference region is completely outside the image.</p>
+</div>
+<div id="bookmark-SearchWindow" class="paragraph">
+<p><em>Search Window Config</em> must be an OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid unreserved search window configuration value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>6</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5748</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Ref Offset</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Search Window Config</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>6</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5748</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Ref Offset</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Search Window Config</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcImeSetDualReferenceINTEL"
-style="
-width:100%;
-">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
+<table id="bookmark-OpSubgroupAvcImeSetDualReferenceINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="7" ><div><div class="paragraph"><p><strong>OpSubgroupAvcImeSetDualReferenceINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="7"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcImeSetDualReferenceINTEL</strong><br>
 <br>
 Update the input payload for a VME dual-reference search with the configurations for the
-reference window search regions, and return it.</p></div>
-<div class="admonitionblock">
-<table><tr>
+reference window search regions, and return it.</p>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/important.png" alt="Important">
+<i class="fa icon-important" title="Important"></i>
 </td>
 <td class="content">
-<div class="paragraph"><p>If a reference image is an interlaced scan image, then the top field lines are considered as logically overlapping with the bottom field lines (i.e. the top field MBs are considered as logically overlapping with the bottom MBs) for the purposes for specifying the corresponding <em>Fwd Ref Offset</em> and/or <em>Bwd Ref Offset</em> values.</p></div>
-</td>
-</tr></table>
+<div class="paragraph">
+<p>If a reference image is an interlaced scan image, then the top field lines are considered as logically overlapping with the bottom field lines (i.e. the top field MBs are considered as logically overlapping with the bottom MBs) for the purposes for specifying the corresponding <em>Fwd Ref Offset</em> and/or <em>Bwd Ref Offset</em> values.</p>
 </div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Fwd Ref Offset</em>/<em>Bwd Ref Offset</em> specify the 2D forward/backward reference window offset, and must be a vector(2) of i16 values and interpreted as signed values. The X and Y coordinates must be in the range [-2048, 2047], otherwise the results are undefined. The reference window is allowed to be partially outside the image. Pixel replication is applied to generate out-of-bound reference pixels. It is specified in PEL units. Results are undefined in the reference region is completely outside the image.</p></div>
-<div class="paragraph"><p><em>Search Window Config</em> must be an OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid unreserved search window configuration value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Fwd Ref Offset</em>/<em>Bwd Ref Offset</em> specify the 2D forward/backward reference window offset, and must be a vector(2) of i16 values and interpreted as signed values. The X and Y coordinates must be in the range [-2048, 2047], otherwise the results are undefined. The reference window is allowed to be partially outside the image. Pixel replication is applied to generate out-of-bound reference pixels. It is specified in PEL units. Results are undefined in the reference region is completely outside the image.</p>
+</div>
+<div class="paragraph">
+<p><em>Search Window Config</em> must be an OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid unreserved search window configuration value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>7</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5749</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Fwd Ref Offset</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Bwd Ref Offset</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">id&gt; Search Window Config</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>7</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5749</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Fwd Ref Offset</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Bwd Ref Offset</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">id&gt; Search Window Config</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><p class="tableblock"><strong>OpSubgroupAvcImeRefWindowSizeINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><strong>OpSubgroupAvcImeRefWindowSizeINTEL</strong><br>
 <br>
 Get the 2D size of the reference window in pixel units.</p>
 <p class="tableblock"><em>Result Type</em> must be a vector(2) of i16 values and 0 Signedness.</p>
-<p class="tableblock"><em>Search Window Config</em> must be an OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid unreserved search window configuration value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p>
+<p class="tableblock"><em>Search Window Config</em> must be an OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid unreserved search window configuration value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
 <p class="tableblock"><em>Dual Ref</em> must be a 8-bit scalar integer type and must evaluate to zero for a single reference search window and one for a dual-reference search window. It is treated as an unsigned value.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5750</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Search Window Config</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Dual Ref</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5750</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Search Window Config</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Dual Ref</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="7" ><div><div class="paragraph"><p><strong>OpSubgroupAvcImeAdjustRefOffsetINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="7"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcImeAdjustRefOffsetINTEL</strong><br>
 <br>
 If the input 2D reference window offset, <em>Ref Offset</em>, causes the reference window to be fully out-of-bound of the reference image, adjust it such that the reference window is
-within bounds of the reference image.</p></div>
-<div class="admonitionblock">
-<table><tr>
+within bounds of the reference image.</p>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/important.png" alt="Important">
+<i class="fa icon-important" title="Important"></i>
 </td>
 <td class="content">
-<div class="paragraph"><p>If the reference image is an interlaced scan image, then the bottom field lines are considered as logically overlapping with the top field lines the purposes for specifying the image size value. Since, the actual layout of the top and bottom fields in the reference image is in an interleaved fashion, the height of the top or bottom fields should be exactly half of the actual reference image height.</p></div>
-</td>
-</tr></table>
+<div class="paragraph">
+<p>If the reference image is an interlaced scan image, then the bottom field lines are considered as logically overlapping with the top field lines the purposes for specifying the image size value. Since, the actual layout of the top and bottom fields in the reference image is in an interleaved fashion, the height of the top or bottom fields should be exactly half of the actual reference image height.</p>
 </div>
-<div class="admonitionblock">
-<table><tr>
+</td>
+</tr>
+</table>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/note.png" alt="Note">
+<i class="fa icon-note" title="Note"></i>
 </td>
 <td class="content">
-<div class="paragraph"><p>A call to OpSubgroupAvcImeAdjustRefOffsetINTEL is optional. It is required only if the reference window offsets inputs to <span class="blue"><a href="#bookmark-OpSubgroupAvcImeSetSingleReferenceINTEL">OpSubgroupAvcImeSetSingleReferenceINTEL</a></span>  or
-<span class="blue"><a href="#bookmark-OpSubgroupAvcImeSetDualReferenceINTEL">OpSubgroupAvcImeSetDualReferenceINTEL</a></span>  is potentially out-of-bounds and need to be adjusted.</p></div>
-</td>
-</tr></table>
+<div class="paragraph">
+<p>A call to OpSubgroupAvcImeAdjustRefOffsetINTEL is optional. It is required only if the reference window offsets inputs to <span class="blue"><a href="#bookmark-OpSubgroupAvcImeSetSingleReferenceINTEL">OpSubgroupAvcImeSetSingleReferenceINTEL</a></span>  or
+<span class="blue"><a href="#bookmark-OpSubgroupAvcImeSetDualReferenceINTEL">OpSubgroupAvcImeSetDualReferenceINTEL</a></span>  is potentially out-of-bounds and need to be adjusted.</p>
 </div>
-<div class="paragraph"><p><em>Result Type</em> must be a vector(2) of i16 values and interpreted as signed values.</p></div>
-<div class="paragraph"><p><em>Ref Offset</em> must be a vector(2) of i16 values and interpreted as signed values. It specifies the 2D reference window offset. The X and Y coordinates must be in the range [-2048, 2047], otherwise the results are undefined.</p></div>
-<div class="paragraph"><p><em>Src Coord</em> must be a vector(2) of i16 values and 0 Signedness. It represents the 2D offset of the top left corner of the source MB in pixel units in the source image. Source MBs at the image borders are allowed to be partial, but the top-left corner must be within the image.</p></div>
-<div class="paragraph"><p><em>Ref Window Size</em> must be a vector(2) of i16 values and 0 Signedness. It specifies
-the 2D size of the reference window in pixel units.</p></div>
-<div class="paragraph"><p><em>Image Size</em> must be a vector(2) of i16 values and 0 Signedness. It specifies the 2D
-size of the progressive scan, or top or bottom fields, of the interlaced scan image in pixel units.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be a vector(2) of i16 values and interpreted as signed values.</p>
+</div>
+<div class="paragraph">
+<p><em>Ref Offset</em> must be a vector(2) of i16 values and interpreted as signed values. It specifies the 2D reference window offset. The X and Y coordinates must be in the range [-2048, 2047], otherwise the results are undefined.</p>
+</div>
+<div class="paragraph">
+<p><em>Src Coord</em> must be a vector(2) of i16 values and 0 Signedness. It represents the 2D offset of the top left corner of the source MB in pixel units in the source image. Source MBs at the image borders are allowed to be partial, but the top-left corner must be within the image.</p>
+</div>
+<div class="paragraph">
+<p><em>Ref Window Size</em> must be a vector(2) of i16 values and 0 Signedness. It specifies
+the 2D size of the reference window in pixel units.</p>
+</div>
+<div class="paragraph">
+<p><em>Image Size</em> must be a vector(2) of i16 values and 0 Signedness. It specifies the 2D
+size of the progressive scan, or top or bottom fields, of the interlaced scan image in pixel units.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>7</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5751</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Ref Offset</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Coord</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Ref Window Size</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Image Size</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>7</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5751</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Ref Offset</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Coord</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Ref Window Size</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Image Size</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_payload_type_conversion_instructions">Payload type conversion instructions</h5>
-<div class="paragraph"><p>These are optional instructions that may be called following the search configuration phase to convert IME payload to MCE payloads and vice-versa.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<div class="paragraph">
+<p>These are optional instructions that may be called following the search configuration phase to convert IME payload to MCE payloads and vice-versa.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcImeConvertToMcePayloadINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcImeConvertToMcePayloadINTEL</strong><br>
 <br>
 Convert the IME payload to a generic MCE payload.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5752</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5752</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcMceConvertToImePayloadINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcMceConvertToImePayloadINTEL</strong><br>
 <br>
 Convert the generic MCE payload to a IME payload.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5732</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5732</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_miscellaneous_property_configuration_instructions">Miscellaneous property configuration instructions</h5>
-<div class="paragraph"><p>These are optional instructions that may be called following the search configuration phase to enable miscellaneous properties setting in the payload.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<div class="paragraph">
+<p>These are optional instructions that may be called following the search configuration phase to enable miscellaneous properties setting in the payload.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><div><div class="paragraph"><p><strong>OpSubgroupAvcImeSetMaxMotionVectorCountINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcImeSetMaxMotionVectorCountINTEL</strong><br>
 <br>
 Specify the maximum number of motion vectors allowed for the current MB. The default setting is 32. Any other value may alter the MB partitioning decision. The IME operation
-will compute the best allowed partitioning such that the number of sub-block motion vectors will not exceed <span class="monospaced">Max Motion Vector Count</span>.</p></div>
-<div class="admonitionblock">
-<table><tr>
+will compute the best allowed partitioning such that the number of sub-block motion vectors will not exceed <code>Max Motion Vector Count</code>.</p>
+</div>
+<div class="admonitionblock tip">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/tip.png" alt="Tip">
+<i class="fa icon-tip" title="Tip"></i>
 </td>
 <td class="content">
-<div class="paragraph"><p>This can be used to handle the restriction for certain profiles for AVC in that the maximum number of motion vectors allowed for two consecutive MBs can only be 16.</p></div>
-</td>
-</tr></table>
+<div class="paragraph">
+<p>This can be used to handle the restriction for certain profiles for AVC in that the maximum number of motion vectors allowed for two consecutive MBs can only be 16.</p>
 </div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Max Motion Vector Count</em> must be an OpTypeInt with 8-bit Width and 0 Signedness, and specifies the maximum number of motion vectors allowed for the current MB. It must be in the range [1, 32], otherwise the results are undefined.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Max Motion Vector Count</em> must be an OpTypeInt with 8-bit Width and 0 Signedness, and specifies the maximum number of motion vectors allowed for the current MB. It must be in the range [1, 32], otherwise the results are undefined.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>5</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5753</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Max Motion Vector Count</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>5</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5753</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Max Motion Vector Count</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcImeSetUnidirectionalMixDisableINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcImeSetUnidirectionalMixDisableINTEL</strong><br>
 <br>
 Update the input payload to disable a mix of forward and backward MVs in the result.</p>
 <p class="tableblock">Default is to enable it.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5754</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5754</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><p class="tableblock"><strong>OpSubgroupAvcImeSetEarlySearchTerminationThresholdINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><strong>OpSubgroupAvcImeSetEarlySearchTerminationThresholdINTEL</strong><br>
 <br>
 Specifies the threshold value of a distortion compute of a 16x16 partition of a MB for a
 single-reference search, below which no more searching is performed for the MB.</p>
@@ -4889,127 +4428,142 @@ single-reference search, below which no more searching is performed for the MB.<
 <em>Result Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness.</p>
 <p class="tableblock"><em>Threshold</em> must be an OpTypeInt with 8-bit Width and 0 Signedness, and is specified in U4U4 format. Additionally, the integer value must fit within 14 bits.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5755</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Threshold</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5755</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Threshold</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-weightedsad"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<table id="bookmark-weightedsad" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><div><div class="paragraph"><p><strong>OpSubgroupAvcImeSetWeightedSadINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcImeSetWeightedSadINTEL</strong><br>
 <br>
-Set the (16) SAD weights for each 4x4 sub-block.</p></div>
-<div class="paragraph"><p>These values are used to decrease the SAD magnitude of each 4x4 sub-block by dividing
-the SAD of 4x4 sub-block of the source MB by its mapped weight. It requires a <span class="blue"><a href="#bookmark-PartitionMask"><em>Partition Mask</em></a></span> of 16x16 and forward <span class="blue"><a href="#bookmark-SearchWindow"><em>Search Window Configuration</em></a></span>.</p></div>
-<div class="paragraph"><p>The weighting pattern used is the traditional Z order for each 4x4 block. Weighted-SAD
-Control Mapping:</p></div>
+Set the (16) SAD weights for each 4x4 sub-block.</p>
+</div>
+<div class="paragraph">
+<p>These values are used to decrease the SAD magnitude of each 4x4 sub-block by dividing
+the SAD of 4x4 sub-block of the source MB by its mapped weight. It requires a <span class="blue"><a href="#bookmark-PartitionMask"><em>Partition Mask</em></a></span> of 16x16 and forward <span class="blue"><a href="#bookmark-SearchWindow"><em>Search Window Configuration</em></a></span>.</p>
+</div>
+<div class="paragraph">
+<p>The weighting pattern used is the traditional Z order for each 4x4 block. Weighted-SAD
+Control Mapping:</p>
+</div>
 <div class="literalblock">
-<div class="content monospaced">
+<div class="content">
 <pre>0 1 4 5
 2 3 6 7
 8 9 C D
 A B E F</pre>
-</div></div>
-<div class="paragraph"><p>A prior call to <span class="blue"><a href="#bookmark-OpSubgroupAvcImeSetSingleReferenceINTEL">OpSubgroupAvcImeSetSingleReferenceINTEL</a></span> to set up the forward reference image is required.</p></div>
-<div class="admonitionblock">
-<table><tr>
+</div>
+</div>
+<div class="paragraph">
+<p>A prior call to <span class="blue"><a href="#bookmark-OpSubgroupAvcImeSetSingleReferenceINTEL">OpSubgroupAvcImeSetSingleReferenceINTEL</a></span> to set up the forward reference image is required.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/note.png" alt="Note">
+<i class="fa icon-note" title="Note"></i>
 </td>
 <td class="content">
-<div class="paragraph"><p>This feature is mainly intended for improved block matching in image-rate conversion (FRC) kernels.</p></div>
-</td>
-</tr></table>
+<div class="paragraph">
+<p>This feature is mainly intended for improved block matching in image-rate conversion (FRC) kernels.</p>
 </div>
-<div class="paragraph"><p><em>Packed Sad Weights</em> must be an OpTypeInt with 32-bit Width and 0 Signedness. Each weight is of 2 bits represented in a packed format for each of the 4x4 blocks in Z order.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><em>Packed Sad Weights</em> must be an OpTypeInt with 32-bit Width and 0 Signedness. Each weight is of 2 bits represented in a packed format for each of the 4x4 blocks in Z order.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>5</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5756</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Packed Sad Weights</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>5</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5756</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Packed Sad Weights</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_evaluation_instructions">Evaluation instructions</h5>
-<div class="paragraph"><p>These instructions perform the evaluation of the IME operation configured in the payload with a VME media sampler and return the results.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
+<div class="paragraph">
+<p>These instructions perform the evaluation of the IME operation configured in the payload with a VME media sampler and return the results.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2858%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><strong>OpSubgroupAvcImeEvaluateWithSingleReferenceINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><strong>OpSubgroupAvcImeEvaluateWithSingleReferenceINTEL</strong><br>
 <br>
 Evaluate the basic IME operation with a single reference and return its results. The IME payload must have been configured with <span class="blue"><a href="#bookmark-OpSubgroupAvcImeSetSingleReferenceINTEL">OpSubgroupAvcImeSetSingleReferenceINTEL</a></span> .</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Src Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies the source image.</p>
 <p class="tableblock"><em>Ref Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies a forward reference image.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5757</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Ref Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5757</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Ref Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="7" ><p class="tableblock"><strong>OpSubgroupAvcImeEvaluateWithDualReferenceINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="7"><p class="tableblock"><strong>OpSubgroupAvcImeEvaluateWithDualReferenceINTEL</strong><br>
 <br>
 Evaluate the basic IME operation with dual references and return its results. The IME payload must have been configured with <span class="blue"><a href="#bookmark-OpSubgroupAvcImeSetDualReferenceINTEL">OpSubgroupAvcImeSetDualReferenceINTEL</a></span>.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p>
@@ -5017,70 +4571,68 @@ Evaluate the basic IME operation with dual references and return its results. Th
 <p class="tableblock"><em>Fwd Ref Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies a forward reference image.</p>
 <p class="tableblock"><em>Bwd Ref Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies a backward reference image.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5758</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Fwd Ref Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Bwd Ref Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5758</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Fwd Ref Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Bwd Ref Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2858%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><strong>OpSubgroupAvcImeEvaluateWithSingleReferenceStreamoutINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><strong>OpSubgroupAvcImeEvaluateWithSingleReferenceStreamoutINTEL</strong><br>
 <br>
 Evaluate the single reference IME operation with streamout and return its results. The IME payload must have been configured with <span class="blue"><a href="#bookmark-OpSubgroupAvcImeSetSingleReferenceINTEL">OpSubgroupAvcImeSetSingleReferenceINTEL</a></span>.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL"><em>OpTypeAvcImeResultSingleReferenceStreamoutINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Src Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies the source image.</p>
 <p class="tableblock"><em>Ref Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies a forward reference image.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5761</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Ref Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5761</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Ref Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="7" ><p class="tableblock"><strong>OpSubgroupAvcImeEvaluateWithDualReferenceStreamoutINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="7"><p class="tableblock"><strong>OpSubgroupAvcImeEvaluateWithDualReferenceStreamoutINTEL</strong><br>
 <br>
 Evaluate the basic IME operation with dual references with streamout and return its results. The IME payload must have been configured with <span class="blue"><a href="#bookmark-OpSubgroupAvcImeSetDualReferenceINTEL">OpSubgroupAvcImeSetDualReferenceINTEL</a></span>.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL"><em>OpTypeAvcImeResultDualReferenceStreamoutINTEL</em></a></span> type.</p>
@@ -5088,36 +4640,35 @@ Evaluate the basic IME operation with dual references with streamout and return 
 <p class="tableblock"><em>Fwd Ref Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies a forward reference image.</p>
 <p class="tableblock"><em>Bwd Ref Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies a backward reference image.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5762</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Fwd Ref Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Bwd Ref Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5762</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Fwd Ref Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Bwd Ref Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="7" ><p class="tableblock"><strong>OpSubgroupAvcImeEvaluateWithSingleReferenceStreaminINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="7"><p class="tableblock"><strong>OpSubgroupAvcImeEvaluateWithSingleReferenceStreaminINTEL</strong><br>
 <br>
 Evaluate the single reference IME operation with streamin and return its results. The IME payload must have been configured with <span class="blue"><a href="#bookmark-OpSubgroupAvcImeSetSingleReferenceINTEL">OpSubgroupAvcImeSetSingleReferenceINTEL</a></span>.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p>
@@ -5125,37 +4676,36 @@ Evaluate the single reference IME operation with streamin and return its results
 <p class="tableblock"><em>Ref Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies a forward reference image.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Streamin Components</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeSingleReferenceStreaminINTEL"><em>OpTypeAvcImeSingleReferenceStreaminINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5759</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Ref Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Streamin Components</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5759</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Ref Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Streamin Components</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:11%;">
-<col style="width:11%;">
-<col style="width:11%;">
-<col style="width:11%;">
-<col style="width:11%;">
-<col style="width:11%;">
-<col style="width:11%;">
-<col style="width:11%;">
-<col style="width:11%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 11.1111%;">
+<col style="width: 11.1111%;">
+<col style="width: 11.1111%;">
+<col style="width: 11.1111%;">
+<col style="width: 11.1111%;">
+<col style="width: 11.1111%;">
+<col style="width: 11.1111%;">
+<col style="width: 11.1111%;">
+<col style="width: 11.1112%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="8" ><p class="tableblock"><strong>OpSubgroupAvcImeEvaluateWithDualReferenceStreaminINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="8"><p class="tableblock"><strong>OpSubgroupAvcImeEvaluateWithDualReferenceStreaminINTEL</strong><br>
 <br>
 Evaluate the dual reference IME operation with streamin and return its results. The IME payload must have been configured with <span class="blue"><a href="#bookmark-OpSubgroupAvcImeSetDualReferenceINTEL">OpSubgroupAvcImeSetDualReferenceINTEL</a></span>.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p>
@@ -5164,37 +4714,36 @@ Evaluate the dual reference IME operation with streamin and return its results. 
 <p class="tableblock"><em>Bwd Ref Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies a backward reference image.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Streamin Components</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeDualReferenceStreaminINTEL"><em>OpTypeAvcImeDualReferenceStreaminINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">8</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5760</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Fwd Ref Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Bwd Ref Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Streamin Components</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5760</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Fwd Ref Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Bwd Ref Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Streamin Components</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="7" ><p class="tableblock"><strong>OpSubgroupAvcImeEvaluateWithSingleReferenceStreaminoutINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="7"><p class="tableblock"><strong>OpSubgroupAvcImeEvaluateWithSingleReferenceStreaminoutINTEL</strong><br>
 <br>
 Evaluate the single reference IME operation with streamin/streamout and return its results. The IME payload must have been configured with <span class="blue"><a href="#bookmark-OpSubgroupAvcImeSetSingleReferenceINTEL">OpSubgroupAvcImeSetSingleReferenceINTEL</a></span>.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL"><em>OpTypeAvcImeResultSingleReferenceStreamoutINTEL</em></a></span> type.</p>
@@ -5202,37 +4751,36 @@ Evaluate the single reference IME operation with streamin/streamout and return i
 <p class="tableblock"><em>Ref Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies a forward reference image.+</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Streamin Components</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeSingleReferenceStreaminINTEL"><em>OpTypeAvcImeSingleReferenceStreaminINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5763</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Ref Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Streamin Components</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5763</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Ref Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Streamin Components</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:11%;">
-<col style="width:11%;">
-<col style="width:11%;">
-<col style="width:11%;">
-<col style="width:11%;">
-<col style="width:11%;">
-<col style="width:11%;">
-<col style="width:11%;">
-<col style="width:11%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 11.1111%;">
+<col style="width: 11.1111%;">
+<col style="width: 11.1111%;">
+<col style="width: 11.1111%;">
+<col style="width: 11.1111%;">
+<col style="width: 11.1111%;">
+<col style="width: 11.1111%;">
+<col style="width: 11.1111%;">
+<col style="width: 11.1112%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="8" ><p class="tableblock"><strong>OpSubgroupAvcImeEvaluateWithDualReferenceStreaminoutINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="8"><p class="tableblock"><strong>OpSubgroupAvcImeEvaluateWithDualReferenceStreaminoutINTEL</strong><br>
 <br>
 Evaluate the dual reference IME operation with streamin/streamout and return its results. The IME payload must have been configured with <span class="blue"><a href="#bookmark-OpSubgroupAvcImeSetDualReferenceINTEL">OpSubgroupAvcImeSetDualReferenceINTEL</a></span>.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL"><em>OpTypeAvcImeResultDualReferenceStreamoutINTEL</em></a></span> type.</p>
@@ -5241,963 +4789,1108 @@ Evaluate the dual reference IME operation with streamin/streamout and return its
 <p class="tableblock"><em>Bwd Ref Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies a backward reference image.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImePayloadINTEL"><em>OpTypeAvcImePayloadINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Streamin Components</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeDualReferenceStreaminINTEL"><em>OpTypeAvcImeDualReferenceStreaminINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">8</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5764</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Fwd Ref Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Bwd Ref Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Streamin Components</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5764</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Fwd Ref Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Bwd Ref Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Streamin Components</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_result_type_conversion_instructions">Result type conversion instructions</h5>
-<div class="paragraph"><p>These are optional instructions that may be called following the evaluation phase to convert IME results to MCE results and vice-versa.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<div class="paragraph">
+<p>These are optional instructions that may be called following the evaluation phase to convert IME results to MCE results and vice-versa.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcImeConvertToMceResultINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcImeConvertToMceResultINTEL</strong><br>
 <br>
 Convert the IME result to a generic MCE result.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMceResultINTEL"><em>OpTypeAvcMceResultINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5765</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5765</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcMceConvertToImeResultINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcMceConvertToImeResultINTEL</strong><br>
 <br>
 Convert the generic MCE result to a IME result.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMceResultINTEL"><em>OpTypeAvcMceResultINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5733</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5733</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_result_processing_instructions">Result processing instructions</h5>
-<div class="paragraph"><p>These instructions are called following the evaluation phase to extract the various result components from an IME evaluation result.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<div class="paragraph">
+<p>These instructions are called following the evaluation phase to extract the various result components from an IME evaluation result.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcImeGetSingleReferenceStreaminINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcImeGetSingleReferenceStreaminINTEL</strong><br>
 <br>
 Return the streamed out BMVs and distortions from the input result from a single reference streamout IME operation that can be used as streamin input for a subsequent IME operation.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeSingleReferenceStreaminINTEL"><em>OpTypeAvcImeSingleReferenceStreaminINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL"><em>OpTypeAvcImeResultSingleReferenceStreamoutINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5766</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5766</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcImeGetDualReferenceStreaminINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcImeGetDualReferenceStreaminINTEL</strong><br>
 <br>
 Return the streamed out BMVs and distortions from the input result from a dual reference streamout IME operation that can be used as streamin input for a subsequent IME operation.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeDualReferenceStreaminINTEL"><em>OpTypeAvcImeDualReferenceStreaminINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL"><em>OpTypeAvcImeResultDualReferenceStreamoutINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5767</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5767</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcImeStripSingleReferenceStreamoutINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcImeStripSingleReferenceStreamoutINTEL</strong><br>
 <br>
 Strip out the single reference streamout BMVs and distortions from the streamout results and return the rest.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL"><em>OpTypeAvcImeResultSingleReferenceStreamoutINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5768</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5768</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcImeStripDualReferenceStreamoutINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcImeStripDualReferenceStreamoutINTEL</strong><br>
 <br>
 Strip out the dual reference streamout BMVs and distortions from the streamout results and return the rest.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL"><em>OpTypeAvcImeResultDualReferenceStreamoutINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5769</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5769</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-singlerefmv"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<table id="bookmark-singlerefmv" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><div><div class="paragraph"><p><strong>OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL</strong><br>
 <br>
 Get the packed motion vectors for the input major shape from the IME single reference
-streamout results.</p></div>
-<div class="paragraph"><p>Up to 4 packed MVs are returned, one per work-item. If the major shape is:</p></div>
-<div class="ulist"><ul>
+streamout results.</p>
+</div>
+<div class="paragraph">
+<p>Up to 4 packed MVs are returned, one per work-item. If the major shape is:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-16x6, then one packed MV is returned by work-item 0
-</p>
+<p>16x6, then one packed MV is returned by work-item 0</p>
 </li>
 <li>
-<p>
-16x8, or 8x16, then two packed MVs are returned by work-items 0 and 1
-</p>
+<p>16x8, or 8x16, then two packed MVs are returned by work-items 0 and 1</p>
 </li>
 <li>
-<p>
-8x8, then four packed MVs are returned by work-items 0 to 3.
-</p>
+<p>8x8, then four packed MVs are returned by work-items 0 to 3.</p>
 </li>
-</ul></div>
-<div class="paragraph"><p><em>Result Type</em> must be a OpTypeInt with 32-bit Width and 0 Signedness.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL"><em>OpTypeAvcImeResultSingleReferenceStreamoutINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Major Shape</em> must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</ul>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be a OpTypeInt with 32-bit Width and 0 Signedness.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL"><em>OpTypeAvcImeResultSingleReferenceStreamoutINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Major Shape</em> must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>5</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5770</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Major Shape</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>5</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5770</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Major Shape</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2858%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><div><div class="paragraph"><p><strong>OpSubgroupAvcImeGetStreamoutDualReferenceMajorShapeMotionVectorsINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcImeGetStreamoutDualReferenceMajorShapeMotionVectorsINTEL</strong><br>
 <br>
 Get the packed motion vectors for the input major shape from the IME dual reference
-streamout results.</p></div>
-<div class="paragraph"><p>Up to 4 packed MVs are returned, one per work-item in the same format as for motion
-vectors for single reference streamout as described in <span class="blue"><a href="#bookmark-singlerefmv">OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL</a></span>.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be a OpTypeInt with 32-bit Width and 0 Signedness.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL"><em>OpTypeAvcImeResultDualReferenceStreamoutINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Major Shape</em> must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div>
-<div class="paragraph"><p><em>Direction</em> must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major direction value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+streamout results.</p>
+</div>
+<div class="paragraph">
+<p>Up to 4 packed MVs are returned, one per work-item in the same format as for motion
+vectors for single reference streamout as described in <span class="blue"><a href="#bookmark-singlerefmv">OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be a OpTypeInt with 32-bit Width and 0 Signedness.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL"><em>OpTypeAvcImeResultDualReferenceStreamoutINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Major Shape</em> must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Direction</em> must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major direction value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>6</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5773</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Major Shape</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Direction</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>6</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5773</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Major Shape</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Direction</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><div><div class="paragraph"><p><strong>OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeDistortionsINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeDistortionsINTEL</strong><br>
 <br>
-Get the distortions for the input major shape from the IME single reference streamout results.</p></div>
-<div class="paragraph"><p>Up to 4 distortions are returned, one per work-item in the same format as for motion
-vectors as described in <span class="blue"><a href="#bookmark-singlerefmv">OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL</a></span>.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be a OpTypeInt with 16-bit Width and 0 Signedness.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL"><em>OpTypeAvcImeResultSingleReferenceStreamoutINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Major Shape</em> must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+Get the distortions for the input major shape from the IME single reference streamout results.</p>
+</div>
+<div class="paragraph">
+<p>Up to 4 distortions are returned, one per work-item in the same format as for motion
+vectors as described in <span class="blue"><a href="#bookmark-singlerefmv">OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be a OpTypeInt with 16-bit Width and 0 Signedness.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL"><em>OpTypeAvcImeResultSingleReferenceStreamoutINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Major Shape</em> must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>5</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5771</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Major Shape</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>5</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5771</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Major Shape</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2858%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><div><div class="paragraph"><p><strong>OpSubgroupAvcImeGetStreamoutDualReferenceMajorShapeDistortionsINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcImeGetStreamoutDualReferenceMajorShapeDistortionsINTEL</strong><br>
 <br>
-Get the distortions for the input major shape from the IME dual reference streamout results.</p></div>
-<div class="paragraph"><p>Up to 4 distortion are returned, one per work-item in the same format as for motion
-vectors for single reference streamout as described in <span class="blue"><a href="#bookmark-singlerefmv">OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL</a></span>.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be a OpTypeInt with 16-bit Width and 0 Signedness.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL"><em>OpTypeAvcImeResultDualReferenceStreamoutINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Major Shape</em> must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div>
-<div class="paragraph"><p><em>Direction</em> must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major direction value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+Get the distortions for the input major shape from the IME dual reference streamout results.</p>
+</div>
+<div class="paragraph">
+<p>Up to 4 distortion are returned, one per work-item in the same format as for motion
+vectors for single reference streamout as described in <span class="blue"><a href="#bookmark-singlerefmv">OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be a OpTypeInt with 16-bit Width and 0 Signedness.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL"><em>OpTypeAvcImeResultDualReferenceStreamoutINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Major Shape</em> must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Direction</em> must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major direction value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>6</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5774</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Major Shape</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Direction</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>6</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5774</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Major Shape</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Direction</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><div><div class="paragraph"><p><strong>OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeReferenceIdsINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeReferenceIdsINTEL</strong><br>
 <br>
-Get the reference identifiers for the input major shape and direction from the IME dual reference streamout results</p></div>
-<div class="paragraph"><p>Up to 4 reference identifiers are returned, one per work-item in the same format as for motion
-vectors as described in <span class="blue"><a href="#bookmark-singlerefmv">OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL</a></span>.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be a OpTypeInt with 8-bit Width and 0 Signedness.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL"><em>OpTypeAvcImeResultSingleReferenceStreamoutINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Major Shape</em> must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+Get the reference identifiers for the input major shape and direction from the IME dual reference streamout results</p>
+</div>
+<div class="paragraph">
+<p>Up to 4 reference identifiers are returned, one per work-item in the same format as for motion
+vectors as described in <span class="blue"><a href="#bookmark-singlerefmv">OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be a OpTypeInt with 8-bit Width and 0 Signedness.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL"><em>OpTypeAvcImeResultSingleReferenceStreamoutINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Major Shape</em> must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>5</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5772</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Major Shape</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>5</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5772</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Major Shape</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2858%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><div><div class="paragraph"><p><strong>OpSubgroupAvcImeGetStreamoutDualReferenceMajorShapeReferenceIdsINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcImeGetStreamoutDualReferenceMajorShapeReferenceIdsINTEL</strong><br>
 <br>
-Get the reference identifiers for the input major shape from the IME dual reference streamout results.</p></div>
-<div class="paragraph"><p>Up to 4 reference identifiers are returned, one per work-item in the same format as for motion vectors for single reference streamout as described in <span class="blue"><a href="#bookmark-singlerefmv">OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL</a></span>.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be a OpTypeInt with 8-bit Width and 0 Signedness.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL"><em>OpTypeAvcImeResultDualReferenceStreamoutINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Major Shape</em> must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div>
-<div class="paragraph"><p><em>Direction</em> must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major direction value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+Get the reference identifiers for the input major shape from the IME dual reference streamout results.</p>
+</div>
+<div class="paragraph">
+<p>Up to 4 reference identifiers are returned, one per work-item in the same format as for motion vectors for single reference streamout as described in <span class="blue"><a href="#bookmark-singlerefmv">OpSubgroupAvcImeGetStreamoutSingleReferenceMajorShapeMotionVectorsINTEL</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be a OpTypeInt with 8-bit Width and 0 Signedness.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL"><em>OpTypeAvcImeResultDualReferenceStreamoutINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Major Shape</em> must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major shape value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Direction</em> must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is a valid inter macro-block major direction value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>6</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5775</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Major Shape</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Direction</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>6</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5775</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Major Shape</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Direction</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><div><div class="paragraph"><p><strong>OpSubgroupAvcImeGetBorderReachedINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcImeGetBorderReachedINTEL</strong><br>
 <br>
-Get the bitmask indicating whether any border of forward/backward reference image is reached by one or more MVs in the winning inter shape. The bitmask values are as per the inter border reached values as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div>
-<div class="paragraph"><p>The search window must have been configured for a forward reference if image_select is
-set as <span class="blue"><a href="#bookmark-forward">AVC_ME_FRAME_FORWARD_INTEL</a></span> and with a backward reference if image_select is set as <span class="blue"><a href="#bookmark-backward">AVC_ME_FRAME_BACKWARD_INTEL</a></span>.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be a OpTypeInt with 8-bit Width and 0 Signedness.</p></div>
-<div class="paragraph"><p><em>Image Select</em> must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is either <span class="blue"><a href="#bookmark-forward">AVC_ME_FRAME_FORWARD_INTEL</a></span> or <span class="blue"><a href="#bookmark-backward">AVC_ME_FRAME_BACKWARD_INTEL</a></span>.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+Get the bitmask indicating whether any border of forward/backward reference image is reached by one or more MVs in the winning inter shape. The bitmask values are as per the inter border reached values as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div>
+<div class="paragraph">
+<p>The search window must have been configured for a forward reference if image_select is
+set as <span class="blue"><a href="#bookmark-forward">AVC_ME_FRAME_FORWARD_INTEL</a></span> and with a backward reference if image_select is set as <span class="blue"><a href="#bookmark-backward">AVC_ME_FRAME_BACKWARD_INTEL</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be a OpTypeInt with 8-bit Width and 0 Signedness.</p>
+</div>
+<div class="paragraph">
+<p><em>Image Select</em> must be a OpTypeInt with 8-bit Width and 0 Signedness, and must come from a constant instruction of an integer-type scalar whose value is either <span class="blue"><a href="#bookmark-forward">AVC_ME_FRAME_FORWARD_INTEL</a></span> or <span class="blue"><a href="#bookmark-backward">AVC_ME_FRAME_BACKWARD_INTEL</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>5</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5776</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Image Select</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>5</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5776</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Image Select</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><div><div class="paragraph"><p><strong>OpSubgroupAvcImeGetTruncatedSearchIndicationINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcImeGetTruncatedSearchIndicationINTEL</strong><br>
 <br>
 Get the indication that the search operation was prevented from providing the lowest
 distortion solution due to the tighter constraints on the maximum number of MB motion
-vectors configured for the search operation.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be a OpTypeInt with 8-bit Width and 0 Signedness.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+vectors configured for the search operation.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be a OpTypeInt with 8-bit Width and 0 Signedness.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>4</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5777</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>4</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5777</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><div><div class="paragraph"><p><strong>OpSubgroupAvcImeGetUnidirectionalEarlySearchTerminationINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcImeGetUnidirectionalEarlySearchTerminationINTEL</strong><br>
 <br>
-Get the indication that unidirectional search operation terminated early because the configured distortion threshold was met.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be a OpTypeInt with 8-bit Width and 0 Signedness.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+Get the indication that unidirectional search operation terminated early because the configured distortion threshold was met.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be a OpTypeInt with 8-bit Width and 0 Signedness.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>4</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5778</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>4</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5778</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><div><div class="paragraph"><p><strong>OpSubgroupAvcImeGetWeightingPatternMinimumMotionVectorINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcImeGetWeightingPatternMinimumMotionVectorINTEL</strong><br>
 <br>
 Get the 16x16 motion vector corresponding to the minimum 16x16 distortion when applying
-the traditional Z-order SAD weighting pattern.</p></div>
-<div class="admonitionblock">
-<table><tr>
+the traditional Z-order SAD weighting pattern.</p>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/important.png" alt="Important">
+<i class="fa icon-important" title="Important"></i>
 </td>
 <td class="content">
-<div class="paragraph"><p>This can only be called if a SAD weighting pattern was set prior to evaluation using
-<span class="blue"><a href="#bookmark-weightedsad">OpSubgroupAvcImeSetWeightedSadINTEL</a></span>.</p></div>
-</td>
-</tr></table>
+<div class="paragraph">
+<p>This can only be called if a SAD weighting pattern was set prior to evaluation using
+<span class="blue"><a href="#bookmark-weightedsad">OpSubgroupAvcImeSetWeightedSadINTEL</a></span>.</p>
 </div>
-<div class="paragraph"><p><em>Result Type</em> must be a OpTypeInt with 32-bit Width and 0 Signedness.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be a OpTypeInt with 32-bit Width and 0 Signedness.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>4</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5779</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>4</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5779</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><div><div class="paragraph"><p><strong>OpSubgroupAvcImeGetWeightingPatternMinimumDistortionINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcImeGetWeightingPatternMinimumDistortionINTEL</strong><br>
 <br>
-Get the minimum 16x16 distortion when applying the traditional Z-order SAD weighting pattern.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be a OpTypeInt with 16-bit Width and 0 Signedness.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+Get the minimum 16x16 distortion when applying the traditional Z-order SAD weighting pattern.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be a OpTypeInt with 16-bit Width and 0 Signedness.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcImeResultINTEL"><em>OpTypeAvcImeResultINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>4</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5780</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>4</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5780</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<div style="page-break-after:always"></div>
+<div style="page-break-after: always;"></div>
 </div>
 </div>
 <div class="sect3">
 <h4 id="bookmark-GroupREFInstructions">REF instructions</h4>
-<div class="paragraph"><p>These instruction are only guaranteed to work correctly if placed strictly within uniform control flow within the Subgroup execution scope. This ensures that if any invocation executes it, all invocations will execute it. If placed elsewhere, the results are undefined.</p></div>
+<div class="paragraph">
+<p>These instruction are only guaranteed to work correctly if placed strictly within uniform control flow within the Subgroup execution scope. This ensures that if any invocation executes it, all invocations will execute it. If placed elsewhere, the results are undefined.</p>
+</div>
 <div class="sect4">
 <h5 id="_initialization_instructions_2">Initialization instructions</h5>
-<div class="paragraph"><p>These instructions create a properly initialized payload that can be used for further configured for evaluating REF operations. This is a required initial phase. A call to either <span class="blue"><a href="#bookmark-OpSubgroupAvcFmeInitializeINTEL">OpSubgroupAvcFmeInitializeINTEL</a></span> or <span class="blue"><a href="#bookmark-OpSubgroupAvcBmeInitializeINTEL">OpSubgroupAvcBmeInitializeINTEL</a></span> is required.</p></div>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcFmeInitializeINTEL"
-style="
-width:100%;
-">
-<col style="width:9%;">
-<col style="width:9%;">
-<col style="width:9%;">
-<col style="width:9%;">
-<col style="width:9%;">
-<col style="width:9%;">
-<col style="width:9%;">
-<col style="width:9%;">
-<col style="width:9%;">
-<col style="width:9%;">
-<col style="width:9%;">
+<div class="paragraph">
+<p>These instructions create a properly initialized payload that can be used for further configured for evaluating REF operations. This is a required initial phase. A call to either <span class="blue"><a href="#bookmark-OpSubgroupAvcFmeInitializeINTEL">OpSubgroupAvcFmeInitializeINTEL</a></span> or <span class="blue"><a href="#bookmark-OpSubgroupAvcBmeInitializeINTEL">OpSubgroupAvcBmeInitializeINTEL</a></span> is required.</p>
+</div>
+<table id="bookmark-OpSubgroupAvcFmeInitializeINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 9.0909%;">
+<col style="width: 9.0909%;">
+<col style="width: 9.0909%;">
+<col style="width: 9.0909%;">
+<col style="width: 9.0909%;">
+<col style="width: 9.0909%;">
+<col style="width: 9.0909%;">
+<col style="width: 9.0909%;">
+<col style="width: 9.0909%;">
+<col style="width: 9.0909%;">
+<col style="width: 9.091%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="10" ><div><div class="paragraph"><p><strong>OpSubgroupAvcFmeInitializeINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="10"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcFmeInitializeINTEL</strong><br>
 <br>
-Return an initialized payload for a VME fractional motion estimation operation (FME).</p></div>
-<div class="paragraph"><p>The payload is initialized for progressive frame operations, and the cost configuration
-values and the miscellaneous property values are all initialized to zero. The cost configuration and the miscellaneous property configuration instructions must be used to override the initial configurations in the payload.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefPayloadINTEL"><em>OpTypeAvcRefPayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Src Coord</em> must be a vector(2) of i16 values and 0 Signedness, and represents the 2D offset of the top left corner of the source MB in pixel units in the source image.</p></div>
-<div class="admonitionblock">
-<table><tr>
+Return an initialized payload for a VME fractional motion estimation operation (FME).</p>
+</div>
+<div class="paragraph">
+<p>The payload is initialized for progressive frame operations, and the cost configuration
+values and the miscellaneous property values are all initialized to zero. The cost configuration and the miscellaneous property configuration instructions must be used to override the initial configurations in the payload.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefPayloadINTEL"><em>OpTypeAvcRefPayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Src Coord</em> must be a vector(2) of i16 values and 0 Signedness, and represents the 2D offset of the top left corner of the source MB in pixel units in the source image.</p>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/important.png" alt="Important">
+<i class="fa icon-important" title="Important"></i>
 </td>
 <td class="content">
-<div class="paragraph"><p>If the source image is an interlaced scan image, then the bottom field lines are considered as logically overlapping with the top field lines (i.e. the top field MBs are considered as logically overlapping with the bottom MBs) for the purposes for specifying
-the <em>Src Coord</em> value.</p></div>
-</td>
-</tr></table>
+<div class="paragraph">
+<p>If the source image is an interlaced scan image, then the bottom field lines are considered as logically overlapping with the top field lines (i.e. the top field MBs are considered as logically overlapping with the bottom MBs) for the purposes for specifying
+the <em>Src Coord</em> value.</p>
 </div>
-<div class="paragraph"><p><em>Motion Vectors</em> must be an OpTypeInt with 64-bit Width and 0 Signedness. It represents the BMVs returned by an IME in the same format as
-returned by <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetMotionVectorsINTEL">OpSubgroupAvcMceGetMotionVectorsINTEL</a></span>. The MVs are in QPEL units. The X and Y coordinates of each MV must be in the range [-2048.00, 2047.75), otherwise the results are undefined.</p></div>
-<div class="admonitionblock">
-<table><tr>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><em>Motion Vectors</em> must be an OpTypeInt with 64-bit Width and 0 Signedness. It represents the BMVs returned by an IME in the same format as
+returned by <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetMotionVectorsINTEL">OpSubgroupAvcMceGetMotionVectorsINTEL</a></span>. The MVs are in QPEL units. The X and Y coordinates of each MV must be in the range [-2048.00, 2047.75), otherwise the results are undefined.</p>
+</div>
+<div class="admonitionblock caution">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/caution.png" alt="Caution">
+<i class="fa icon-caution" title="Caution"></i>
 </td>
 <td class="content">
-<div class="paragraph"><p>If this operand&#8217;s value is manually composed, all sub-block MVs must be replicated per its format for each partition.  For example for 16x16 partition, all sub-block MVs must be replicated to the same MV, and for 8x8 partition, each 8x8 must have its respective sub-block MVs replicated.</p></div>
-</td>
-</tr></table>
+<div class="paragraph">
+<p>If this operand&#8217;s value is manually composed, all sub-block MVs must be replicated per its format for each partition.  For example for 16x16 partition, all sub-block MVs must be replicated to the same MV, and for 8x8 partition, each 8x8 must have its respective sub-block MVs replicated.</p>
 </div>
-<div class="paragraph"><p><em>Major Shapes</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterMajorShapeINTEL">OpSubgroupAvcMceGetInterMajorShapeINTEL</a></span>.</p></div>
-<div class="paragraph"><p><em>Minor Shapes</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterMajorShapeINTEL">OpSubgroupAvcMceGetInterMajorShapeINTEL</a></span>.</p></div>
-<div class="paragraph"><p><em>Directions</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of
-<span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterDirectionsINTEL">OpSubgroupAvcMceGetInterDirectionsINTEL</a></span>.</p></div>
-<div class="paragraph"><p><em>Pixel Resolution</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values for it are either <span class="blue"><a href="#bookmark-AVC_ME_SUBPIXEL_MODE_HPEL_INTEL"><em>AVC_ME_SUBPIXEL_MODE_HPEL_INTEL</em></a></span> or <span class="blue"><a href="#bookmark-AVC_ME_SUBPIXEL_MODE_HPEL_INTEL"><em>AVC_ME_SUBPIXEL_MODE_QPEL_INTEL</em></a></span>.</p></div>
-<div class="paragraph"><p><em>Sad Adjustment</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid sad adjustment value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><em>Major Shapes</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterMajorShapeINTEL">OpSubgroupAvcMceGetInterMajorShapeINTEL</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Minor Shapes</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterMajorShapeINTEL">OpSubgroupAvcMceGetInterMajorShapeINTEL</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Directions</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of
+<span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterDirectionsINTEL">OpSubgroupAvcMceGetInterDirectionsINTEL</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Pixel Resolution</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values for it are either <span class="blue"><a href="#bookmark-AVC_ME_SUBPIXEL_MODE_HPEL_INTEL"><em>AVC_ME_SUBPIXEL_MODE_HPEL_INTEL</em></a></span> or <span class="blue"><a href="#bookmark-AVC_ME_SUBPIXEL_MODE_HPEL_INTEL"><em>AVC_ME_SUBPIXEL_MODE_QPEL_INTEL</em></a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Sad Adjustment</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid sad adjustment value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>10</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5781</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Coord</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Motion Vectors</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Major Shapes</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Minor Shapes</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Direction</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Pixel Resolution</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Sad Adjustment</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>10</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5781</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Coord</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Motion Vectors</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Major Shapes</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Minor Shapes</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Direction</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Pixel Resolution</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Sad Adjustment</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcBmeInitializeINTEL"
-style="
-width:100%;
-">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
+<table id="bookmark-OpSubgroupAvcBmeInitializeINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 8.3333%;">
+<col style="width: 8.3333%;">
+<col style="width: 8.3333%;">
+<col style="width: 8.3333%;">
+<col style="width: 8.3333%;">
+<col style="width: 8.3333%;">
+<col style="width: 8.3333%;">
+<col style="width: 8.3333%;">
+<col style="width: 8.3333%;">
+<col style="width: 8.3333%;">
+<col style="width: 8.3333%;">
+<col style="width: 8.3337%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="11" ><div><div class="paragraph"><p><strong>OpSubgroupAvcBmeInitializeINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="11"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcBmeInitializeINTEL</strong><br>
 <br>
-Return an initialized payload for a VME bidirectional motion estimation (BME) operation.</p></div>
-<div class="paragraph"><p>The payload is initialized for progressive frame operations, and the cost configuration
-values and the miscellaneous property values are all initialized to zero. The cost configuration and the miscellaneous property configuration instructions must be used to override the initial configurations in the payload.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefPayloadINTEL"><em>OpTypeAvcRefPayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Src Coord</em> must be a vector(2) of i16 values and 0 Signedness, and represents the 2D offset of the top left corner of the source MB in pixel units in the source image.</p></div>
-<div class="admonitionblock">
-<table><tr>
+Return an initialized payload for a VME bidirectional motion estimation (BME) operation.</p>
+</div>
+<div class="paragraph">
+<p>The payload is initialized for progressive frame operations, and the cost configuration
+values and the miscellaneous property values are all initialized to zero. The cost configuration and the miscellaneous property configuration instructions must be used to override the initial configurations in the payload.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefPayloadINTEL"><em>OpTypeAvcRefPayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Src Coord</em> must be a vector(2) of i16 values and 0 Signedness, and represents the 2D offset of the top left corner of the source MB in pixel units in the source image.</p>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/important.png" alt="Important">
+<i class="fa icon-important" title="Important"></i>
 </td>
 <td class="content">
-<div class="paragraph"><p>If the source image is an interlaced scan image, then the bottom field lines are considered as logically overlapping with the top field lines (i.e. the top field MBs are considered as logically overlapping with the bottom MBs) for the purposes for specifying
-the <em>Src Coord</em> value.</p></div>
-</td>
-</tr></table>
+<div class="paragraph">
+<p>If the source image is an interlaced scan image, then the bottom field lines are considered as logically overlapping with the top field lines (i.e. the top field MBs are considered as logically overlapping with the bottom MBs) for the purposes for specifying
+the <em>Src Coord</em> value.</p>
 </div>
-<div class="paragraph"><p><em>Motion Vectors</em> must be an OpTypeInt with 64-bit Width and 0 Signedness. It represents the BMVs returned by an IME in the same format as
-returned by <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetMotionVectorsINTEL">OpSubgroupAvcMceGetMotionVectorsINTEL</a></span>. The MVs are in QPEL units. The X and Y coordinates of each MV must be in the range [-2048.00, 2047.75), otherwise the results are undefined.</p></div>
-<div class="admonitionblock">
-<table><tr>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><em>Motion Vectors</em> must be an OpTypeInt with 64-bit Width and 0 Signedness. It represents the BMVs returned by an IME in the same format as
+returned by <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetMotionVectorsINTEL">OpSubgroupAvcMceGetMotionVectorsINTEL</a></span>. The MVs are in QPEL units. The X and Y coordinates of each MV must be in the range [-2048.00, 2047.75), otherwise the results are undefined.</p>
+</div>
+<div class="admonitionblock caution">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/caution.png" alt="Caution">
+<i class="fa icon-caution" title="Caution"></i>
 </td>
 <td class="content">
-<div class="paragraph"><p>If this operand&#8217;s value is manually composed, all sub-block MVs must be replicated per its format for each partition.  For example for 16x16 partition, all sub-block MVs must be replicated to the same MV, and for 8x8 partition, each 8x8 must have its respective sub-block MVs replicated.</p></div>
-</td>
-</tr></table>
+<div class="paragraph">
+<p>If this operand&#8217;s value is manually composed, all sub-block MVs must be replicated per its format for each partition.  For example for 16x16 partition, all sub-block MVs must be replicated to the same MV, and for 8x8 partition, each 8x8 must have its respective sub-block MVs replicated.</p>
 </div>
-<div class="paragraph"><p><em>Major Shapes</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterMajorShapeINTEL">OpSubgroupAvcMceGetInterMajorShapeINTEL</a></span>.</p></div>
-<div class="paragraph"><p><em>Minor Shapes</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterMajorShapeINTEL">OpSubgroupAvcMceGetInterMajorShapeINTEL</a></span>.</p></div>
-<div class="paragraph"><p><em>Directions</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of
-<span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterDirectionsINTEL">OpSubgroupAvcMceGetInterDirectionsINTEL</a></span>.</p></div>
-<div class="paragraph"><p><em>Pixel Resolution</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values for it are either <span class="blue"><a href="#bookmark-AVC_ME_SUBPIXEL_MODE_HPEL_INTEL"><em>AVC_ME_SUBPIXEL_MODE_HPEL_INTEL</em></a></span> or <span class="blue"><a href="#bookmark-AVC_ME_SUBPIXEL_MODE_HPEL_INTEL"><em>AVC_ME_SUBPIXEL_MODE_QPEL_INTEL</em></a></span>.</p></div>
-<div class="paragraph"><p><em>Bidirectional Weight</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid bidirectional weight value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div>
-<div class="paragraph"><p><em>Sad Adjustment</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid sad adjustment value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><em>Major Shapes</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterMajorShapeINTEL">OpSubgroupAvcMceGetInterMajorShapeINTEL</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Minor Shapes</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterMajorShapeINTEL">OpSubgroupAvcMceGetInterMajorShapeINTEL</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Directions</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values and format for it are as per the return value of
+<span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterDirectionsINTEL">OpSubgroupAvcMceGetInterDirectionsINTEL</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Pixel Resolution</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Legal values for it are either <span class="blue"><a href="#bookmark-AVC_ME_SUBPIXEL_MODE_HPEL_INTEL"><em>AVC_ME_SUBPIXEL_MODE_HPEL_INTEL</em></a></span> or <span class="blue"><a href="#bookmark-AVC_ME_SUBPIXEL_MODE_HPEL_INTEL"><em>AVC_ME_SUBPIXEL_MODE_QPEL_INTEL</em></a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Bidirectional Weight</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid bidirectional weight value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Sad Adjustment</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid sad adjustment value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>11</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5782</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Coord</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Motion Vectors</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Major Shapes</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Minor Shapes</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Direction</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Pixel Resolution</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Bidirectional Weight</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Sad Adjustment</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>11</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5782</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Coord</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Motion Vectors</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Major Shapes</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Minor Shapes</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Direction</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Pixel Resolution</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Bidirectional Weight</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Sad Adjustment</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_payload_type_conversion_instructions_2">Payload type conversion instructions</h5>
-<div class="paragraph"><p>These are optional instructions that may be called following the initialization phase to convert REF payload to MCE payloads and vice-versa.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<div class="paragraph">
+<p>These are optional instructions that may be called following the initialization phase to convert REF payload to MCE payloads and vice-versa.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcRefConvertToMcePayloadINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcRefConvertToMcePayloadINTEL</strong><br>
 <br>
 Convert the REF payload to a generic MCE payload.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefPayloadINTEL"><em>OpTypeAvcRefPayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5783</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5783</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcMceConvertToRefPayloadINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcMceConvertToRefPayloadINTEL</strong><br>
 <br>
 Convert the generic MCE payload to a REF payload.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefPayloadINTEL"><em>OpTypeAvcRefPayloadINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5734</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5734</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_miscellaneous_property_configuration_instructions_2">Miscellaneous property configuration instructions</h5>
-<div class="paragraph"><p>These are optional instructions that may be called following the initialization phase to enable miscellaneous properties setting in the payload.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<div class="paragraph">
+<p>These are optional instructions that may be called following the initialization phase to enable miscellaneous properties setting in the payload.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcRefSetBidirectionalMixDisableINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcRefSetBidirectionalMixDisableINTEL</strong><br>
 <br>
 Update the input payload to disable a mix of bidirectional and unidirectional MVs in the result.</p>
 <p class="tableblock">Default is to enable it.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefPayloadINTEL"><em>OpTypeAvcRefPayloadINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefPayloadINTEL"><em>OpTypeAvcRefPayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5784</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5784</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><div><div class="paragraph"><p><strong>OpSubgroupAvcRefSetBilinearFilterEnableINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcRefSetBilinearFilterEnableINTEL</strong><br>
 <br>
 Update the input payload to do enable bilinear filter interpolation instead of 4-tap
-filter interpolation. Default is 4-tap filter interpolation.</p></div>
-<div class="admonitionblock">
-<table><tr>
+filter interpolation. Default is 4-tap filter interpolation.</p>
+</div>
+<div class="admonitionblock caution">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/caution.png" alt="Caution">
+<i class="fa icon-caution" title="Caution"></i>
 </td>
 <td class="content">
-<div class="paragraph"><p>This should not be called if the payload was initialized with integer pixel resolution.</p></div>
-</td>
-</tr></table>
+<div class="paragraph">
+<p>This should not be called if the payload was initialized with integer pixel resolution.</p>
 </div>
-<div class="paragraph"><p>Default is to enable it.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefPayloadINTEL"><em>OpTypeAvcRefPayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefPayloadINTEL"><em>OpTypeAvcRefPayloadINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Default is to enable it.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefPayloadINTEL"><em>OpTypeAvcRefPayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefPayloadINTEL"><em>OpTypeAvcRefPayloadINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>4</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5785</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>4</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5785</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_evaluation_instructions_2">Evaluation instructions</h5>
-<div class="paragraph"><p>These instructions perform the evaluation of the REF operation configured in the payload with a VME media sampler and return the results.</p></div>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcRefEvaluateWithSingleReferenceINTEL"
-style="
-width:100%;
-">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
+<div class="paragraph">
+<p>These instructions perform the evaluation of the REF operation configured in the payload with a VME media sampler and return the results.</p>
+</div>
+<table id="bookmark-OpSubgroupAvcRefEvaluateWithSingleReferenceINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2858%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><strong>OpSubgroupAvcRefEvaluateWithSingleReferenceINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><strong>OpSubgroupAvcRefEvaluateWithSingleReferenceINTEL</strong><br>
 <br>
 Evaluate the basic REF operation with a single reference and return its results.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefResultINTEL"><em>OpTypeAvcRefResultINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Src Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies the source image.</p>
 <p class="tableblock"><em>Ref Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies a forward reference image.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefPayloadINTEL"><em>OpTypeAvcRefPayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5786</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Ref Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5786</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Ref Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcRefEvaluateWithDualReferenceINTEL"
-style="
-width:100%;
-">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
+<table id="bookmark-OpSubgroupAvcRefEvaluateWithDualReferenceINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="7" ><p class="tableblock"><strong>OpSubgroupAvcRefEvaluateWithDualReferenceINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="7"><p class="tableblock"><strong>OpSubgroupAvcRefEvaluateWithDualReferenceINTEL</strong><br>
 <br>
 Evaluate the basic REF operation with dual references and return its results.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefResultINTEL"><em>OpTypeAvcRefResultINTEL</em></a></span> type.</p>
@@ -6205,815 +5898,926 @@ Evaluate the basic REF operation with dual references and return its results.</p
 <p class="tableblock"><em>Fwd Ref Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies a forward reference image.</p>
 <p class="tableblock"><em>Bwd Ref Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies a backward reference image.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefPayloadINTEL"><em>OpTypeAvcRefPayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5787</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Fwd Ref Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Bwd Ref Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5787</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Fwd Ref Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Bwd Ref Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcRefEvaluateWithMultiReferenceINTEL"
-style="
-width:100%;
-">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
+<table id="bookmark-OpSubgroupAvcRefEvaluateWithMultiReferenceINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2858%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><div><div class="paragraph"><p><strong>OpSubgroupAvcRefEvaluateWithMultiReferenceINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcRefEvaluateWithMultiReferenceINTEL</strong><br>
 <br>
-Evaluate the basic REF operation with multi references and return its results.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefResultINTEL"><em>OpTypeAvcRefResultINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Src Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies the source image.</p></div>
-<div class="paragraph"><p><em>Packed Reference Ids</em> must be an OpTypeInt with 32-bit Width and 0 Signedness, with the following bits specifying the values for the pair of reference images for each major partition.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:66%;">
+Evaluate the basic REF operation with multi references and return its results.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefResultINTEL"><em>OpTypeAvcRefResultINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Src Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies the source image.</p>
+</div>
+<div class="paragraph">
+<p><em>Packed Reference Ids</em> must be an OpTypeInt with 32-bit Width and 0 Signedness, with the following bits specifying the values for the pair of reference images for each major partition.</p>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 55%;">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3:0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3:0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 0</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7:4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7:4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 0</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">11:8</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">11:8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">15:12</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">15:12</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">19:16</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">19:16</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 2</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">23:20</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">23:20</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 2</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">27:24</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">27:24</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 3</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">31:28</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">31:28</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 3</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>A forward[backward] reference identifier value of <em>n</em> indicates the forward[backward]
+<div class="paragraph">
+<p>A forward[backward] reference identifier value of <em>n</em> indicates the forward[backward]
 image from the <em>n</em><sup>th</sup> pair of forward/backward reference images, with the value of <em>n</em>
-ranging from 0 to 15.</p></div>
-<div class="paragraph"><p>If the REF operation is configured with only forward reference images then, the
-values of the backward reference identifiers are not used.</p></div>
-<div class="paragraph"><p>The blocks are numbered using the traditional Z order. For larger block sizes, the
+ranging from 0 to 15.</p>
+</div>
+<div class="paragraph">
+<p>If the REF operation is configured with only forward reference images then, the
+values of the backward reference identifiers are not used.</p>
+</div>
+<div class="paragraph">
+<p>The blocks are numbered using the traditional Z order. For larger block sizes, the
 sub-block reference identifier pairs must be replicated. For example, for a 16x16 block, all four pair of reference identifiers must be replicated to the value of the first pair
-for block 0.</p></div>
-<div class="admonitionblock">
-<table><tr>
+for block 0.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/note.png" alt="Note">
+<i class="fa icon-note" title="Note"></i>
 </td>
 <td class="content">
-<div class="paragraph"><p>The value for the <em>Packed Reference Ids</em> is typically obtained by calling <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterReferenceIdsINTEL">OpSubgroupAvcMceGetInterReferenceIdsINTEL</a></span> for the preceding IME operation&#8217;s result.</p></div>
-</td>
-</tr></table>
+<div class="paragraph">
+<p>The value for the <em>Packed Reference Ids</em> is typically obtained by calling <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterReferenceIdsINTEL">OpSubgroupAvcMceGetInterReferenceIdsINTEL</a></span> for the preceding IME operation&#8217;s result.</p>
 </div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefPayloadINTEL"><em>OpTypeAvcRefPayloadINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefPayloadINTEL"><em>OpTypeAvcRefPayloadINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>6</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5788</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Packed Reference Ids</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>6</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5788</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Packed Reference Ids</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcRefEvaluateWithMultiReferenceInterlacedINTEL"
-style="
-width:100%;
-">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
+<table id="bookmark-OpSubgroupAvcRefEvaluateWithMultiReferenceInterlacedINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="7" ><div><div class="paragraph"><p><strong>OpSubgroupAvcRefEvaluateWithMultiReferenceInterlacedINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="7"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcRefEvaluateWithMultiReferenceInterlacedINTEL</strong><br>
 <br>
 Evaluate the basic REF operation with multi references and return its results. This
-is used for interlaced source and reference images.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefResultINTEL"><em>OpTypeAvcRefResultINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Src Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies the source image.</p></div>
-<div class="paragraph"><p><em>Packed Reference Ids</em> must be an OpTypeInt with 32-bit Width and 0 Signedness, with the following bits specifying the values for the pair of reference images for each major partition.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:66%;">
+is used for interlaced source and reference images.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefResultINTEL"><em>OpTypeAvcRefResultINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Src Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies the source image.</p>
+</div>
+<div class="paragraph">
+<p><em>Packed Reference Ids</em> must be an OpTypeInt with 32-bit Width and 0 Signedness, with the following bits specifying the values for the pair of reference images for each major partition.</p>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 55%;">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3:0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3:0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 0</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7:4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7:4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 0</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">11:8</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">11:8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">15:12</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">15:12</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">19:16</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">19:16</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 2</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">23:20</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">23:20</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 2</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">27:24</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">27:24</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 3</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">31:28</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">31:28</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 3</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>A forward[backward] reference identifier value of <em>n</em> indicates the forward[backward]
+<div class="paragraph">
+<p>A forward[backward] reference identifier value of <em>n</em> indicates the forward[backward]
 image from the <em>n</em><sup>th</sup> pair of forward/backward reference images, with the value of <em>n</em>
-ranging from 0 to 15.</p></div>
-<div class="paragraph"><p>If the REF operation is configured with only forward reference images then, the
-values of the backward reference identifiers are not used.</p></div>
-<div class="paragraph"><p>The blocks are numbered using the traditional Z order. For larger block sizes, the
+ranging from 0 to 15.</p>
+</div>
+<div class="paragraph">
+<p>If the REF operation is configured with only forward reference images then, the
+values of the backward reference identifiers are not used.</p>
+</div>
+<div class="paragraph">
+<p>The blocks are numbered using the traditional Z order. For larger block sizes, the
 sub-block reference identifier pairs must be replicated. For example, for a 16x16 block, all four pair of reference identifiers must be replicated to the value of the first pair
-for block 0.</p></div>
-<div class="admonitionblock">
-<table><tr>
+for block 0.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/note.png" alt="Note">
+<i class="fa icon-note" title="Note"></i>
 </td>
 <td class="content">
-<div class="paragraph"><p>The value for the <em>Packed Reference Ids</em> is typically obtained by calling <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterReferenceIdsINTEL">OpSubgroupAvcMceGetInterReferenceIdsINTEL</a></span> for the preceding IME operation&#8217;s result.</p></div>
-</td>
-</tr></table>
+<div class="paragraph">
+<p>The value for the <em>Packed Reference Ids</em> is typically obtained by calling <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterReferenceIdsINTEL">OpSubgroupAvcMceGetInterReferenceIdsINTEL</a></span> for the preceding IME operation&#8217;s result.</p>
 </div>
-<div class="paragraph"><p><em>Packed Reference Field Polarities</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Reference field polarities for forward and backward reference images are specified for each of the allowed major partitions using it, with the following bits specifying the reference field polarities for the major partitions.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:66%;">
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><em>Packed Reference Field Polarities</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Reference field polarities for forward and backward reference images are specified for each of the allowed major partitions using it, with the following bits specifying the reference field polarities for the major partitions.</p>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 50%;">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 0</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 2</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 3</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 0</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 2</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 3</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>If the dual-reference evaluation instructions are not used, then the values of the
-backward reference field polarities are not used.</p></div>
-<div class="paragraph"><p>The blocks are numbered using the traditional Z order. For larger block sizes, the
+<div class="paragraph">
+<p>If the dual-reference evaluation instructions are not used, then the values of the
+backward reference field polarities are not used.</p>
+</div>
+<div class="paragraph">
+<p>The blocks are numbered using the traditional Z order. For larger block sizes, the
 sub-block reference field polarities are replicated. For example, for a 16x16 block all
-four pairs of reference field polarities are replicated to the value of the first pair for block 0.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefPayloadINTEL"><em>OpTypeAvcRefPayloadINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+four pairs of reference field polarities are replicated to the value of the first pair for block 0.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefPayloadINTEL"><em>OpTypeAvcRefPayloadINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>7</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5789</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Packed Reference Ids</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Packed Reference Field Polarities</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>7</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5789</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Packed Reference Ids</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Packed Reference Field Polarities</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_result_type_conversion_instructions_2">Result type conversion instructions</h5>
-<div class="paragraph"><p>These are optional instructions that may be called following the evaluation phase to convert REF results to MCE results and vice-versa.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<div class="paragraph">
+<p>These are optional instructions that may be called following the evaluation phase to convert REF results to MCE results and vice-versa.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcRefConvertToMceResultINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcRefConvertToMceResultINTEL</strong><br>
 <br>
 Convert the REF result to a generic MCE result.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMceResultINTEL"><em>OpTypeAvcMceResultINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefResultINTEL"><em>OpTypeAvcRefResultINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5790</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5790</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcMceConvertToRefResultINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcMceConvertToRefResultINTEL</strong><br>
 <br>
 Convert the generic MCE result to a REF result.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcRefResultINTEL"><em>OpTypeAvcRefResultINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMceResultINTEL"><em>OpTypeAvcMceResultINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5735</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5735</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<div style="page-break-after:always"></div>
+<div style="page-break-after: always;"></div>
 </div>
 </div>
 <div class="sect3">
 <h4 id="bookmark-GroupSICInstructions">SIC instructions</h4>
-<div class="paragraph"><p>These instruction are only guaranteed to work correctly if placed strictly within uniform control flow within the Subgroup execution scope. This ensures that if any invocation executes it, all invocations will execute it. If placed elsewhere, the results are undefined.</p></div>
+<div class="paragraph">
+<p>These instruction are only guaranteed to work correctly if placed strictly within uniform control flow within the Subgroup execution scope. This ensures that if any invocation executes it, all invocations will execute it. If placed elsewhere, the results are undefined.</p>
+</div>
 <div class="sect4">
 <h5 id="_initialization_instructions_3">Initialization instructions</h5>
-<div class="paragraph"><p>These instructions create a properly initialized payload that can be used for further configured for evaluating SIC operations. This is a required initial phase.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<div class="paragraph">
+<p>These instructions create a properly initialized payload that can be used for further configured for evaluating SIC operations. This is a required initial phase.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><div><div class="paragraph"><p><strong>OpSubgroupAvcSicInitializeINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcSicInitializeINTEL</strong><br>
 <br>
-Return an initialized payload for a VME SIC operation.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Src Coord</em> must be a vector(2) of i16 values and 0 Signedness. It represents the 2D offset of the top left corner of the source MB in pixel units in the source image. Source MBs at the image borders are allowed to be partial, but the top-left corner must be within the image.</p></div>
-<div class="admonitionblock">
-<table><tr>
+Return an initialized payload for a VME SIC operation.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Src Coord</em> must be a vector(2) of i16 values and 0 Signedness. It represents the 2D offset of the top left corner of the source MB in pixel units in the source image. Source MBs at the image borders are allowed to be partial, but the top-left corner must be within the image.</p>
+</div>
+<div class="admonitionblock important">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/important.png" alt="Important">
+<i class="fa icon-important" title="Important"></i>
 </td>
 <td class="content">
-<div class="olist arabic"><ol class="arabic">
+<div class="olist arabic">
+<ol class="arabic">
 <li>
-<p>
-If the source image is an interlaced scan image, then the bottom field lines are
+<p>If the source image is an interlaced scan image, then the bottom field lines are
 considered as logically overlapping with the top field lines (i.e. the top field MBs
-are considered as logically overlapping with the bottom MBs) for the purposes for specifying the <em>Src Coord</em> value.
-</p>
+are considered as logically overlapping with the bottom MBs) for the purposes for specifying the <em>Src Coord</em> value.</p>
 </li>
 <li>
-<p>
-If the SIC operation is being configured for chroma based intra estimation, then the x and y coordinates of <em>Src Coord</em> must be multiples of 2.
-</p>
+<p>If the SIC operation is being configured for chroma based intra estimation, then the x and y coordinates of <em>Src Coord</em> must be multiples of 2.</p>
 </li>
-</ol></div>
+</ol>
+</div>
 </td>
-</tr></table>
+</tr>
+</table>
 </div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>4</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5791</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Coord</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>4</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5791</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Coord</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_configuration_instructions_2">Configuration instructions</h5>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcSicConfigureSkcINTEL"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:10%;">
+<table id="bookmark-OpSubgroupAvcSicConfigureSkcINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 10%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="9" ><div><div class="paragraph"><p><strong>OpSubgroupAvcSicConfigureSkcINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="9"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcSicConfigureSkcINTEL</strong><br>
 <br>
-Configure the SIC payload for (uni or bi-directional) skip checks.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Skip Block Partition Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to one of the specified partition mask values as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div>
-<div class="paragraph"><p><em>Skip Motion Vector Mask</em> must be an OpTypeInt with 32-bit Width and 0 Signedness. Legal values for it can be composed using the OpBitwiseOr instruction from the values defined for it as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>; both unidirectional and bidirectional skip vectors can be specified uniquely for each major partition (16x16 or 8x8) by an appropriate selection of the skip motion vector mask enumeration values. If the 16x16 <em>Skip Block Partition Type</em> is specified, then only the 16x16 enumeration values may be used, else only the 8x8 enumeration values may be used.</p></div>
-<div class="admonitionblock">
-<table><tr>
+Configure the SIC payload for (uni or bi-directional) skip checks.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Skip Block Partition Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to one of the specified partition mask values as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Skip Motion Vector Mask</em> must be an OpTypeInt with 32-bit Width and 0 Signedness. Legal values for it can be composed using the OpBitwiseOr instruction from the values defined for it as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>; both unidirectional and bidirectional skip vectors can be specified uniquely for each major partition (16x16 or 8x8) by an appropriate selection of the skip motion vector mask enumeration values. If the 16x16 <em>Skip Block Partition Type</em> is specified, then only the 16x16 enumeration values may be used, else only the 8x8 enumeration values may be used.</p>
+</div>
+<div class="admonitionblock tip">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/tip.png" alt="Tip">
+<i class="fa icon-tip" title="Tip"></i>
 </td>
 <td class="content">
-<div class="paragraph"><p>The instruction <span class="blue"><a href="#bookmark-OpSubgroupAvcSicGetMotionVectorMask">OpSubgroupAvcSicGetMotionVectorMask</a></span> may be used to set this operand&#8217;s value.</p></div>
-</td>
-</tr></table>
+<div class="paragraph">
+<p>The instruction <span class="blue"><a href="#bookmark-OpSubgroupAvcSicGetMotionVectorMask">OpSubgroupAvcSicGetMotionVectorMask</a></span> may be used to set this operand&#8217;s value.</p>
 </div>
-<div class="paragraph"><p><em>Motion Vectors</em> must be an OpTypeInt with 64-bit Width and 0 Signedness, and specifies the input packed BMVs. Either the forward or backward is ignored if the setting in <em>Skip Motion Vector Mask</em> is backward or forward respectively. If the setting is bidirectional, then both the forward and backward motion vectors will be used.  If the <em>Skip Block Partition Type</em> is 16x16, work-item 0 in the subgroup provides the BMV, and if the <em>Skip Block Partition Type</em> is 8x8, work-items 0 to 4 in the subgroup provide the four BMVs. The MVs are in QPEL units. The X and Y coordinates of each MV must be in the range [-2048.00, 2047.75] and [-512.00 to 511.75] respectively, otherwise the results are undefined.</p></div>
-<div class="paragraph"><p><em>Bidirectional Weight</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid bidirectional weight value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.  If the setting is unidirectional, then the this parameter value is ignored and can be set to the value <em>0</em>.</p></div>
-<div class="paragraph"><p><em>Sad Adjustment</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid sad adjustment value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><em>Motion Vectors</em> must be an OpTypeInt with 64-bit Width and 0 Signedness, and specifies the input packed BMVs. Either the forward or backward is ignored if the setting in <em>Skip Motion Vector Mask</em> is backward or forward respectively. If the setting is bidirectional, then both the forward and backward motion vectors will be used.  If the <em>Skip Block Partition Type</em> is 16x16, work-item 0 in the subgroup provides the BMV, and if the <em>Skip Block Partition Type</em> is 8x8, work-items 0 to 4 in the subgroup provide the four BMVs. The MVs are in QPEL units. The X and Y coordinates of each MV must be in the range [-2048.00, 2047.75] and [-512.00 to 511.75] respectively, otherwise the results are undefined.</p>
+</div>
+<div class="paragraph">
+<p><em>Bidirectional Weight</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid bidirectional weight value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.  If the setting is unidirectional, then the this parameter value is ignored and can be set to the value <em>0</em>.</p>
+</div>
+<div class="paragraph">
+<p><em>Sad Adjustment</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid sad adjustment value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>9</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5792</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Skip Block Partition Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Skip Motion Vector Mask</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Motion Vectors</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Bidirectional Weight</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Sad Adjustment</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>9</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5792</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Skip Block Partition Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Skip Motion Vector Mask</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Motion Vectors</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Bidirectional Weight</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Sad Adjustment</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcSicConfigureIpeLumaINTEL"
-style="
-width:100%;
-">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
+<table id="bookmark-OpSubgroupAvcSicConfigureIpeLumaINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 8.3333%;">
+<col style="width: 8.3333%;">
+<col style="width: 8.3333%;">
+<col style="width: 8.3333%;">
+<col style="width: 8.3333%;">
+<col style="width: 8.3333%;">
+<col style="width: 8.3333%;">
+<col style="width: 8.3333%;">
+<col style="width: 8.3333%;">
+<col style="width: 8.3333%;">
+<col style="width: 8.3333%;">
+<col style="width: 8.3337%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="11" ><div><div class="paragraph"><p><strong>OpSubgroupAvcSicConfigureIpeLumaINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="11"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcSicConfigureIpeLumaINTEL</strong><br>
 <br>
-Return an initialized payload for a VME luma intra prediction estimation (IPE) operation.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Luma Intra Partition Mask</em> must be an OpTypeInt with 8-bit Width and 0 Signedness, which can be composed from their respective values as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span> using the OpBitwiseAnd instruction.</p></div>
-<div class="paragraph"><p><em>Intra Neighbour Availabilty</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid intra neighbour availabilty value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div>
-<div class="paragraph"><p><em>Left Edge Luma Pixels</em>, <em>Upper Left Corner Luma Pixel</em>, <em>Upper Edge Luma Pixels</em>, <em>Upper Right Edge Luma Pixels</em> must be an OpTypeInt with 8-bit Width and 0 Signedness, and specify the neighbor edge pixels for the left, top-left corner, top
-and top right edges with each work-item providing each pixel value. These pixels values are used to perform the intra mode estimation.</p></div>
-<div class="paragraph"><p>For the left and top edge pixels, successive subgroup work-items 0 to 15 provide the
+Return an initialized payload for a VME luma intra prediction estimation (IPE) operation.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Luma Intra Partition Mask</em> must be an OpTypeInt with 8-bit Width and 0 Signedness, which can be composed from their respective values as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span> using the OpBitwiseAnd instruction.</p>
+</div>
+<div class="paragraph">
+<p><em>Intra Neighbour Availabilty</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid intra neighbour availabilty value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Left Edge Luma Pixels</em>, <em>Upper Left Corner Luma Pixel</em>, <em>Upper Edge Luma Pixels</em>, <em>Upper Right Edge Luma Pixels</em> must be an OpTypeInt with 8-bit Width and 0 Signedness, and specify the neighbor edge pixels for the left, top-left corner, top
+and top right edges with each work-item providing each pixel value. These pixels values are used to perform the intra mode estimation.</p>
+</div>
+<div class="paragraph">
+<p>For the left and top edge pixels, successive subgroup work-items 0 to 15 provide the
 successive edge pixels. For the top-right edge, successive work-items 0 to 7 provide the
 successive edge pixels; the pixel values in work-items 8 to 15 are ignored. The top-left
-corner pixel is a uniform pixel value with each work-item providing the same corner pixel.</p></div>
-<div class="paragraph"><p><em>Sad Adjustment</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid sad adjustment value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+corner pixel is a uniform pixel value with each work-item providing the same corner pixel.</p>
+</div>
+<div class="paragraph">
+<p><em>Sad Adjustment</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid sad adjustment value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>11</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5793</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Luma Intra Partition Mask</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Intra Neighbour Availabilty</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Left Edge Luma Pixels</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Upper Left Corner Luma Pixel</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Upper Edge Luma Pixels</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Upper Right Edge Luma Pixels</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Sad Adjustment</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>11</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5793</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Luma Intra Partition Mask</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Intra Neighbour Availabilty</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Left Edge Luma Pixels</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Upper Left Corner Luma Pixel</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Upper Edge Luma Pixels</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Upper Right Edge Luma Pixels</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Sad Adjustment</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcSicConfigureIpeLumaChromaINTEL"
-style="
-width:100%;
-">
-<col style="width:6%;">
-<col style="width:6%;">
-<col style="width:6%;">
-<col style="width:6%;">
-<col style="width:6%;">
-<col style="width:6%;">
-<col style="width:6%;">
-<col style="width:6%;">
-<col style="width:6%;">
-<col style="width:6%;">
-<col style="width:6%;">
-<col style="width:6%;">
-<col style="width:6%;">
-<col style="width:6%;">
-<col style="width:6%;">
+<table id="bookmark-OpSubgroupAvcSicConfigureIpeLumaChromaINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 6.6666%;">
+<col style="width: 6.6666%;">
+<col style="width: 6.6666%;">
+<col style="width: 6.6666%;">
+<col style="width: 6.6666%;">
+<col style="width: 6.6666%;">
+<col style="width: 6.6666%;">
+<col style="width: 6.6666%;">
+<col style="width: 6.6666%;">
+<col style="width: 6.6666%;">
+<col style="width: 6.6666%;">
+<col style="width: 6.6666%;">
+<col style="width: 6.6666%;">
+<col style="width: 6.6666%;">
+<col style="width: 6.6676%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="14" ><div><div class="paragraph"><p><strong>OpSubgroupAvcSicConfigureIpeLumaChromaINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="14"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcSicConfigureIpeLumaChromaINTEL</strong><br>
 <br>
-Return an initialized payload for a VME luma and chroma intra prediction estimation (IPE) operation.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Luma Intra Partition Mask</em> must be an OpTypeInt with 8-bit Width and 0 Signedness, which can be composed from their respective values as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span> using the OpBitwiseAnd instruction.</p></div>
-<div class="paragraph"><p><em>Intra Neighbour Availabilty</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid intra neighbour availabilty value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div>
-<div class="paragraph"><p><em>Left Edge Luma Pixels</em>, <em>Upper Left Corner Luma Pixel</em>, <em>Upper Edge Luma Pixels</em>, <em>Upper Right Edge Luma Pixels</em>, <em>Left Edge Chroma Pixels</em>, <em>Upper Left Corner Chroma Pixel</em>, <em>Upper Edge Chroma Pixels</em>  must be an OpTypeInt with 8-bit Width and 0 Signedness, and  specify the neighbor luma and chroma edge pixels for the left, top-left corner, top and top-right (luma only) edges with each work-item providing each pixel value. These pixels values are used to perform the intra mode estimation.</p></div>
-<div class="paragraph"><p>For the left and top edge pixels, successive subgroup work-items 0 to 15 provide the
+Return an initialized payload for a VME luma and chroma intra prediction estimation (IPE) operation.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Luma Intra Partition Mask</em> must be an OpTypeInt with 8-bit Width and 0 Signedness, which can be composed from their respective values as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span> using the OpBitwiseAnd instruction.</p>
+</div>
+<div class="paragraph">
+<p><em>Intra Neighbour Availabilty</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid intra neighbour availabilty value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Left Edge Luma Pixels</em>, <em>Upper Left Corner Luma Pixel</em>, <em>Upper Edge Luma Pixels</em>, <em>Upper Right Edge Luma Pixels</em>, <em>Left Edge Chroma Pixels</em>, <em>Upper Left Corner Chroma Pixel</em>, <em>Upper Edge Chroma Pixels</em>  must be an OpTypeInt with 8-bit Width and 0 Signedness, and  specify the neighbor luma and chroma edge pixels for the left, top-left corner, top and top-right (luma only) edges with each work-item providing each pixel value. These pixels values are used to perform the intra mode estimation.</p>
+</div>
+<div class="paragraph">
+<p>For the left and top edge pixels, successive subgroup work-items 0 to 15 provide the
 successive edge pixels. For the top-right edge, successive work-items 0 to 7 provide the
 successive edge pixels; the pixel values in work-items 8 to 15 are ignored. The top-left
-corner pixel is a uniform pixel value with each work-item providing the same corner pixel.</p></div>
-<div class="paragraph"><p>For the left and top chroma CbCr pixels, successive subgroup work-items 0 to 7 provide the successive CbCr pixels; the pixel values in work-items 8 to 15 are ignored. The top-left corner pixel is a uniform CbCr pixel value with each work-item providing the same corner CbCr pixel.</p></div>
-<div class="paragraph"><p><em>Sad Adjustment</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid sad adjustment value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+corner pixel is a uniform pixel value with each work-item providing the same corner pixel.</p>
+</div>
+<div class="paragraph">
+<p>For the left and top chroma CbCr pixels, successive subgroup work-items 0 to 7 provide the successive CbCr pixels; the pixel values in work-items 8 to 15 are ignored. The top-left corner pixel is a uniform CbCr pixel value with each work-item providing the same corner CbCr pixel.</p>
+</div>
+<div class="paragraph">
+<p><em>Sad Adjustment</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid sad adjustment value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationChromaINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>14</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5794</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Luma Intra Partition Mask</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Intra Neighbour Availabilty</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Left Edge Luma Pixels</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Upper Left Corner Luma Pixel</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Upper Edge Luma Pixels</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Upper Right Edge Luma Pixels</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Left Edge Chroma Pixels</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Upper Left Corner Chroma Pixel</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Upper Edge Chroma Pixels</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Sad Adjustment</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>14</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5794</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Luma Intra Partition Mask</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Intra Neighbour Availabilty</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Left Edge Luma Pixels</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Upper Left Corner Luma Pixel</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Upper Edge Luma Pixels</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Upper Right Edge Luma Pixels</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Left Edge Chroma Pixels</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Upper Left Corner Chroma Pixel</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Upper Edge Chroma Pixels</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Sad Adjustment</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><p class="tableblock"><strong>OpSubgroupAvcSicGetMotionVectorMaskINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><strong>OpSubgroupAvcSicGetMotionVectorMaskINTEL</strong><br>
 <br>
 Compose the value for the input argument <em>Skip Motion Vector Mask</em> for the
 input <em>Skip Block Partition Type</em> and direction.</p>
 <p class="tableblock"><em>Result Type</em> must be an OpTypeInt with 32-bit Width and 0 Signedness.</p>
-<p class="tableblock"><em>Skip Block Partition Type</em> must be an OpTypeInt with 32-bit Width and 0 Signedness, which must evaluate to valid partition mask values for either 16x16 or 8x8 as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p>
+<p class="tableblock"><em>Skip Block Partition Type</em> must be an OpTypeInt with 32-bit Width and 0 Signedness, which must evaluate to valid partition mask values for either 16x16 or 8x8 as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
 <p class="tableblock"><em>Direction</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. It is a bit field with the directions for the 4 8x8 sub-partitions in traditional Z order, or for only the 16x16 partition. Two bits are reserved for each of the four sub-partitions in row-major order.  The 2-bit values are as per the inter macro-block major direction values. If the <em>Skip Block Partition Type</em> indicates a 16x16 shape, then only the 1<sup>st</sup> 2 bits contains the direction, and other bits must be zeroed.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5795</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Skip Block Partition Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Direction</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5795</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Skip Block Partition Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Direction</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_payload_type_conversion_instructions_3">Payload type conversion instructions</h5>
-<div class="paragraph"><p>These are optional instructions that may be called following the search configuration phase to convert SIC payload to MCE payloads and vice-versa.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<div class="paragraph">
+<p>These are optional instructions that may be called following the search configuration phase to convert SIC payload to MCE payloads and vice-versa.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcSicConvertToMcePayloadINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcSicConvertToMcePayloadINTEL</strong><br>
 <br>
 Convert the SIC payload to a generic MCE payload.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5796</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5796</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcMceConvertToSicPayloadINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcMceConvertToSicPayloadINTEL</strong><br>
 <br>
 Convert the generic MCE payload to a SIC payload.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMcePayloadINTEL"><em>OpTypeAvcMcePayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5736</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5736</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_intra_shape_cost_configuration_instructions">Intra shape cost configuration instructions</h5>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><div><div class="paragraph"><p><strong>OpSubgroupAvcSicSetIntraLumaShapePenaltyINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcSicSetIntraLumaShapePenaltyINTEL</strong><br>
 <br>
-Set the shape penalty for inter motion estimation.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Packed Shape Penalty</em> must be a 32-bit scalar integer type. It is treated as an unsigned value. The following bits specify the shape penalty in U4U4 format:</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:75%;">
+Set the shape penalty for inter motion estimation.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Packed Shape Penalty</em> must be a 32-bit scalar integer type. It is treated as an unsigned value. The following bits specify the shape penalty in U4U4 format:</p>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 55%;">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7:0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Must be zero</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7:0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Must be zero</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">15:8</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">16x16</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">15:8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">16x16</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">23:16</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">8x8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">23:16</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">8x8</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">31:24</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4x4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">31:24</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4x4</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>The U4U4 decoded integer values for each of the bytes must fit within 12 bits.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<div class="paragraph">
+<p>The U4U4 decoded integer values for each of the bytes must fit within 12 bits.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>5</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5797</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Packed Shape Penalty</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>5</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5797</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Packed Shape Penalty</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_intra_mode_cost_configuration_instructions">Intra mode cost configuration instructions</h5>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcSicSetIntraLumaModeCostFunctionINTEL"
-style="
-width:100%;
-">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
+<table id="bookmark-OpSubgroupAvcSicSetIntraLumaModeCostFunctionINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="7" ><div><div class="paragraph"><p><strong>OpSubgroupAvcSicSetIntraLumaModeCostFunctionINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="7"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcSicSetIntraLumaModeCostFunctionINTEL</strong><br>
 <br>
-Update the payload to configure the luma mode cost function to be applied to the computed luma mode for SIC intra operations.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Luma Mode Penalty</em> specifies the penalty to be applied to the estimated luma mode if it differs from its predicted luma mode (based on its neighbor intra modes). It is specified in U4U4 format and must bit in 10 bits.</p></div>
-<div class="paragraph"><p><em>Luma Packed Neighbor Modes</em> specifies the values of the already computed top and left neighbor modes for the bordering 4x4 blocks, with the 4x4 blocks numbered in the traditional Z-order as shown
-below.</p></div>
+Update the payload to configure the luma mode cost function to be applied to the computed luma mode for SIC intra operations.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Luma Mode Penalty</em> specifies the penalty to be applied to the estimated luma mode if it differs from its predicted luma mode (based on its neighbor intra modes). It is specified in U4U4 format and must bit in 10 bits.</p>
+</div>
+<div class="paragraph">
+<p><em>Luma Packed Neighbor Modes</em> specifies the values of the already computed top and left neighbor modes for the bordering 4x4 blocks, with the 4x4 blocks numbered in the traditional Z-order as shown
+below.</p>
+</div>
 <div class="literalblock">
-<div class="content monospaced">
+<div class="content">
 <pre>0 1 4 5
 2 3 6 7
 8 9 C D
 A B E F</pre>
-</div></div>
-<div class="paragraph"><p>The following bits specify the neighbor modes.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:75%;">
+</div>
+</div>
+<div class="paragraph">
+<p>The following bits specify the neighbor modes.</p>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 55%;">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 75%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3:0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Left neighbor block 5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3:0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Left neighbor block 5</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7:4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Left neighbor block 7</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7:4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Left neighbor block 7</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">11:8</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Left neighbor block D</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">11:8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Left neighbor block D</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">15:12</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Left neighbor block F</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">15:12</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Left neighbor block F</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">19:16</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Top neighbor block A</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">19:16</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Top neighbor block A</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">23:20</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Top neighbor block B</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">23:20</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Top neighbor block B</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">27:24</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Top neighbor block E</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">27:24</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Top neighbor block E</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">31:28</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Top neighbor block F</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">31:28</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Top neighbor block F</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><em>Luma Packed Non Dc Penalty</em> specifies the penalty to be applied for any computed non-DC luma mode for each of the 16x16, 8x8, and 4x4 shapes, with the following bits specifying the penalties.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:66%;">
+<div class="paragraph">
+<p><em>Luma Packed Non Dc Penalty</em> specifies the penalty to be applied for any computed non-DC luma mode for each of the 16x16, 8x8, and 4x4 shapes, with the following bits specifying the penalties.</p>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 55%;">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7:0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Intra16x16</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7:0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Intra16x16</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">15:8</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Intra8x8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">15:8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Intra8x8</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">23:16</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Intra4x4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">23:16</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Intra4x4</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">31:24</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Must be zero</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">31:24</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Must be zero</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>The component byte values are specified in 8-bit integer format.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p>The intra distortion for each intra luma block can be described by the following formulas:</p></div>
+<div class="paragraph">
+<p>The component byte values are specified in 8-bit integer format.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p>The intra distortion for each intra luma block can be described by the following formulas:</p>
+</div>
 <div class="literalblock">
-<div class="content monospaced">
+<div class="content">
 <pre>Intra_4x4_SAD(or Haar) +
 Luma_Shape_Penalty_4x4 +
 Luma_Non_Dc_4x4_Penalty(if not  DC) +
@@ -7030,340 +6834,382 @@ end{gather}
 Intra_16x16_SAD(or Haar) +
 Luma_Shape_Penalty_16x16 +
 Luma_Non_Dc_16x16_Penalty(if not DC)</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>7</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5798</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Luma Mode Penalty</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Luma Packed Neighbor Modes</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Luma Packed Non Dc Penalty</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>7</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5798</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Luma Mode Penalty</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Luma Packed Neighbor Modes</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Luma Packed Non Dc Penalty</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcSicSetIntraChromaModeCostFunctionINTEL"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<table id="bookmark-OpSubgroupAvcSicSetIntraChromaModeCostFunctionINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><div><div class="paragraph"><p><strong>OpSubgroupAvcSicSetIntraChromaModeCostFunctionINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcSicSetIntraChromaModeCostFunctionINTEL</strong><br>
 <br>
-Update the payload to configure the intra chroma mode cost function by specifying the penalty to be applied to the computed chroma mode for SIC intra operations.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Chroma Mode Base Penalty</em>  is the base penalty to be applied to the computed intra chroma modes. This penalty is in U4U4 format.</p></div>
-<div class="paragraph"><p>The U4U4 decoded integer value must fit in 12 bits.</p></div>
-<div class="paragraph"><p>The base penalty is scaled based on the computed mode as defined below.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:66%;">
+Update the payload to configure the intra chroma mode cost function by specifying the penalty to be applied to the computed chroma mode for SIC intra operations.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Chroma Mode Base Penalty</em>  is the base penalty to be applied to the computed intra chroma modes. This penalty is in U4U4 format.</p>
+</div>
+<div class="paragraph">
+<p>The U4U4 decoded integer value must fit in 12 bits.</p>
+</div>
+<div class="paragraph">
+<p>The base penalty is scaled based on the computed mode as defined below.</p>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 55%;">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">DC</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0x</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">DC</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0x</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">HORZ</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1x</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">HORZ</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1x</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">VERT</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1x</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">VERT</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1x</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">PLANE</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2x</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PLANE</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2x</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>The component byte values are specified in 8-bit integer format.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p>The intra distortion for each intra 8x8 chroma block can be described by the following
-formula:</p></div>
+<div class="paragraph">
+<p>The component byte values are specified in 8-bit integer format.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p>The intra distortion for each intra 8x8 chroma block can be described by the following
+formula:</p>
+</div>
 <div class="literalblock">
-<div class="content monospaced">
+<div class="content">
 <pre>Distortion =
     SAD(or Haar) +
     Chroma_Mode_Base_Penalty
     (scaled based on computed mode)</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</div>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationChromaINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>7</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5799</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Chroma Mode Base Penalty</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>7</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5799</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Chroma Mode Base Penalty</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_miscellaneous_property_configuration_instructions_3">Miscellaneous property configuration instructions</h5>
-<div class="paragraph"><p>These are optional instructions that may be called following the configuration phase to enable miscellaneous properties setting in the payload.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<div class="paragraph">
+<p>These are optional instructions that may be called following the configuration phase to enable miscellaneous properties setting in the payload.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><div><div class="paragraph"><p><strong>OpSubgroupAvcSicSetBilinearFilterEnableINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcSicSetBilinearFilterEnableINTEL</strong><br>
 <br>
 Update the input payload to do enable bilinear filter interpolation instead of 4-tap
-filter interpolation. Default is 4-tap filter interpolation.<br></p></div>
-<div class="admonitionblock">
-<table><tr>
+filter interpolation. Default is 4-tap filter interpolation.<br></p>
+</div>
+<div class="admonitionblock caution">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/caution.png" alt="Caution">
+<i class="fa icon-caution" title="Caution"></i>
 </td>
 <td class="content">
-<div class="paragraph"><p>This should not be called if the payload was initialized with integer pixel resolution.</p></div>
-</td>
-</tr></table>
+<div class="paragraph">
+<p>This should not be called if the payload was initialized with integer pixel resolution.</p>
 </div>
-<div class="paragraph"><p>Default is to enable it.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p>Default is to enable it.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>4</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5800</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>4</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5800</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<table id="bookmark-OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><div><div class="paragraph"><p><strong>OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL</strong><br>
 <br>
 Enable skip check forward transform with the specified SAD coefficients thresholds in
-the frequency domain to approximate the effects of forward quantization.</p></div>
-<div class="paragraph"><p>The skip decision will be enhanced to include an accurate AVC forward transform for skip
+the frequency domain to approximate the effects of forward quantization.</p>
+</div>
+<div class="paragraph">
+<p>The skip decision will be enhanced to include an accurate AVC forward transform for skip
 estimation. This feature is in addition to the previous SAD or HAAR skip estimation. The
 results of the forward transform are compared one coefficient at a time against a
 user-specified threshold, in the input argument packed_sad_coefficients, to
-emulate quantization&#8217;s zeroing effect. The user is returned the count of coefficients that exceeded their threshold along with a sum of the amount exceeded, both grouped at the 8x8 block level (i.e. for each 8x8 block).</p></div>
-<div class="paragraph"><p>This is valid only for SKC operations.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Packed Sad Coefficients</em> must be an OpTypeInt with 64-bit Width and 0 Signedness, and spoecifies the SAD coefficient threshold matrix. The SAD coefficient threshold matrix for a 4x4 transform as shown in the table below is packed into a 64-bit integer. The low 16 bits contains the larger DC threshold. The coefficient thresholds for the remaining 6 AC thresholds in the order of increasing frequency are provided by the successive 8-bit bit ranges.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:25%;">
+emulate quantization&#8217;s zeroing effect. The user is returned the count of coefficients that exceeded their threshold along with a sum of the amount exceeded, both grouped at the 8x8 block level (i.e. for each 8x8 block).</p>
+</div>
+<div class="paragraph">
+<p>This is valid only for SKC operations.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Packed Sad Coefficients</em> must be an OpTypeInt with 64-bit Width and 0 Signedness, and spoecifies the SAD coefficient threshold matrix. The SAD coefficient threshold matrix for a 4x4 transform as shown in the table below is packed into a 64-bit integer. The low 16 bits contains the larger DC threshold. The coefficient thresholds for the remaining 6 AC thresholds in the order of increasing frequency are provided by the successive 8-bit bit ranges.</p>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 70%;">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0 (DC)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1 (AC)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2 (AC)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3 (AC)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0 (DC)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 (AC)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2 (AC)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3 (AC)</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1 (AC)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2 (AC)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3 (AC)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4 (AC)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 (AC)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2 (AC)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3 (AC)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4 (AC)</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2 (AC)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3 (AC)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4 (AC)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5 (AC)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2 (AC)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3 (AC)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4 (AC)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5 (AC)</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3 (AC)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4 (AC)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5 (AC)</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6 (AC)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3 (AC)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4 (AC)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5 (AC)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6 (AC)</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>5</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5801</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Packed Sad Coefficients</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>5</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5801</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Packed Sad Coefficients</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><div><div class="paragraph"><p><strong>OpSubgroupAvcSicSetBlockBasedRawSkipSadINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcSicSetBlockBasedRawSkipSadINTEL</strong><br>
 <br>
 The raw skip SAD computed during the evaluation phase will be the maximal SAD of individual 4x4 (or 8x8) blocks, instead of the sum of the entire individual 4x4 block
-SADs of the MB.</p></div>
-<div class="paragraph"><p>It is valid to call this function only if the payload is configured for a skip check
-operation by a prior call to [blue]#<a href="#bookmark-OpSubgroupAvcSicConfigureSkcINTEL">OpSubgroupAvcSicConfigureSkcINTEL</a>.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Block Based Skip Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness, that must evaluate to a valid block based skip type value as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+SADs of the MB.</p>
+</div>
+<div class="paragraph">
+<p>It is valid to call this function only if the payload is configured for a skip check
+operation by a prior call to [blue]#<a href="#bookmark-OpSubgroupAvcSicConfigureSkcINTEL">OpSubgroupAvcSicConfigureSkcINTEL</a>.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Block Based Skip Type</em> must be an OpTypeInt with 8-bit Width and 0 Signedness, that must evaluate to a valid block based skip type value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>5</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5802</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Block Based Skip Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>5</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5802</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Block Based Skip Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_evaluation_instructions_3">Evaluation instructions</h5>
-<div class="paragraph"><p>These instructions perform the evaluation of the SIC operation configured in the payload with a VME media sampler and return the results.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
-<col style="width:16%;">
+<div class="paragraph">
+<p>These instructions perform the evaluation of the SIC operation configured in the payload with a VME media sampler and return the results.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.6666%;">
+<col style="width: 16.667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><p class="tableblock"><strong>OpSubgroupAvcSicEvaluateIPEINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><strong>OpSubgroupAvcSicEvaluateIPEINTEL</strong><br>
 <br>
 Evaluate the SIC IPE operation and return its results.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicResultINTEL"><em>OpTypeAvcSicResultINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Src Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies the source image.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5803</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5803</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2858%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><strong>OpSubgroupAvcSicEvaluateWithSingleReferenceINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><strong>OpSubgroupAvcSicEvaluateWithSingleReferenceINTEL</strong><br>
 <br>
 Evaluate the SIC operation with single reference and return its results.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicResultINTEL"><em>OpTypeAvcSicResultINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Src Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies the source image.</p>
 <p class="tableblock"><em>Ref Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies a forward reference image.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5804</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Ref Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5804</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Ref Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="7" ><p class="tableblock"><strong>OpSubgroupAvcSicEvaluateWithDualReferenceINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="7"><p class="tableblock"><strong>OpSubgroupAvcSicEvaluateWithDualReferenceINTEL</strong><br>
 <br>
 Evaluate the SIC operation with dual references and return its results.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicResultINTEL"><em>OpTypeAvcSicResultINTEL</em></a></span> type.</p>
@@ -7371,628 +7217,673 @@ Evaluate the SIC operation with dual references and return its results.</p>
 <p class="tableblock"><em>Fwd Ref Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies a forward reference image.</p>
 <p class="tableblock"><em>Bwd Ref Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies a backward reference image.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5805</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Fwd Ref Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Bwd Ref Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5805</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Fwd Ref Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Bwd Ref Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcSicEvaluateWithMultiReferenceINTEL"
-style="
-width:100%;
-">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:14%;">
+<table id="bookmark-OpSubgroupAvcSicEvaluateWithMultiReferenceINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2858%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><div><div class="paragraph"><p><strong>OpSubgroupAvcSicEvaluateWithMultiReferenceINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcSicEvaluateWithMultiReferenceINTEL</strong><br>
 <br>
-Evaluate the SIC operation with multi references and return its results.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicResultINTEL"><em>OpTypeAvcSicResultINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Src Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies the source image.</p></div>
-<div class="paragraph"><p><em>Packed Reference Ids</em> must be an OpTypeInt with 32-bit Width and 0 Signedness, with the following bits specifying the values for the pair of reference images for each major partition.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:66%;">
+Evaluate the SIC operation with multi references and return its results.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicResultINTEL"><em>OpTypeAvcSicResultINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Src Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies the source image.</p>
+</div>
+<div class="paragraph">
+<p><em>Packed Reference Ids</em> must be an OpTypeInt with 32-bit Width and 0 Signedness, with the following bits specifying the values for the pair of reference images for each major partition.</p>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 55%;">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3:0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3:0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 0</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7:4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7:4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 0</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">11:8</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">11:8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">15:12</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">15:12</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">19:16</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">19:16</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 2</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">23:20</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">23:20</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 2</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">27:24</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">27:24</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 3</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">31:28</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">31:28</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 3</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>A forward[backward] reference identifier value of <em>n</em> indicates the forward[backward]
+<div class="paragraph">
+<p>A forward[backward] reference identifier value of <em>n</em> indicates the forward[backward]
 image from the <em>n</em><sup>th</sup> pair of forward/backward reference images, with the value of <em>n</em>
-ranging from 0 to 15.</p></div>
-<div class="paragraph"><p>If the SIC operation is configured with only forward reference images then, the
-values of the backward reference identifiers are not used.</p></div>
-<div class="paragraph"><p>The blocks are numbered using the traditional Z order. For larger block sizes, the
+ranging from 0 to 15.</p>
+</div>
+<div class="paragraph">
+<p>If the SIC operation is configured with only forward reference images then, the
+values of the backward reference identifiers are not used.</p>
+</div>
+<div class="paragraph">
+<p>The blocks are numbered using the traditional Z order. For larger block sizes, the
 sub-block reference identifier pairs must be replicated. For example, for a 16x16 block, all four pair of reference identifiers must be replicated to the value of the first pair
-for block 0.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+for block 0.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>6</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5806</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Packed Reference Ids</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>6</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5806</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Packed Reference Ids</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcSicEvaluateWithMultiReferenceInterlacedINTEL"
-style="
-width:100%;
-">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:12%;">
+<table id="bookmark-OpSubgroupAvcSicEvaluateWithMultiReferenceInterlacedINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="7" ><div><div class="paragraph"><p><strong>OpSubgroupAvcSicEvaluateWithMultiReferenceInterlacedINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="7"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcSicEvaluateWithMultiReferenceInterlacedINTEL</strong><br>
 <br>
-Evaluate the SIC operation with multi references and return its results. This is used for interlaced source and reference images.</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicResultINTEL"><em>OpTypeAvcSicResultINTEL</em></a></span> type.</p></div>
-<div class="paragraph"><p><em>Src Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies the source image.</p></div>
-<div class="paragraph"><p><em>Packed Reference Ids</em> must be an OpTypeInt with 32-bit Width and 0 Signedness, with the following bits specifying the values for the pair of reference images for each major partition.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:66%;">
+Evaluate the SIC operation with multi references and return its results. This is used for interlaced source and reference images.</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicResultINTEL"><em>OpTypeAvcSicResultINTEL</em></a></span> type.</p>
+</div>
+<div class="paragraph">
+<p><em>Src Image</em> is an object whose type is an <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span>, and specifies the source image.</p>
+</div>
+<div class="paragraph">
+<p><em>Packed Reference Ids</em> must be an OpTypeInt with 32-bit Width and 0 Signedness, with the following bits specifying the values for the pair of reference images for each major partition.</p>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 55%;">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3:0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3:0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 0</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7:4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7:4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 0</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">11:8</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">11:8</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">15:12</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">15:12</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">19:16</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">19:16</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 2</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">23:20</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">23:20</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 2</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">27:24</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">27:24</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 3</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">31:28</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">31:28</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 3</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>A forward[backward] reference identifier value of <em>n</em> indicates the forward[backward]
+<div class="paragraph">
+<p>A forward[backward] reference identifier value of <em>n</em> indicates the forward[backward]
 image from the <em>n</em><sup>th</sup> pair of forward/backward reference images, with the value of <em>n</em>
-ranging from 0 to 15.</p></div>
-<div class="paragraph"><p>If the SIC operation is configured with only forward reference images then, the
-values of the backward reference identifiers are not used.</p></div>
-<div class="paragraph"><p>The blocks are numbered using the traditional Z order. For larger block sizes, the
+ranging from 0 to 15.</p>
+</div>
+<div class="paragraph">
+<p>If the SIC operation is configured with only forward reference images then, the
+values of the backward reference identifiers are not used.</p>
+</div>
+<div class="paragraph">
+<p>The blocks are numbered using the traditional Z order. For larger block sizes, the
 sub-block reference identifier pairs must be replicated. For example, for a 16x16 block, all four pair of reference identifiers must be replicated to the value of the first pair
-for block 0.</p></div>
-<div class="admonitionblock">
-<table><tr>
+for block 0.</p>
+</div>
+<div class="admonitionblock note">
+<table>
+<tr>
 <td class="icon">
-<img src="./images/icons/note.png" alt="Note">
+<i class="fa icon-note" title="Note"></i>
 </td>
 <td class="content">
-<div class="paragraph"><p>The value for the <em>Packed Reference Ids</em> is typically obtained by calling <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterSicerenceIdsINTEL">OpSubgroupAvcMceGetInterSicerenceIdsINTEL</a></span> for the preceding IME operation&#8217;s result.</p></div>
-</td>
-</tr></table>
+<div class="paragraph">
+<p>The value for the <em>Packed Reference Ids</em> is typically obtained by calling <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterSicerenceIdsINTEL">OpSubgroupAvcMceGetInterSicerenceIdsINTEL</a></span> for the preceding IME operation&#8217;s result.</p>
 </div>
-<div class="paragraph"><p><em>Packed Reference Field Polarities</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Reference field polarities for forward and backward reference images are specified for each of the allowed major partitions using it, with the following bits specifying the reference field polarities for the major partitions.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:66%;">
+</td>
+</tr>
+</table>
+</div>
+<div class="paragraph">
+<p><em>Packed Reference Field Polarities</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Reference field polarities for forward and backward reference images are specified for each of the allowed major partitions using it, with the following bits specifying the reference field polarities for the major partitions.</p>
+</div>
+<table class="tableblock frame-all grid-all" style="width: 50%;">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 0</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 2</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Fwd reference block 3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Fwd reference block 3</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 0</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 1</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 2</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Bwd reference block 3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Bwd reference block 3</p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>If the dual-reference evaluation instructions are not used, then the values of the
-backward reference field polarities are not used.</p></div>
-<div class="paragraph"><p>The blocks are numbered using the traditional Z order. For larger block sizes, the
+<div class="paragraph">
+<p>If the dual-reference evaluation instructions are not used, then the values of the
+backward reference field polarities are not used.</p>
+</div>
+<div class="paragraph">
+<p>The blocks are numbered using the traditional Z order. For larger block sizes, the
 sub-block reference field polarities are replicated. For example, for a 16x16 block all
-four pairs of reference field polarities are replicated to the value of the first pair for block 0.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+four pairs of reference field polarities are replicated to the value of the first pair for block 0.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicPayloadINTEL"><em>OpTypeAvcSicPayloadINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>7</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5807</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Src Image</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Packed Reference Ids</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Packed Reference Field Polarities</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>7</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5807</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Src Image</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Packed Reference Ids</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Packed Reference Field Polarities</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_result_type_conversion_instructions_3">Result type conversion instructions</h5>
-<div class="paragraph"><p>These are optional instructions that may be called following the evaluation phase to convert SIC results to MCE results and vice-versa.</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<div class="paragraph">
+<p>These are optional instructions that may be called following the evaluation phase to convert SIC results to MCE results and vice-versa.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcSicConvertToMceResultINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcSicConvertToMceResultINTEL</strong><br>
 <br>
 Convert the SIC result to a generic MCE result.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMceResultINTEL"><em>OpTypeAvcMceResultINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicResultINTEL"><em>OpTypeAvcSicResultINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5808</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5808</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcMceConvertToSicResultINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcMceConvertToSicResultINTEL</strong><br>
 <br>
 Convert the generic MCE result to a SIC result.</p>
 <p class="tableblock"><em>Result Type</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicResultINTEL"><em>OpTypeAvcSicResultINTEL</em></a></span> type.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcMceResultINTEL"><em>OpTypeAvcMceResultINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5737</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5737</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect4">
 <h5 id="_result_processing_instructions_2">Result processing instructions</h5>
-<div class="paragraph"><p>These instructions are called following the evaluation phase to extract the various result components from an SIC evaluation result.</p></div>
-<table class="tableblock frame-all grid-all" id="bookmark-OpSubgroupAvcSicGetIpeLumaShapeINTEL"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<div class="paragraph">
+<p>These instructions are called following the evaluation phase to extract the various result components from an SIC evaluation result.</p>
+</div>
+<table id="bookmark-OpSubgroupAvcSicGetIpeLumaShapeINTEL" class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcSicGetIpeLumaShapeINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcSicGetIpeLumaShapeINTEL</strong><br>
 <br>
 Return the best intra shape from the SIC result.</p>
-<p class="tableblock">The returned values are valid intra-MB shapes as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p>
+<p class="tableblock">The returned values are valid intra-MB shapes as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
 <p class="tableblock"><em>Result Type</em> must be a OpTypeInt with 8-bit Width and 0 Signedness.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicResultINTEL"><em>OpTypeAvcSicResultINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5809</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5809</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcSicGetBestIpeLumaDistortionINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcSicGetBestIpeLumaDistortionINTEL</strong><br>
 <br>
 Return the best intra luma distortion for the shape return by <span class="blue"><a href="#bookmark-OpSubgroupAvcSicGetIpeLumaShapeINTEL"><em>OpSubgroupAvcSicGetIpeLumaShapeINTEL</em></a></span>  from the SIC result.</p>
 <p class="tableblock"><em>Result Type</em> must be a OpTypeInt with 16-bit Width and 0 Signedness.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicResultINTEL"><em>OpTypeAvcSicResultINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5810</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5810</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcSicGetBestIpeChromaDistortionINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcSicGetBestIpeChromaDistortionINTEL</strong><br>
 <br>
 Return the best intra chroma distortion for the 8x8 shape from the SIC result.</p>
 <p class="tableblock"><em>Result Type</em> must be a OpTypeInt with 16-bit Width and 0 Signedness.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicResultINTEL"><em>OpTypeAvcSicResultINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5811</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5811</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><div><div class="paragraph"><p><strong>OpSubgroupAvcSicGetPackedIpeLumaModesINTEL</strong><br>
-<br></p></div>
-<div class="paragraph"><p>Return the packed intra luma modes for all blocks from the SIC result.</p></div>
-<div class="paragraph"><p>There are four bits per
-luma mode for a block and legal values are valid intra luma modes as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p></div>
-<div class="paragraph"><p>The number of blocks is based on the result of <span class="blue"><a href="#bookmark-OpSubgroupAvcSicGetIpeLumaShapeINTEL"><em>OpSubgroupAvcSicGetIpeLumaShapeINTEL</em></a></span>.</p></div>
-<div class="paragraph"><p>If the luma shape is:</p></div>
-<div class="ulist"><ul>
+<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcSicGetPackedIpeLumaModesINTEL</strong><br>
+<br></p>
+</div>
+<div class="paragraph">
+<p>Return the packed intra luma modes for all blocks from the SIC result.</p>
+</div>
+<div class="paragraph">
+<p>There are four bits per
+luma mode for a block and legal values are valid intra luma modes as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
+</div>
+<div class="paragraph">
+<p>The number of blocks is based on the result of <span class="blue"><a href="#bookmark-OpSubgroupAvcSicGetIpeLumaShapeINTEL"><em>OpSubgroupAvcSicGetIpeLumaShapeINTEL</em></a></span>.</p>
+</div>
+<div class="paragraph">
+<p>If the luma shape is:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-16x16, then one mode is  returned in bits [0, 3]
-</p>
+<p>16x16, then one mode is  returned in bits [0, 3]</p>
 </li>
 <li>
-<p>
-8x8, then four modes corresponding to the four partitions are returned by bits in the ranges [0, 3], [16,19], [32, 35], and [48, 51]; the order of the four partitions are in the traditional Z-order
-</p>
+<p>8x8, then four modes corresponding to the four partitions are returned by bits in the ranges [0, 3], [16,19], [32, 35], and [48, 51]; the order of the four partitions are in the traditional Z-order</p>
 </li>
 <li>
-<p>
-4x4, then 16 modes (4 bits per mode) are returned of all 16 partitions by all the bits; the order of the 16 partitions are in the traditional Z-order as shown below:
-</p>
+<p>4x4, then 16 modes (4 bits per mode) are returned of all 16 partitions by all the bits; the order of the 16 partitions are in the traditional Z-order as shown below:</p>
 <div class="literalblock">
-<div class="content monospaced">
+<div class="content">
 <pre>0 1 4 5
 2 3 6 7
 8 9 C D
 A B E F</pre>
-</div></div>
+</div>
+</div>
 </li>
-</ul></div>
-<div class="paragraph"><p><em>Result Type</em> must be a OpTypeInt with 64-bit Width and 0 Signedness.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicResultINTEL"><em>OpTypeAvcSicResultINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</ul>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be a OpTypeInt with 64-bit Width and 0 Signedness.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicResultINTEL"><em>OpTypeAvcSicResultINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>4</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5812</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>4</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5812</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcSicGetIpeChromaModeINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcSicGetIpeChromaModeINTEL</strong><br>
 <br>
 Return the intra chroma mode for the 8x8 block from the SIC result.</p>
-<p class="tableblock">The returned values are valid intra chroma modes as per <span class="blue"><a href="#bookmark-BF">Section 3</a></span>.</p>
+<p class="tableblock">The returned values are valid intra chroma modes as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>.</p>
 <p class="tableblock"><em>Result Type</em> must be a OpTypeInt with 8-bit Width and 0 Signedness.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicResultINTEL"><em>OpTypeAvcSicResultINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationChromaINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5813</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5813</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><div><div class="paragraph"><p><strong>OpSubgroupAvcSicGetPackedSkcLumaCountThresholdINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcSicGetPackedSkcLumaCountThresholdINTEL</strong><br>
 <br>
-Return the packed count of luma coefficient components that exceeded their transform thresholds from the SIC result for each 8x8 partition in traditional Z-order.</p></div>
-<div class="paragraph"><p>The format of the results is as follows:</p></div>
-<div class="ulist"><ul>
+Return the packed count of luma coefficient components that exceeded their transform thresholds from the SIC result for each 8x8 partition in traditional Z-order.</p>
+</div>
+<div class="paragraph">
+<p>The format of the results is as follows:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-count of coefficients that exceeded their respective threshold for block 8x8_0 is   returned in bit [0, 7]
-</p>
+<p>count of coefficients that exceeded their respective threshold for block 8x8_0 is   returned in bit [0, 7]</p>
 </li>
 <li>
-<p>
-count of coefficients that exceeded their respective threshold for block 8x8_1 is returned in bit [8, 15]
-</p>
+<p>count of coefficients that exceeded their respective threshold for block 8x8_1 is returned in bit [8, 15]</p>
 </li>
 <li>
-<p>
-count of coefficients that exceeded their respective threshold for block 8x8_2 is returned in bit [16, 23]
-</p>
+<p>count of coefficients that exceeded their respective threshold for block 8x8_2 is returned in bit [16, 23]</p>
 </li>
 <li>
-<p>
-count of coefficients that exceeded their respective threshold for block 8x8_0 is returned in bit [24, 31]
-</p>
+<p>count of coefficients that exceeded their respective threshold for block 8x8_0 is returned in bit [24, 31]</p>
 </li>
-</ul></div>
-<div class="paragraph"><p>The results are only valid if the SIC operation was configured with frequency domain SAD transform coefficients using  <span class="blue"><a href="#bookmark-OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL"><em>OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL</em></a></span>  .</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be a OpTypeInt with 32-bit Width and 0 Signedness.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicResultINTEL"><em>OpTypeAvcSicResultINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</ul>
+</div>
+<div class="paragraph">
+<p>The results are only valid if the SIC operation was configured with frequency domain SAD transform coefficients using  <span class="blue"><a href="#bookmark-OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL"><em>OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL</em></a></span>  .</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be a OpTypeInt with 32-bit Width and 0 Signedness.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicResultINTEL"><em>OpTypeAvcSicResultINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>4</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5814</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>4</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5814</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><div><div class="paragraph"><p><strong>OpSubgroupAvcSicGetPackedSkcLumaSumThresholdINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><div class="content"><div class="paragraph">
+<p><strong>OpSubgroupAvcSicGetPackedSkcLumaSumThresholdINTEL</strong><br>
 <br>
-Return the packed sum of luma coefficient components that exceeded their transform thresholds from the SIC result for each 8x8 partition in traditional Z-order.</p></div>
-<div class="paragraph"><p>The format of the results is as follows:</p></div>
-<div class="ulist"><ul>
+Return the packed sum of luma coefficient components that exceeded their transform thresholds from the SIC result for each 8x8 partition in traditional Z-order.</p>
+</div>
+<div class="paragraph">
+<p>The format of the results is as follows:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-sum of coefficients that exceeded their respective threshold for block 8x8_0 is returned in bit [0, 15]
-</p>
+<p>sum of coefficients that exceeded their respective threshold for block 8x8_0 is returned in bit [0, 15]</p>
 </li>
 <li>
-<p>
-sum of coefficients that exceeded their respective threshold for block 8x8_1 is returned in bit [16,31]
-</p>
+<p>sum of coefficients that exceeded their respective threshold for block 8x8_1 is returned in bit [16,31]</p>
 </li>
 <li>
-<p>
-sum of coefficients that exceeded their respective threshold for block 8x8_2 is returned in bit [32,47]
-</p>
+<p>sum of coefficients that exceeded their respective threshold for block 8x8_2 is returned in bit [32,47]</p>
 </li>
 <li>
-<p>
-sum of coefficients that exceeded their respective threshold for block 8x8_0 is returned in bit [48, 63]
-</p>
+<p>sum of coefficients that exceeded their respective threshold for block 8x8_0 is returned in bit [48, 63]</p>
 </li>
-</ul></div>
-<div class="paragraph"><p>The results are only valid if the SIC operation was configured with frequency domain SAD transform coefficients using  <span class="blue"><a href="#bookmark-OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL"><em>OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL</em></a></span>  .</p></div>
-<div class="paragraph"><p><em>Result Type</em> must be a OpTypeInt with 64-bit Width and 0 Signedness.</p></div>
-<div class="paragraph"><p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicResultINTEL"><em>OpTypeAvcSicResultINTEL</em></a></span> type.</p></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+</ul>
+</div>
+<div class="paragraph">
+<p>The results are only valid if the SIC operation was configured with frequency domain SAD transform coefficients using  <span class="blue"><a href="#bookmark-OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL"><em>OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL</em></a></span>  .</p>
+</div>
+<div class="paragraph">
+<p><em>Result Type</em> must be a OpTypeInt with 64-bit Width and 0 Signedness.</p>
+</div>
+<div class="paragraph">
+<p><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicResultINTEL"><em>OpTypeAvcSicResultINTEL</em></a></span> type.</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationIntraINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><div><div class="literalblock">
-<div class="content monospaced">
-<pre>4</pre>
-</div></div></div></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5815</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><div class="content"><div class="paragraph">
+<p>4</p>
+</div></div></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5815</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><strong>OpSubgroupAvcSicGetInterRawSadsINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpSubgroupAvcSicGetInterRawSadsINTEL</strong><br>
 <br>
 Return the skip check raw SAD (i.e. without any mode or shape costs included) for the entire MB if the input payload was note configured for block based skip checks, otherwise return the maximal SAD of individual 4x4 (or 8x8, if the block size for block based skip checking was configured as 8x8) blocks with the MB.</p>
 <p class="tableblock"><em>Result Type</em> must be a OpTypeInt with 16-bit Width and 0 Signedness.</p>
 <p class="tableblock"><em>Payload</em> must be the <span class="blue"><a href="#bookmark-OpTypeAvcSicResultINTEL"><em>OpTypeAvcSicResultINTEL</em></a></span> type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupAvcMotionEstimationINTEL</strong><br></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5816</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Result Type</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Result &lt;id&gt;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">&lt;id&gt; Payload</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5816</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Result Type</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Result &lt;id&gt;</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">&lt;id&gt; Payload</p></td>
 </tr>
 </tbody>
 </table>
-<div style="page-break-after:always"></div>
+<div style="page-break-after: always;"></div>
 </div>
 </div>
 </div>
@@ -8001,52 +7892,50 @@ Return the skip check raw SAD (i.e. without any mode or shape costs included) fo
 <div class="sect1">
 <h2 id="_validation_rules">Validation Rules</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Modify Section <strong>2.16.1</strong>, <strong>Universal Validation Rules</strong>, adding the following under the "Data Rules" bullet:<br></p></div>
-<div class="paragraph"><p>All <span class="blue"><a href="#bookmark-OpVmeImageINTEL">OpVmeImageINTEL</a></span> instructions must be in the same block in which their Result &lt;id&gt; are consumed. Result &lt;id&gt; from OpVmeImageINTEL instructions must not appear as operands to OpPhi instructions or OpSelect instructions, or any instructions other than the image lookup and query instructions specified to take an operand whose type is OpTypeVmeImageINTEL.</p></div>
+<div class="paragraph">
+<p>Modify Section <strong>2.16.1</strong>, <strong>Universal Validation Rules</strong>, adding the following under the "Data Rules" bullet:<br></p>
+</div>
+<div class="paragraph">
+<p>All <span class="blue"><a href="#bookmark-OpVmeImageINTEL">OpVmeImageINTEL</a></span> instructions must be in the same block in which their Result &lt;id&gt; are consumed. Result &lt;id&gt; from OpVmeImageINTEL instructions must not appear as operands to OpPhi instructions or OpSelect instructions, or any instructions other than the image lookup and query instructions specified to take an operand whose type is OpTypeVmeImageINTEL.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:100%;
-">
-<col style="width:4%;">
-<col style="width:13%;">
-<col style="width:21%;">
-<col style="width:60%;">
+<table class="tableblock frame-all grid-rows stretch">
+<colgroup>
+<col style="width: 4.3478%;">
+<col style="width: 13.0434%;">
+<col style="width: 21.7391%;">
+<col style="width: 60.8697%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" >Rev</th>
-<th class="tableblock halign-left valign-top" >Date</th>
-<th class="tableblock halign-left valign-top" >Author</th>
-<th class="tableblock halign-left valign-top" >Changes</th>
+<th class="tableblock halign-left valign-top">Rev</th>
+<th class="tableblock halign-left valign-top">Date</th>
+<th class="tableblock halign-left valign-top">Author</th>
+<th class="tableblock halign-left valign-top">Changes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2018-10-29</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Biju George</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>Initial version</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2018-10-29</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Biju George</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Initial version</strong></p></td>
 </tr>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footnotes"><hr></div>
-<div id="footer">
-<div id="footer-text">
-Last updated
- 2018-11-20 13:33:57 PST
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_fp_fast_math_mode.html
+++ b/extensions/INTEL/SPV_INTEL_fp_fast_math_mode.html
@@ -4,441 +4,45 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.10">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_FP_FAST_MATH_MODE</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
-/* Uncomment @import statement to use as custom stylesheet */
-/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
-article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}
-audio,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
-a{background:none}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-abbr[title]{border-bottom:1px dotted}
-b,strong{font-weight:bold}
-dfn{font-style:italic}
-hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:0}
-p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
-abbr{text-transform:none}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
-blockquote cite::before{content:"\2014 \0020"}
-blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
-:not(pre)>code.nobreak{word-wrap:normal}
-:not(pre)>code.nowrap{white-space:nowrap}
-pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
-pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
-pre>code{display:block}
-pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:100%;background:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #e7e7e9}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details>summary:first-of-type{cursor:pointer;display:list-item;outline:none;margin-bottom:.75em}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:inherit}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border-style:solid;border-width:1px;border-color:#dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;-webkit-border-radius:4px;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
-@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
-.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
-.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.prettyprint{background:#f7f7f8}
-pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
-pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
-pre.prettyprint li code[data-lang]::before{opacity:1}
-pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
-table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
-table.linenotable td.code{padding-left:.75em}
-table.linenotable td.linenos{border-right:1px solid currentColor;opacity:.35;padding-right:.5em}
-pre.pygments .lineno{border-right:1px solid currentColor;opacity:.35;display:inline-block;margin-right:.75em}
-pre.pygments .lineno::before{content:"";margin-right:-.125em}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
-.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
-.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
-.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
-table.tableblock{max-width:100%;border-collapse:separate}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-td.tableblock>.content>:last-child.sidebarblock{margin-bottom:0}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
-table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
-table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
-table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
-table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
-table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
-table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
-table.frame-all{border-width:1px}
-table.frame-sides{border-width:0 1px}
-table.frame-topbot,table.frame-ends{border-width:1px 0}
-table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-ul.checklist{margin-left:.625em}
-ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
-ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
-.imageblock.left{margin:.25em .625em 1.25em 0}
-.imageblock.right{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
-.gist .file-data>table td.line-data{width:99%}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background:#00fafa}
-.black{color:#000}
-.black-background{background:#000}
-.blue{color:#0000bf}
-.blue-background{background:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background:#fa00fa}
-.gray{color:#606060}
-.gray-background{background:#7d7d7d}
-.green{color:#006000}
-.green-background{background:#007d00}
-.lime{color:#00bf00}
-.lime-background{background:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background:#7d0000}
-.navy{color:#000060}
-.navy-background{background:#00007d}
-.olive{color:#606000}
-.olive-background{background:#7d7d00}
-.purple{color:#600060}
-.purple-background{background:#7d007d}
-.red{color:#bf0000}
-.red-background{background:#fa0000}
-.silver{color:#909090}
-.silver-background{background:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_FP_FAST_MATH_MODE</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_5">Modifications to the SPIR-V Specification, Version 1.5</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
 <div class="sect1">
@@ -674,11 +278,6 @@ Allow algebraic transformations according to real-number associative algebra, ev
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2021-05-23 19:51:51 -0300
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_fp_max_error.html
+++ b/extensions/INTEL/SPV_INTEL_fp_max_error.html
@@ -4,494 +4,102 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.17">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_fp_max_error</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-html{font-family:sans-serif;-webkit-text-size-adjust:100%}
-a{background:none}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-b,strong{font-weight:bold}
-abbr{font-size:.9em}
-abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
-dfn{font-style:italic}
-hr{height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-audio,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type=checkbox],input[type=radio]{padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,::before,::after{box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:0}
-p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-:not(pre).nobreak{word-wrap:normal}
-:not(pre).nowrap{white-space:nowrap}
-:not(pre).pre-wrap{white-space:pre-wrap}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
-pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
-pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
-pre>code{display:block}
-pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #e7e7e9}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details{margin-left:1.25rem}
-details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
-details>summary::-webkit-details-marker{display:none}
-details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
-details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
-details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
-@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
-.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
-.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.prettyprint{background:#f7f7f8}
-pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
-pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
-pre.prettyprint li code[data-lang]::before{opacity:1}
-pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
-table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
-table.linenotable td.code{padding-left:.75em}
-table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
-pre.pygments span.linenos{display:inline-block;margin-right:.75em}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
-.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
-.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
-.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
-td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>*>tr>*{border-width:1px}
-table.grid-cols>*>tr>*{border-width:0 1px}
-table.grid-rows>*>tr>*{border-width:1px 0}
-table.frame-all{border-width:1px}
-table.frame-ends{border-width:1px 0}
-table.frame-sides{border-width:0 1px}
-table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
-table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
-table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
-table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
-table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-li>p:empty:only-child::before{content:"";display:inline-block}
-ul.checklist>li>p:first-child{margin-left:-1em}
-ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
-ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-td.hdlist2{word-wrap:anywhere}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
-.imageblock.left{margin:.25em .625em 1.25em 0}
-.imageblock.right{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background:#00fafa}
-.black{color:#000}
-.black-background{background:#000}
-.blue{color:#0000bf}
-.blue-background{background:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background:#fa00fa}
-.gray{color:#606060}
-.gray-background{background:#7d7d7d}
-.green{color:#006000}
-.green-background{background:#007d00}
-.lime{color:#00bf00}
-.lime-background{background:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background:#7d0000}
-.navy{color:#000060}
-.navy-background{background:#00007d}
-.olive{color:#606000}
-.olive-background{background:#7d7d00}
-.purple{color:#600060}
-.purple-background{background:#7d007d}
-.red{color:#bf0000}
-.red-background{background:#fa0000}
-.silver{color:#909090}
-.silver-background{background:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]{border-bottom:1px dotted}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#header,#content,#footnotes,#footer{max-width:none}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article data-line-1">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_fp_max_error</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New capabilities</a></li>
+<li><a href="#_new_decorations">New Decorations</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification, Version 1.6</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
-<div class="sect1 data-line-4">
+<div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-6">
+<div class="paragraph">
 <p>SPV_INTEL_fp_max_error</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-8">
+<div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-10">
+<div class="paragraph">
 <p>To report problems with this extension, please open a new issue at:</p>
 </div>
-<div class="paragraph data-line-12">
-<p><a href="https://github.com/KhronosGroup/SPIRV-Registry" class="undefined" data-href="https://github.com/KhronosGroup/SPIRV-Registry">https://github.com/KhronosGroup/SPIRV-Registry</a></p>
+<div class="paragraph">
+<p><a href="https://github.com/KhronosGroup/SPIRV-Registry" class="bare">https://github.com/KhronosGroup/SPIRV-Registry</a></p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-14">
+<div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="ulist data-line-16">
+<div class="ulist">
 <ul>
-<li class="data-line-16">
+<li>
 <p>Shuo Niu, Intel</p>
 </li>
-<li class="data-line-17">
+<li>
 <p>Daniel Zhang, Intel</p>
 </li>
 </ul>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-19">
+<div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-21">
+<div class="paragraph">
 <p>Copyright (c) 2023 Intel Corporation.  All rights reserved.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-23">
+<div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-25">
+<div class="paragraph">
 <p>Final draft</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-27">
+<div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all data-line-30" style="width: 40%;">
+<table class="tableblock frame-all grid-all" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -499,7 +107,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2023-03-16</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-09</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -509,74 +117,74 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </table>
 </div>
 </div>
-<div class="sect1 data-line-35">
+<div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-37">
+<div class="paragraph">
 <p>This extension is written against the SPIR-V Specification,
 Version 1.6 Revision 2.</p>
 </div>
-<div class="paragraph data-line-40">
+<div class="paragraph">
 <p>This extension requires SPIR-V 1.0.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-42">
+<div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-44">
+<div class="paragraph">
 <p>This extension adds a decoration that may be attached to any instruction of floating-point type. It can be used to express the maximum acceptable relative error in the result of that instruction, in ULPs.</p>
 </div>
-<div class="paragraph data-line-46">
+<div class="paragraph">
 <p>Note that this takes precedence over accuracy requirements from the environment specification. Please refer to the client environment specification for the list of instruction that the decoration can be attached to. The client environment specification will also provide a list of valid values for the maximum acceptable relative error.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-48">
+<div class="sect1">
 <h2 id="_extension_name">Extension Name</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-50">
+<div class="paragraph">
 <p>To use this extension within a SPIR-V module, the following <strong>OpExtension</strong> must be present in the module:</p>
 </div>
-<div class="listingblock data-line-52">
+<div class="listingblock">
 <div class="content">
 <pre>OpExtension "SPV_INTEL_fp_max_error"</pre>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-56">
+<div class="sect1">
 <h2 id="_new_capabilities">New capabilities</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-57">
+<div class="paragraph">
 <p>This extension introduces a new capability:</p>
 </div>
-<div class="listingblock data-line-59">
+<div class="listingblock">
 <div class="content">
 <pre>FPMaxErrorINTEL</pre>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-63">
+<div class="sect1">
 <h2 id="_new_decorations">New Decorations</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-65">
+<div class="paragraph">
 <p>This extension adds the following decoration under the <strong>FPMaxErrorINTEL</strong> capability:</p>
 </div>
-<div class="listingblock data-line-67">
+<div class="listingblock">
 <div class="content">
 <pre>FPMaxErrorDecorationINTEL</pre>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-71">
+<div class="sect1">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<div class="openblock data-line-73">
+<div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-rows data-line-77" style="width: 40%;">
+<table class="tableblock frame-all grid-rows" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -596,17 +204,17 @@ Version 1.6 Revision 2.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-83">
+<div class="sect1">
 <h2 id="_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification, Version 1.6</h2>
 <div class="sectionbody">
-<div class="sect2 data-line-85">
+<div class="sect2">
 <h3 id="_decoration">Decoration</h3>
-<div class="paragraph data-line-87">
+<div class="paragraph">
 <p>Modify Section 3.20, Decoration, adding the following row to the Decoration table:</p>
 </div>
-<div class="openblock data-line-89">
+<div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch data-line-91">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -626,7 +234,7 @@ Version 1.6 Revision 2.</p>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>FPMaxErrorDecorationINTEL</strong><br>
 Apply to a floating-point instruction to express the maximum acceptable relative error in the result of that instruction, in ULPs. ULP is defined as follows:</p>
 <p class="tableblock">If x is a real number that lies between two finite consecutive floating-point numbers a and b, without being equal to one of them, then ulp(x) = |b - a|, otherwise ulp(x) is the distance between the two non-equal finite floating-point numbers nearest to x. Moreover, ulp(NaN) is NaN.
-To give attribution, this description referenced Jean-Michel Muller&#8217;s definition of ulp(x) with slight clarification for behaviour at zero. For details, please refer to <a href="https://hal.inria.fr/inria-00070503/document" class="undefined" data-href="https://hal.inria.fr/inria-00070503/document">https://hal.inria.fr/inria-00070503/document</a>.</p>
+To give attribution, this description referenced Jean-Michel Muller&#8217;s definition of ulp(x) with slight clarification for behaviour at zero. For details, please refer to <a href="https://hal.inria.fr/inria-00070503/document" class="bare">https://hal.inria.fr/inria-00070503/document</a>.</p>
 <p class="tableblock"><em>Max Error</em> is a positive 32-bit float type number representing the maximum acceptable relative error.</p>
 <p class="tableblock">Note that this decoration can increase or decrease allowable error. It overrides the accuracy from the environment specification and allows both the expressions of additional error and/or less error when it differs from the environment specification.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Literal<br>
@@ -638,14 +246,14 @@ To give attribution, this description referenced Jean-Michel Muller&#8217;s defi
 </div>
 </div>
 </div>
-<div class="sect2 data-line-108">
+<div class="sect2">
 <h3 id="_capability">Capability</h3>
-<div class="paragraph data-line-110">
+<div class="paragraph">
 <p>Modify Section 3.31, Capability, adding a row to the Capability table:</p>
 </div>
-<div class="openblock data-line-111">
+<div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch data-line-113">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -668,26 +276,26 @@ To give attribution, this description referenced Jean-Michel Muller&#8217;s defi
 </div>
 </div>
 </div>
-<div class="sect2 data-line-119">
+<div class="sect2">
 <h3 id="_validation_rules">Validation Rules</h3>
-<div class="paragraph data-line-121">
+<div class="paragraph">
 <p>None.</p>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-123">
+<div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-125">
+<div class="paragraph">
 <p>None.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-127">
+<div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch data-line-132">
+<table class="tableblock frame-all grid-rows stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">
@@ -705,18 +313,13 @@ To give attribution, this description referenced Jean-Michel Muller&#8217;s defi
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2023-03-16</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-09</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Shuo Niu</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Initial public release</strong></p></td>
 </tr>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2023-03-16 15:10:46 -0700
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_fpga_argument_interfaces.html
+++ b/extensions/INTEL/SPV_INTEL_fpga_argument_interfaces.html
@@ -1,500 +1,382 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-  <meta charset="UTF-8">
-  <!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="generator" content="Asciidoctor 1.5.4">
-  <title>SPV_INTEL_fpga_argument_interfaces</title>
-  <link rel="stylesheet" href="https://asciidoclive.com/assets/asciidoctor.js/css/asciidoctor.css">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.23">
+<title>SPV_INTEL_fpga_argument_interfaces</title>
+<style>
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
+</style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-
-<body class="book">
-  <div id="header">
-    <h1>SPV_INTEL_fpga_argument_interfaces</h1>
-  </div>
-  <div id="content">
-    <div class="sect1">
-      <h2 id="_name_strings">Name Strings</h2>
-      <div class="sectionbody">
-        <div class="paragraph">
-          <p>SPV_INTEL_fpga_argument_interfaces</p>
-        </div>
-      </div>
-    </div>
-    <div class="sect1">
-      <h2 id="_contact">Contact</h2>
-      <div class="sectionbody">
-        <div class="paragraph">
-          <p>To report problems with this extension, please open a new issue at:</p>
-        </div>
-        <div class="paragraph">
-          <p><a href="https://github.com/KhronosGroup/SPIRV-Headers" class="bare">https://github.com/KhronosGroup/SPIRV-Headers</a></p>
-        </div>
-      </div>
-    </div>
-    <div class="sect1">
-      <h2 id="_contributors">Contributors</h2>
-      <div class="sectionbody">
-        <div class="paragraph">
-          <p>Abhishek Tiwari, Intel<br> Joe Garvey, Intel</p>
-        </div>
-      </div>
-    </div>
-    <div class="sect1">
-      <h2 id="_notice">Notice</h2>
-      <div class="sectionbody">
-        <div class="paragraph">
-          <p>Copyright (c) 2022 Intel Corporation. All rights reserved.</p>
-        </div>
-      </div>
-    </div>
-    <div class="sect1">
-      <h2 id="_status">Status</h2>
-      <div class="sectionbody">
-        <div class="paragraph">
-          <p>Final draft</p>
-        </div>
-      </div>
-    </div>
-    <div class="sect1">
-      <h2 id="_version">Version</h2>
-      <div class="sectionbody">
-        <div class="paragraph">
-          <p>Built On: 2023-01-25<br> Revision: 1</p>
-        </div>
-      </div>
-    </div>
-    <div class="sect1">
-      <h2 id="_dependencies">Dependencies</h2>
-      <div class="sectionbody">
-        <div class="paragraph">
-          <p>This extension is written against the SPIR-V Specification, Version 1.6
-            Revision 2.</p>
-        </div>
-        <div class="paragraph">
-          <p>This extension requires SPIR-V 1.0.</p>
-        </div>
-      </div>
-    </div>
-    <div class="sect1">
-      <h2 id="_overview">Overview</h2>
-      <div class="sectionbody">
-        <div class="paragraph">
-          <p>This extension adds kernel argument decorations that influence the interfaces
-            built for for Field Programmable Gate Array (FPGA) kernel arguments.</p>
-        </div>
-      </div>
-    </div>
-    <div class="sect1">
-      <h2 id="_extension_name">Extension Name</h2>
-      <div class="sectionbody">
-        <div class="paragraph">
-          <p>To use this extension within a SPIR-V module, the following <strong>OpExtension</strong>            must be present in the module:</p>
-        </div>
-        <div class="listingblock">
-          <div class="content">
-            <pre>OpExtension "SPV_INTEL_fpga_argument_interfaces"</pre>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="sect1">
-      <h2 id="_new_capabilities">New Capabilities</h2>
-      <div class="sectionbody">
-        <div class="paragraph">
-          <p>This extension introduces the following new capability:</p>
-        </div>
-        <div class="listingblock">
-          <div class="content">
-            <pre>FPGAArgumentInterfacesINTEL</pre>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="sect1">
-      <h2 id="_token_number_assignments">Token Number Assignments</h2>
-      <div class="sectionbody">
-        <div class="openblock">
-          <div class="content">
-            <table class="tableblock frame-all grid-rows" style="width: 40%;">
-              <colgroup>
-                <col style="width: 70%;">
-                <col style="width: 30%;">
-              </colgroup>
-              <tbody>
-                <tr>
-                  <td class="tableblock halign-left valign-top">
-                    <p class="tableblock">FPGAArgumentInterfacesINTEL</p>
-                  </td>
-                  <td class="tableblock halign-left valign-top">
-                    <p class="tableblock">6174</p>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="tableblock halign-left valign-top">
-                    <p class="tableblock">ConduitKernelArgumentINTEL</p>
-                  </td>
-                  <td class="tableblock halign-left valign-top">
-                    <p class="tableblock">6175</p>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="tableblock halign-left valign-top">
-                    <p class="tableblock">RegisterMapKernelArgumentINTEL</p>
-                  </td>
-                  <td class="tableblock halign-left valign-top">
-                    <p class="tableblock">6176</p>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="tableblock halign-left valign-top">
-                    <p class="tableblock">MMHostInterfaceAddressWidthINTEL</p>
-                  </td>
-                  <td class="tableblock halign-left valign-top">
-                    <p class="tableblock">6177</p>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="tableblock halign-left valign-top">
-                    <p class="tableblock">MMHostInterfaceDataWidthINTEL</p>
-                  </td>
-                  <td class="tableblock halign-left valign-top">
-                    <p class="tableblock">6178</p>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="tableblock halign-left valign-top">
-                    <p class="tableblock">MMHostInterfaceLatencyINTEL</p>
-                  </td>
-                  <td class="tableblock halign-left valign-top">
-                    <p class="tableblock">6179</p>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="tableblock halign-left valign-top">
-                    <p class="tableblock">MMHostInterfaceReadWriteModeINTEL</p>
-                  </td>
-                  <td class="tableblock halign-left valign-top">
-                    <p class="tableblock">6180</p>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="tableblock halign-left valign-top">
-                    <p class="tableblock">MMHostInterfaceMaxBurstINTEL</p>
-                  </td>
-                  <td class="tableblock halign-left valign-top">
-                    <p class="tableblock">6181</p>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="tableblock halign-left valign-top">
-                    <p class="tableblock">MMHostInterfaceWaitRequestINTEL</p>
-                  </td>
-                  <td class="tableblock halign-left valign-top">
-                    <p class="tableblock">6182</p>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="tableblock halign-left valign-top">
-                    <p class="tableblock">StableKernelArgumentINTEL</p>
-                  </td>
-                  <td class="tableblock halign-left valign-top">
-                    <p class="tableblock">6183</p>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="sect1">
-      <h2 id="_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification, Version 1.6</h2>
-      <div class="sectionbody">
-        <div class="sect2">
-          <h3 id="_decoration">Decoration</h3>
-          <div class="paragraph">
-            <p>Modify Section 3.20, Decoration, adding these rows to the Decoration
-              table:</p>
-          </div>
-          <div class="openblock">
-            <div class="content">
-              <table class="tableblock frame-all grid-all spread">
-                <colgroup>
-                  <col style="width: 20%;">
-                  <col style="width: 20%;">
-                  <col style="width: 20%;">
-                  <col style="width: 20%;">
-                  <col style="width: 20%;">
-                </colgroup>
-                <thead>
-                  <tr>
-                    <th class="tableblock halign-center valign-top" colspan="2">Decoration</th>
-                    <th class="tableblock halign-center valign-top" colspan="2">Extra Operands</th>
-                    <th class="tableblock halign-center valign-top">Enabling Capabilities</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock">6175</p>
-                    </td>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock"><strong>ConduitKernelArgumentINTEL</strong><br> Must be applied
-                        only to an <strong>OpFunctionParameter</strong> of a function
-                        that is an <strong>entry point</strong>. Indicates that dedicated
-                        input wires should be created for this argument.</p>
-                    </td>
-                    <td class="tableblock halign-left valign-top" colspan="2"></td>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock"><strong>FPGAArgumentInterfacesINTEL</strong></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock">6176</p>
-                    </td>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock"><strong>RegisterMapKernelArgumentINTEL</strong><br> Must be
-                        applied only to an <strong>OpFunctionParameter</strong> of
-                        a function that is an <strong>entry point</strong>. Indicates
-                        that this argument is stored in registers in the kernel that
-                        are accessed through a common interface shared between this
-                        argument, other RegisterMapKernelArgumentINTEL arguments,
-                        and possibly kernel control signals.</p>
-                    </td>
-                    <td class="tableblock halign-left valign-top" colspan="2"></td>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock"><strong>FPGAArgumentInterfacesINTEL</strong></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock">6177</p>
-                    </td>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock"><strong>MMHostInterfaceAddressWidthINTEL</strong><br> Must
-                        be applied only to a pointer <strong>OpFunctionParameter</strong>                        of a function that is an <strong>entry point</strong>. Indicates
-                        the size, in bits, of the address bus for the Memory Mapped
-                        Interface created for this pointer argument.</p>
-                    </td>
-                    <td class="tableblock halign-left valign-top" colspan="2">
-                      <p class="tableblock">Literal Number (32-bit signed integer)<br>
-                        <em>AddressWidth</em></p>
-                    </td>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock"><strong>FPGAArgumentInterfacesINTEL</strong></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock">6178</p>
-                    </td>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock"><strong>MMHostInterfaceDataWidthINTEL</strong><br> Must be
-                        applied only to a pointer <strong>OpFunctionParameter</strong>                        of a function that is an <strong>entry point</strong>. Indicates
-                        the size, in bits, of the data bus for the Memory Mapped
-                        Interface created for this pointer argument.</p>
-                    </td>
-                    <td class="tableblock halign-left valign-top" colspan="2">
-                      <p class="tableblock">Literal Number (32-bit signed integer)<br>
-                        <em>DataWidth</em></p>
-                    </td>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock"><strong>FPGAArgumentInterfacesINTEL</strong></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock">6179</p>
-                    </td>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock"><strong>MMHostInterfaceLatencyINTEL</strong><br> Must be applied
-                        only to a pointer <strong>OpFunctionParameter</strong> of
-                        a function that is an <strong>entry point</strong>. Indicates
-                        the latency in cycles of the Memory Mapped Interface created
-                        for this pointer argument. If this decoration is present
-                        it guarantees that the latency is fixed.</p>
-                    </td>
-                    <td class="tableblock halign-left valign-top" colspan="2">
-                      <p class="tableblock">Literal Number (32-bit signed integer)<br>
-                        <em>Latency</em></p>
-                    </td>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock"><strong>FPGAArgumentInterfacesINTEL</strong></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock">6180</p>
-                    </td>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock"><strong>MMHostInterfaceReadWriteModeINTEL</strong><br> Must
-                        be applied only to a pointer <strong>OpFunctionParameter</strong>                        of a function that is an <strong>entry point</strong>. Indicates
-                        the read-write mode of the Memory Mapped Interface created
-                        for this pointer argument.</p>
-                    </td>
-                    <td class="tableblock halign-left valign-top" colspan="2">
-                      <p class="tableblock"><strong>Access Qualifier</strong><br>
-                        <em>ReadWriteMode</em></p>
-                    </td>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock"><strong>FPGAArgumentInterfacesINTEL</strong></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock">6181</p>
-                    </td>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock"><strong>MMHostInterfaceMaxBurstINTEL</strong><br> Must be applied
-                        only to a pointer <strong>OpFunctionParameter</strong> of
-                        a function that is an <strong>entry point</strong>. Indicates
-                        the maximum burst count of the Memory Mapped Interface created
-                        for this pointer argument.</p>
-                    </td>
-                    <td class="tableblock halign-left valign-top" colspan="2">
-                      <p class="tableblock">Literal Number (32-bit signed integer)<br>
-                        <em>MaxBurstCount</em></p>
-                    </td>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock"><strong>FPGAArgumentInterfacesINTEL</strong></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock">6182</p>
-                    </td>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock"><strong>MMHostInterfaceWaitRequestINTEL</strong><br> Must be
-                        applied only to a pointer <strong>OpFunctionParameter</strong>                        of a function that is an <strong>entry point</strong>. Indicates
-                        whether the Memory Mapped Interface created for this pointer
-                        argument should accept a waitrequest signal.
-                      </p>
-                      <p class="tableblock">A setting of 1 means build a waitrequest signal and a setting
-                        of 0 means don&#8217;t.</p>
-                    </td>
-                    <td class="tableblock halign-left valign-top" colspan="2">
-                      <p class="tableblock">Literal Number (32-bit signed integer)<br>
-                        <em>Waitrequest</em></p>
-                    </td>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock"><strong>FPGAArgumentInterfacesINTEL</strong></p>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock">6183</p>
-                    </td>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock"><strong>StableKernelArgumentINTEL</strong><br> Must be applied
-                        only to an <strong>OpFunctionParameter</strong> of a function
-                        that is an <strong>entry point</strong>. Indicates that this
-                        input will not change during the execution of pipelined kernel
-                        invocations. Input can change once all active invocations
-                        have finished.</p>
-                    </td>
-                    <td class="tableblock halign-left valign-top" colspan="2"></td>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock"><strong>FPGAArgumentInterfacesINTEL</strong></p>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-        <div class="sect2">
-          <h3 id="_capability">Capability</h3>
-          <div class="paragraph">
-            <p>Modify Section 3.31, Capability, adding a row to the Capability table:</p>
-          </div>
-          <div class="openblock">
-            <div class="content">
-              <table class="tableblock frame-all grid-all spread">
-                <colgroup>
-                  <col style="width: 33.3333%;">
-                  <col style="width: 33.3333%;">
-                  <col style="width: 33.3334%;">
-                </colgroup>
-                <thead>
-                  <tr>
-                    <th class="tableblock halign-center valign-top" colspan="2">Capability</th>
-                    <th class="tableblock halign-center valign-top">Implicitly Declares</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock">6174</p>
-                    </td>
-                    <td class="tableblock halign-left valign-top">
-                      <p class="tableblock">FPGAArgumentInterfacesINTEL</p>
-                    </td>
-                    <td class="tableblock halign-left valign-top"></td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-        <div class="sect2">
-          <h3 id="_validation_rules">Validation Rules</h3>
-          <div class="paragraph">
-            <p>It is invalid to specify both <strong>ConduitKernelArgumentINTEL</strong>              and <strong>RegisterMapKernelArgumentINTEL</strong> decorations on
-              the same <strong>OpFunctionParameter</strong>.</p>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="sect1">
-      <h2 id="_issues">Issues</h2>
-      <div class="sectionbody">
-        <div class="paragraph">
-          <p>None.</p>
-        </div>
-      </div>
-    </div>
-    <div class="sect1">
-      <h2 id="_revision_history">Revision History</h2>
-      <div class="sectionbody">
-        <table class="tableblock frame-all grid-rows spread">
-          <colgroup>
-            <col style="width: 4.7619%;">
-            <col style="width: 14.2857%;">
-            <col style="width: 14.2857%;">
-            <col style="width: 66.6667%;">
-          </colgroup>
-          <thead>
-            <tr>
-              <th class="tableblock halign-left valign-top">Rev</th>
-              <th class="tableblock halign-left valign-top">Date</th>
-              <th class="tableblock halign-left valign-top">Author</th>
-              <th class="tableblock halign-left valign-top">Changes</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="tableblock halign-left valign-top">
-                <p class="tableblock">1</p>
-              </td>
-              <td class="tableblock halign-left valign-top">
-                <p class="tableblock">2022-12-04</p>
-              </td>
-              <td class="tableblock halign-left valign-top">
-                <p class="tableblock">Abhishek Tiwari, Brox Chen</p>
-              </td>
-              <td class="tableblock halign-left valign-top">
-                <p class="tableblock"><strong>Initial public release</strong></p>
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-  </div>
+<body class="article toc2 toc-left">
+<div id="header">
+<h1>SPV_INTEL_fpga_argument_interfaces</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification, Version 1.6</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
+</div>
+<div id="content">
+<div class="sect1">
+<h2 id="_name_strings">Name Strings</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>SPV_INTEL_fpga_argument_interfaces</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_contact">Contact</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>To report problems with this extension, please open a new issue at:</p>
+</div>
+<div class="paragraph">
+<p><a href="https://github.com/KhronosGroup/SPIRV-Headers" class="bare">https://github.com/KhronosGroup/SPIRV-Headers</a></p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_contributors">Contributors</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Abhishek Tiwari, Intel<br>
+Joe Garvey, Intel</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_notice">Notice</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Copyright (c) 2022 Intel Corporation.  All rights reserved.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_status">Status</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Final draft</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_version">Version</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>Built On: 2023-02-08<br>
+Revision: 1</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_dependencies">Dependencies</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This extension is written against the SPIR-V Specification,
+Version 1.6 Revision 2.</p>
+</div>
+<div class="paragraph">
+<p>This extension requires SPIR-V 1.0.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_overview">Overview</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This extension adds kernel argument decorations that influence the interfaces built for for Field Programmable Gate Array (FPGA) kernel arguments.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_extension_name">Extension Name</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>To use this extension within a SPIR-V module, the following <strong>OpExtension</strong> must be present in the module:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>OpExtension "SPV_INTEL_fpga_argument_interfaces"</pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_new_capabilities">New Capabilities</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>This extension introduces the following new capability:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre>FPGAArgumentInterfacesINTEL</pre>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_token_number_assignments">Token Number Assignments</h2>
+<div class="sectionbody">
+<div class="openblock">
+<div class="content">
+<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<colgroup>
+<col style="width: 70%;">
+<col style="width: 30%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">FPGAArgumentInterfacesINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6174</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">ConduitKernelArgumentINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6175</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">RegisterMapKernelArgumentINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6176</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">MMHostInterfaceAddressWidthINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6177</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">MMHostInterfaceDataWidthINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6178</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">MMHostInterfaceLatencyINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6179</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">MMHostInterfaceReadWriteModeINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6180</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">MMHostInterfaceMaxBurstINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6181</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">MMHostInterfaceWaitRequestINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6182</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">StableKernelArgumentINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6183</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification, Version 1.6</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_decoration">Decoration</h3>
+<div class="paragraph">
+<p>Modify Section 3.20, Decoration, adding these rows to the Decoration table:</p>
+</div>
+<div class="openblock">
+<div class="content">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-center valign-top" colspan="2">Decoration</th>
+<th class="tableblock halign-center valign-top" colspan="2">Extra Operands</th>
+<th class="tableblock halign-center valign-top">Enabling Capabilities</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6175</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>ConduitKernelArgumentINTEL</strong><br>
+Must be applied only to an <strong>OpFunctionParameter</strong> of a function that is an <strong>entry point</strong>. Indicates that dedicated input wires should be created for this argument.</p></td>
+<td class="tableblock halign-left valign-top" colspan="2"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>FPGAArgumentInterfacesINTEL</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6176</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>RegisterMapKernelArgumentINTEL</strong><br>
+Must be applied only to an <strong>OpFunctionParameter</strong> of a function that is an <strong>entry point</strong>. Indicates that this argument is stored in registers in the kernel that are accessed through a common interface shared between this argument, other RegisterMapKernelArgumentINTEL arguments, and possibly kernel control signals.</p></td>
+<td class="tableblock halign-left valign-top" colspan="2"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>FPGAArgumentInterfacesINTEL</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6177</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>MMHostInterfaceAddressWidthINTEL</strong><br>
+Must be applied only to a pointer <strong>OpFunctionParameter</strong> of a function that is an <strong>entry point</strong>. Indicates the size, in bits, of the address bus for the Memory Mapped Interface created for this pointer argument.</p></td>
+<td class="tableblock halign-left valign-top" colspan="2"><p class="tableblock">Literal Number (32-bit signed integer)<br>
+<em>AddressWidth</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>FPGAArgumentInterfacesINTEL</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6178</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>MMHostInterfaceDataWidthINTEL</strong><br>
+Must be applied only to a pointer <strong>OpFunctionParameter</strong> of a function that is an <strong>entry point</strong>. Indicates the size, in bits, of the data bus for the Memory Mapped Interface created for this pointer argument.</p></td>
+<td class="tableblock halign-left valign-top" colspan="2"><p class="tableblock">Literal Number (32-bit signed integer)<br>
+<em>DataWidth</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>FPGAArgumentInterfacesINTEL</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6179</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>MMHostInterfaceLatencyINTEL</strong><br>
+Must be applied only to a pointer <strong>OpFunctionParameter</strong> of a function that is an <strong>entry point</strong>. Indicates the latency in cycles of the Memory Mapped Interface created for this pointer argument. If this decoration is present it guarantees that the latency is fixed.</p></td>
+<td class="tableblock halign-left valign-top" colspan="2"><p class="tableblock">Literal Number (32-bit signed integer)<br>
+<em>Latency</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>FPGAArgumentInterfacesINTEL</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6180</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>MMHostInterfaceReadWriteModeINTEL</strong><br>
+Must be applied only to a pointer <strong>OpFunctionParameter</strong> of a function that is an <strong>entry point</strong>. Indicates the read-write mode of the Memory Mapped Interface created for this pointer argument.</p></td>
+<td class="tableblock halign-left valign-top" colspan="2"><p class="tableblock"><strong>Access Qualifier</strong><br>
+<em>ReadWriteMode</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>FPGAArgumentInterfacesINTEL</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6181</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>MMHostInterfaceMaxBurstINTEL</strong><br>
+Must be applied only to a pointer <strong>OpFunctionParameter</strong> of a function that is an <strong>entry point</strong>. Indicates the maximum burst count of the Memory Mapped Interface created for this pointer argument.</p></td>
+<td class="tableblock halign-left valign-top" colspan="2"><p class="tableblock">Literal Number (32-bit signed integer)<br>
+<em>MaxBurstCount</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>FPGAArgumentInterfacesINTEL</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6182</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>MMHostInterfaceWaitRequestINTEL</strong><br>
+Must be applied only to a pointer <strong>OpFunctionParameter</strong> of a function that is an <strong>entry point</strong>. Indicates whether the Memory Mapped Interface created for this pointer argument should accept a waitrequest signal.</p>
+<p class="tableblock">A setting of 1 means build a waitrequest signal and a setting of 0 means don&#8217;t.</p></td>
+<td class="tableblock halign-left valign-top" colspan="2"><p class="tableblock">Literal Number (32-bit signed integer)<br>
+<em>Waitrequest</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>FPGAArgumentInterfacesINTEL</strong></p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6183</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>StableKernelArgumentINTEL</strong><br>
+Must be applied only to an <strong>OpFunctionParameter</strong> of a function that is an <strong>entry point</strong>. Indicates that this input will not change during the execution of pipelined kernel invocations. Input can change once all active invocations have finished.</p></td>
+<td class="tableblock halign-left valign-top" colspan="2"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>FPGAArgumentInterfacesINTEL</strong></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_capability">Capability</h3>
+<div class="paragraph">
+<p>Modify Section 3.31, Capability, adding a row to the Capability table:</p>
+</div>
+<div class="openblock">
+<div class="content">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-center valign-top" colspan="2">Capability</th>
+<th class="tableblock halign-center valign-top">Implicitly Declares</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6174</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">FPGAArgumentInterfacesINTEL</p></td>
+<td class="tableblock halign-left valign-top"></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_validation_rules">Validation Rules</h3>
+<div class="paragraph">
+<p>It is invalid to specify both <strong>ConduitKernelArgumentINTEL</strong> and <strong>RegisterMapKernelArgumentINTEL</strong> decorations on the same <strong>OpFunctionParameter</strong>.</p>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_issues">Issues</h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>None.</p>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_revision_history">Revision History</h2>
+<div class="sectionbody">
+<table class="tableblock frame-all grid-rows stretch">
+<colgroup>
+<col style="width: 4.7619%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 66.6667%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Rev</th>
+<th class="tableblock halign-left valign-top">Date</th>
+<th class="tableblock halign-left valign-top">Author</th>
+<th class="tableblock halign-left valign-top">Changes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2022-12-04</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Abhishek Tiwari, Brox Chen</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Initial public release</strong></p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
 </body>
-
 </html>

--- a/extensions/INTEL/SPV_INTEL_fpga_buffer_location.html
+++ b/extensions/INTEL/SPV_INTEL_fpga_buffer_location.html
@@ -4,494 +4,101 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.17">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_fpga_buffer_location</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-html{font-family:sans-serif;-webkit-text-size-adjust:100%}
-a{background:none}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-b,strong{font-weight:bold}
-abbr{font-size:.9em}
-abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
-dfn{font-style:italic}
-hr{height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-audio,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type=checkbox],input[type=radio]{padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,::before,::after{box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:0}
-p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-:not(pre).nobreak{word-wrap:normal}
-:not(pre).nowrap{white-space:nowrap}
-:not(pre).pre-wrap{white-space:pre-wrap}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
-pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
-pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
-pre>code{display:block}
-pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #e7e7e9}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details{margin-left:1.25rem}
-details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
-details>summary::-webkit-details-marker{display:none}
-details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
-details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
-details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
-@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
-.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
-.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.prettyprint{background:#f7f7f8}
-pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
-pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
-pre.prettyprint li code[data-lang]::before{opacity:1}
-pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
-table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
-table.linenotable td.code{padding-left:.75em}
-table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
-pre.pygments span.linenos{display:inline-block;margin-right:.75em}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
-.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
-.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
-.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
-td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>*>tr>*{border-width:1px}
-table.grid-cols>*>tr>*{border-width:0 1px}
-table.grid-rows>*>tr>*{border-width:1px 0}
-table.frame-all{border-width:1px}
-table.frame-ends{border-width:1px 0}
-table.frame-sides{border-width:0 1px}
-table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
-table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
-table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
-table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
-table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-li>p:empty:only-child::before{content:"";display:inline-block}
-ul.checklist>li>p:first-child{margin-left:-1em}
-ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
-ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-td.hdlist2{word-wrap:anywhere}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
-.imageblock.left{margin:.25em .625em 1.25em 0}
-.imageblock.right{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background:#00fafa}
-.black{color:#000}
-.black-background{background:#000}
-.blue{color:#0000bf}
-.blue-background{background:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background:#fa00fa}
-.gray{color:#606060}
-.gray-background{background:#7d7d7d}
-.green{color:#006000}
-.green-background{background:#007d00}
-.lime{color:#00bf00}
-.lime-background{background:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background:#7d0000}
-.navy{color:#000060}
-.navy-background{background:#00007d}
-.olive{color:#606000}
-.olive-background{background:#7d7d00}
-.purple{color:#600060}
-.purple-background{background:#7d007d}
-.red{color:#bf0000}
-.red-background{background:#fa0000}
-.silver{color:#909090}
-.silver-background{background:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]{border-bottom:1px dotted}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#header,#content,#footnotes,#footer{max-width:none}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article data-line-1">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_fpga_buffer_location</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification, Version 1.6</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
-<div class="sect1 data-line-4">
+<div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-6">
+<div class="paragraph">
 <p>SPV_INTEL_fpga_buffer_location</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-8">
+<div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-10">
+<div class="paragraph">
 <p>To report problems with this extension, please open a new issue at:</p>
 </div>
-<div class="paragraph data-line-12">
-<p><a href="https://github.com/KhronosGroup/SPIRV-Headers" class="undefined" data-href="https://github.com/KhronosGroup/SPIRV-Headers">https://github.com/KhronosGroup/SPIRV-Headers</a></p>
+<div class="paragraph">
+<p><a href="https://github.com/KhronosGroup/SPIRV-Headers" class="bare">https://github.com/KhronosGroup/SPIRV-Headers</a></p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-14">
+<div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="ulist data-line-16">
+<div class="ulist">
 <ul>
-<li class="data-line-16">
-<p>Joe Garvey, Intel<br></p>
+<li>
+<p>Joe Garvey, Intel</p>
 </li>
-<li class="data-line-16">
-<p>Daniel Zhang, Intel<br></p>
+<li>
+<p>Daniel Zhang, Intel</p>
 </li>
 </ul>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-18">
+<div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-20">
+<div class="paragraph">
 <p>Copyright (c) 2023 Intel Corporation.  All rights reserved.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-22">
+<div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-24">
+<div class="paragraph">
 <p>Final Draft</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-26">
+<div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all data-line-29" style="width: 40%;">
+<table class="tableblock frame-all grid-all" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -509,58 +116,58 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </table>
 </div>
 </div>
-<div class="sect1 data-line-34">
+<div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-36">
+<div class="paragraph">
 <p>This extension is written against the SPIR-V Specification,
 Version 1.6 Revision 2.</p>
 </div>
-<div class="paragraph data-line-39">
+<div class="paragraph">
 <p>This extension requires SPIR-V 1.0.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-41">
+<div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-43">
+<div class="paragraph">
 <p>This extension adds a pointer decoration that is useful for FPGA targets.  This decoration indicates that a particular global memory pointer can only access a particular physical memory location.  Knowing this information at compile time can allow FPGA compilers to generate load store units of lower area for accesses done through such a pointer.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-45">
+<div class="sect1">
 <h2 id="_extension_name">Extension Name</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-46">
+<div class="paragraph">
 <p>To use this extension within a SPIR-V module, the following <strong>OpExtension</strong> must be present in the module:</p>
 </div>
-<div class="listingblock data-line-48">
+<div class="listingblock">
 <div class="content">
 <pre>OpExtension "SPV_INTEL_fpga_buffer_location"</pre>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-52">
+<div class="sect1">
 <h2 id="_new_capabilities">New Capabilities</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-53">
+<div class="paragraph">
 <p>This extension introduces a new capability:</p>
 </div>
-<div class="listingblock data-line-55">
+<div class="listingblock">
 <div class="content">
 <pre>FPGABufferLocationINTEL</pre>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-59">
+<div class="sect1">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<div class="openblock data-line-61">
+<div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-rows data-line-65" style="width: 40%;">
+<table class="tableblock frame-all grid-rows" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -580,17 +187,17 @@ Version 1.6 Revision 2.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-71">
+<div class="sect1">
 <h2 id="_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification, Version 1.6</h2>
 <div class="sectionbody">
-<div class="sect2 data-line-73">
+<div class="sect2">
 <h3 id="_decoration">Decoration</h3>
-<div class="paragraph data-line-75">
+<div class="paragraph">
 <p>Modify Section 3.20, Decoration, adding these rows to the Decoration table:</p>
 </div>
-<div class="openblock data-line-77">
+<div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch data-line-79">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -618,14 +225,14 @@ Apply only to a pointer. Indicates that the pointer must only point into the phy
 </div>
 </div>
 </div>
-<div class="sect2 data-line-87">
+<div class="sect2">
 <h3 id="_capability">Capability</h3>
-<div class="paragraph data-line-89">
+<div class="paragraph">
 <p>Modify Section 3.31, Capability, adding a row to the Capability table:</p>
 </div>
-<div class="openblock data-line-90">
+<div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch data-line-92">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -648,26 +255,26 @@ Apply only to a pointer. Indicates that the pointer must only point into the phy
 </div>
 </div>
 </div>
-<div class="sect2 data-line-98">
+<div class="sect2">
 <h3 id="_validation_rules">Validation Rules</h3>
-<div class="paragraph data-line-100">
+<div class="paragraph">
 <p>None.</p>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-102">
+<div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-104">
+<div class="paragraph">
 <p>None.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-112">
+<div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch data-line-117">
+<table class="tableblock frame-all grid-rows stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">
@@ -692,11 +299,6 @@ Apply only to a pointer. Indicates that the pointer must only point into the phy
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2023-02-01 13:37:05 -0800
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_fpga_cluster_attributes.html
+++ b/extensions/INTEL/SPV_INTEL_fpga_cluster_attributes.html
@@ -4,494 +4,99 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.17">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_fpga_cluster_attributes</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
-/* Uncomment the following line when using as a custom stylesheet */
-/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
-html{font-family:sans-serif;-webkit-text-size-adjust:100%}
-a{background:none}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-b,strong{font-weight:bold}
-abbr{font-size:.9em}
-abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
-dfn{font-style:italic}
-hr{height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-audio,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type=checkbox],input[type=radio]{padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,::before,::after{box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:0}
-p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-:not(pre).nobreak{word-wrap:normal}
-:not(pre).nowrap{white-space:nowrap}
-:not(pre).pre-wrap{white-space:pre-wrap}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
-pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
-pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
-pre>code{display:block}
-pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #e7e7e9}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details{margin-left:1.25rem}
-details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
-details>summary::-webkit-details-marker{display:none}
-details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
-details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
-details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
-@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
-.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
-.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.prettyprint{background:#f7f7f8}
-pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
-pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
-pre.prettyprint li code[data-lang]::before{opacity:1}
-pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
-table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
-table.linenotable td.code{padding-left:.75em}
-table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
-pre.pygments span.linenos{display:inline-block;margin-right:.75em}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
-.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
-.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
-.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
-td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>*>tr>*{border-width:1px}
-table.grid-cols>*>tr>*{border-width:0 1px}
-table.grid-rows>*>tr>*{border-width:1px 0}
-table.frame-all{border-width:1px}
-table.frame-ends{border-width:1px 0}
-table.frame-sides{border-width:0 1px}
-table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
-table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
-table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
-table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
-table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-li>p:empty:only-child::before{content:"";display:inline-block}
-ul.checklist>li>p:first-child{margin-left:-1em}
-ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
-ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-td.hdlist2{word-wrap:anywhere}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
-.imageblock.left{margin:.25em .625em 1.25em 0}
-.imageblock.right{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background:#00fafa}
-.black{color:#000}
-.black-background{background:#000}
-.blue{color:#0000bf}
-.blue-background{background:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background:#fa00fa}
-.gray{color:#606060}
-.gray-background{background:#7d7d7d}
-.green{color:#006000}
-.green-background{background:#007d00}
-.lime{color:#00bf00}
-.lime-background{background:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background:#7d0000}
-.navy{color:#000060}
-.navy-background{background:#00007d}
-.olive{color:#606000}
-.olive-background{background:#7d7d00}
-.purple{color:#600060}
-.purple-background{background:#7d007d}
-.red{color:#bf0000}
-.red-background{background:#fa0000}
-.silver{color:#909090}
-.silver-background{background:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]{border-bottom:1px dotted}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#header,#content,#footnotes,#footer{max-width:none}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article data-line-1">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_fpga_cluster_attributes</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New capabilities</a></li>
+<li><a href="#_new_decorations">New Decorations</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification, Version 1.6</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
-<div class="sect1 data-line-4">
+<div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-6">
+<div class="paragraph">
 <p>SPV_INTEL_fpga_cluster_attributes</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-8">
+<div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-10">
+<div class="paragraph">
 <p>To report problems with this extension, please open a new issue at:</p>
 </div>
-<div class="paragraph data-line-12">
-<p><a href="https://github.com/KhronosGroup/SPIRV-Registry" class="undefined" data-href="https://github.com/KhronosGroup/SPIRV-Registry">https://github.com/KhronosGroup/SPIRV-Registry</a></p>
+<div class="paragraph">
+<p><a href="https://github.com/KhronosGroup/SPIRV-Registry" class="bare">https://github.com/KhronosGroup/SPIRV-Registry</a></p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-14">
+<div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="ulist data-line-16">
+<div class="ulist">
 <ul>
-<li class="data-line-16">
+<li>
 <p>Jessica Davies, Intel</p>
 </li>
 </ul>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-18">
+<div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-20">
+<div class="paragraph">
 <p>Copyright (c) 2020, 2023 Intel Corporation.  All rights reserved.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-22">
+<div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-24">
+<div class="paragraph">
 <p>Final draft</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-26">
+<div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all data-line-29" style="width: 40%;">
+<table class="tableblock frame-all grid-all" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -509,46 +114,46 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </table>
 </div>
 </div>
-<div class="sect1 data-line-34">
+<div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-36">
+<div class="paragraph">
 <p>This extension is written against the SPIR-V Specification,
 Version 1.6 Revision 2.</p>
 </div>
-<div class="paragraph data-line-39">
+<div class="paragraph">
 <p>This extension requires SPIR-V 1.0.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-41">
+<div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-43">
+<div class="paragraph">
 <p>This extension adds decorations to request that statically-scheduled clusters use a stall-enable signal, or an exit FIFO, on an FPGA target.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-45">
+<div class="sect1">
 <h2 id="_extension_name">Extension Name</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-47">
+<div class="paragraph">
 <p>To use this extension within a SPIR-V module, the following <strong>OpExtension</strong> must be present in the module:</p>
 </div>
-<div class="listingblock data-line-49">
+<div class="listingblock">
 <div class="content">
 <pre>OpExtension "SPV_INTEL_fpga_cluster_attributes"</pre>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-53">
+<div class="sect1">
 <h2 id="_new_capabilities">New capabilities</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-54">
+<div class="paragraph">
 <p>This extension introduces two new capabilities:</p>
 </div>
-<div class="listingblock data-line-56">
+<div class="listingblock">
 <div class="content">
 <pre>FPGAClusterAttributesINTEL
 FPGAClusterAttributesV2INTEL</pre>
@@ -556,33 +161,33 @@ FPGAClusterAttributesV2INTEL</pre>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-61">
+<div class="sect1">
 <h2 id="_new_decorations">New Decorations</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-63">
+<div class="paragraph">
 <p>This extension adds the following decoration under the <strong>FPGAClusterAttributesINTEL</strong> capability:</p>
 </div>
-<div class="listingblock data-line-65">
+<div class="listingblock">
 <div class="content">
 <pre>StallEnableINTEL</pre>
 </div>
 </div>
-<div class="paragraph data-line-69">
+<div class="paragraph">
 <p>This extension adds the following decoration under the <strong>FPGAClusterAttributesV2INTEL</strong> capability:</p>
 </div>
-<div class="listingblock data-line-71">
+<div class="listingblock">
 <div class="content">
 <pre>StallFreeINTEL</pre>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-76">
+<div class="sect1">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<div class="openblock data-line-78">
+<div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-rows data-line-82" style="width: 40%;">
+<table class="tableblock frame-all grid-rows" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -610,17 +215,17 @@ FPGAClusterAttributesV2INTEL</pre>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-90">
+<div class="sect1">
 <h2 id="_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification, Version 1.6</h2>
 <div class="sectionbody">
-<div class="sect2 data-line-92">
+<div class="sect2">
 <h3 id="_decoration">Decoration</h3>
-<div class="paragraph data-line-94">
+<div class="paragraph">
 <p>Modify Section 3.20, Decoration, adding these rows to the Decoration table:</p>
 </div>
-<div class="openblock data-line-96">
+<div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch data-line-98">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -655,14 +260,14 @@ Only valid on OpFunction. Request, to the extent possible, that statically-sched
 </div>
 </div>
 </div>
-<div class="sect2 data-line-110">
+<div class="sect2">
 <h3 id="_capability">Capability</h3>
-<div class="paragraph data-line-112">
+<div class="paragraph">
 <p>Modify Section 3.31, Capability, adding the following rows to the Capability table:</p>
 </div>
-<div class="openblock data-line-113">
+<div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch data-line-115">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -690,26 +295,26 @@ Only valid on OpFunction. Request, to the extent possible, that statically-sched
 </div>
 </div>
 </div>
-<div class="sect2 data-line-122">
+<div class="sect2">
 <h3 id="_validation_rules">Validation Rules</h3>
-<div class="paragraph data-line-124">
+<div class="paragraph">
 <p>At most one of the <strong>StallEnableINTEL</strong> and <strong>StallFreeINTEL</strong> decorations can appear on an <strong>OpFunction</strong>.</p>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-126">
+<div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-128">
+<div class="paragraph">
 <p>None.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-130">
+<div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch data-line-135">
+<table class="tableblock frame-all grid-rows stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">
@@ -740,11 +345,6 @@ Only valid on OpFunction. Request, to the extent possible, that statically-sched
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2023-04-11 12:46:44 -0400
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_fpga_dsp_control.html
+++ b/extensions/INTEL/SPV_INTEL_fpga_dsp_control.html
@@ -4,441 +4,46 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.10">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_fpga_dsp_control</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
-/* Uncomment @import statement to use as custom stylesheet */
-/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
-article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}
-audio,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
-a{background:none}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-abbr[title]{border-bottom:1px dotted}
-b,strong{font-weight:bold}
-dfn{font-style:italic}
-hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:0}
-p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
-abbr{text-transform:none}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
-blockquote cite::before{content:"\2014 \0020"}
-blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
-:not(pre)>code.nobreak{word-wrap:normal}
-:not(pre)>code.nowrap{white-space:nowrap}
-pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
-pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
-pre>code{display:block}
-pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:100%;background:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #e7e7e9}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details>summary:first-of-type{cursor:pointer;display:list-item;outline:none;margin-bottom:.75em}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:inherit}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border-style:solid;border-width:1px;border-color:#dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;-webkit-border-radius:4px;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
-@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
-.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
-.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.prettyprint{background:#f7f7f8}
-pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
-pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
-pre.prettyprint li code[data-lang]::before{opacity:1}
-pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
-table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
-table.linenotable td.code{padding-left:.75em}
-table.linenotable td.linenos{border-right:1px solid currentColor;opacity:.35;padding-right:.5em}
-pre.pygments .lineno{border-right:1px solid currentColor;opacity:.35;display:inline-block;margin-right:.75em}
-pre.pygments .lineno::before{content:"";margin-right:-.125em}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
-.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
-.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
-.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
-table.tableblock{max-width:100%;border-collapse:separate}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-td.tableblock>.content>:last-child.sidebarblock{margin-bottom:0}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
-table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
-table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
-table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
-table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
-table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
-table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
-table.frame-all{border-width:1px}
-table.frame-sides{border-width:0 1px}
-table.frame-topbot,table.frame-ends{border-width:1px 0}
-table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-ul.checklist{margin-left:.625em}
-ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
-ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
-.imageblock.left{margin:.25em .625em 1.25em 0}
-.imageblock.right{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
-.gist .file-data>table td.line-data{width:99%}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background:#00fafa}
-.black{color:#000}
-.black-background{background:#000}
-.blue{color:#0000bf}
-.blue-background{background:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background:#fa00fa}
-.gray{color:#606060}
-.gray-background{background:#7d7d7d}
-.green{color:#006000}
-.green-background{background:#007d00}
-.lime{color:#00bf00}
-.lime-background{background:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background:#7d0000}
-.navy{color:#000060}
-.navy-background{background:#00007d}
-.olive{color:#606000}
-.olive-background{background:#7d7d00}
-.purple{color:#600060}
-.purple-background{background:#7d007d}
-.red{color:#bf0000}
-.red-background{background:#fa0000}
-.silver{color:#909090}
-.silver-background{background:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_fpga_dsp_control</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New capabilities</a></li>
+<li><a href="#_new_decorations">New Decorations</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_5">Modifications to the SPIR-V Specification, Version 1.5</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
 <div class="sect1">
@@ -729,11 +334,6 @@ Request, to the extent possible, that math operations in the function be impleme
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2021-03-12 16:16:35 -0400
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_fpga_invocation_pipelining_attributes.html
+++ b/extensions/INTEL/SPV_INTEL_fpga_invocation_pipelining_attributes.html
@@ -4,441 +4,46 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.10">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_fpga_invocation_pipelining_attributes</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
-/* Uncomment @import statement to use as custom stylesheet */
-/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
-article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}
-audio,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
-a{background:none}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-abbr[title]{border-bottom:1px dotted}
-b,strong{font-weight:bold}
-dfn{font-style:italic}
-hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:0}
-p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
-abbr{text-transform:none}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
-blockquote cite::before{content:"\2014 \0020"}
-blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
-:not(pre)>code.nobreak{word-wrap:normal}
-:not(pre)>code.nowrap{white-space:nowrap}
-pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
-pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
-pre>code{display:block}
-pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:100%;background:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #e7e7e9}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details>summary:first-of-type{cursor:pointer;display:list-item;outline:none;margin-bottom:.75em}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:inherit}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border-style:solid;border-width:1px;border-color:#dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;-webkit-border-radius:4px;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
-@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
-.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
-.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.prettyprint{background:#f7f7f8}
-pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
-pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
-pre.prettyprint li code[data-lang]::before{opacity:1}
-pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
-table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
-table.linenotable td.code{padding-left:.75em}
-table.linenotable td.linenos{border-right:1px solid currentColor;opacity:.35;padding-right:.5em}
-pre.pygments .lineno{border-right:1px solid currentColor;opacity:.35;display:inline-block;margin-right:.75em}
-pre.pygments .lineno::before{content:"";margin-right:-.125em}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
-.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
-.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
-.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
-table.tableblock{max-width:100%;border-collapse:separate}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-td.tableblock>.content>:last-child.sidebarblock{margin-bottom:0}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
-table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
-table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
-table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
-table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
-table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
-table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
-table.frame-all{border-width:1px}
-table.frame-sides{border-width:0 1px}
-table.frame-topbot,table.frame-ends{border-width:1px 0}
-table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-ul.checklist{margin-left:.625em}
-ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
-ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
-.imageblock.left{margin:.25em .625em 1.25em 0}
-.imageblock.right{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
-.gist .file-data>table td.line-data{width:99%}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background:#00fafa}
-.black{color:#000}
-.black-background{background:#000}
-.blue{color:#0000bf}
-.blue-background{background:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background:#fa00fa}
-.gray{color:#606060}
-.gray-background{background:#7d7d7d}
-.green{color:#006000}
-.green-background{background:#007d00}
-.lime{color:#00bf00}
-.lime-background{background:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background:#7d0000}
-.navy{color:#000060}
-.navy-background{background:#00007d}
-.olive{color:#606000}
-.olive-background{background:#7d7d00}
-.purple{color:#600060}
-.purple-background{background:#7d007d}
-.red{color:#bf0000}
-.red-background{background:#fa0000}
-.silver{color:#909090}
-.silver-background{background:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_fpga_invocation_pipelining_attributes</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New capabilities</a></li>
+<li><a href="#_new_decorations">New Decorations</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_5">Modifications to the SPIR-V Specification, Version 1.5</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
 <div class="sect1">
@@ -741,11 +346,6 @@ Only valid on OpFunction. Strong request, to the extent possible, to either supp
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2021-05-23 20:11:09 -0300
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_fpga_latency_control.html
+++ b/extensions/INTEL/SPV_INTEL_fpga_latency_control.html
@@ -4,487 +4,95 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.17">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_fpga_latency_control</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-html{font-family:sans-serif;-webkit-text-size-adjust:100%}
-a{background:none}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-b,strong{font-weight:bold}
-abbr{font-size:.9em}
-abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
-dfn{font-style:italic}
-hr{height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-audio,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type=checkbox],input[type=radio]{padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,::before,::after{box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:0}
-p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-:not(pre).nobreak{word-wrap:normal}
-:not(pre).nowrap{white-space:nowrap}
-:not(pre).pre-wrap{white-space:pre-wrap}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
-pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
-pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
-pre>code{display:block}
-pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #e7e7e9}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details{margin-left:1.25rem}
-details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
-details>summary::-webkit-details-marker{display:none}
-details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
-details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
-details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
-@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
-.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
-.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.prettyprint{background:#f7f7f8}
-pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
-pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
-pre.prettyprint li code[data-lang]::before{opacity:1}
-pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
-table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
-table.linenotable td.code{padding-left:.75em}
-table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
-pre.pygments span.linenos{display:inline-block;margin-right:.75em}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
-.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
-.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
-.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
-td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>*>tr>*{border-width:1px}
-table.grid-cols>*>tr>*{border-width:0 1px}
-table.grid-rows>*>tr>*{border-width:1px 0}
-table.frame-all{border-width:1px}
-table.frame-ends{border-width:1px 0}
-table.frame-sides{border-width:0 1px}
-table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
-table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
-table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
-table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
-table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-li>p:empty:only-child::before{content:"";display:inline-block}
-ul.checklist>li>p:first-child{margin-left:-1em}
-ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
-ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-td.hdlist2{word-wrap:anywhere}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
-.imageblock.left{margin:.25em .625em 1.25em 0}
-.imageblock.right{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background:#00fafa}
-.black{color:#000}
-.black-background{background:#000}
-.blue{color:#0000bf}
-.blue-background{background:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background:#fa00fa}
-.gray{color:#606060}
-.gray-background{background:#7d7d7d}
-.green{color:#006000}
-.green-background{background:#007d00}
-.lime{color:#00bf00}
-.lime-background{background:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background:#7d0000}
-.navy{color:#000060}
-.navy-background{background:#00007d}
-.olive{color:#606000}
-.olive-background{background:#7d7d00}
-.purple{color:#600060}
-.purple-background{background:#7d007d}
-.red{color:#bf0000}
-.red-background{background:#fa0000}
-.silver{color:#909090}
-.silver-background{background:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]{border-bottom:1px dotted}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#header,#content,#footnotes,#footer{max-width:none}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article data-line-1">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_fpga_latency_control</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_new_decorations">New Decorations</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification, Version 1.6</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
-<div class="sect1 data-line-4">
+<div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-6">
+<div class="paragraph">
 <p>SPV_INTEL_fpga_latency_control</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-8">
+<div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-10">
+<div class="paragraph">
 <p>To report problems with this extension, please open a new issue at:</p>
 </div>
-<div class="paragraph data-line-12">
-<p><a href="https://github.com/KhronosGroup/SPIRV-Registry" class="undefined" data-href="https://github.com/KhronosGroup/SPIRV-Registry">https://github.com/KhronosGroup/SPIRV-Registry</a></p>
+<div class="paragraph">
+<p><a href="https://github.com/KhronosGroup/SPIRV-Registry" class="bare">https://github.com/KhronosGroup/SPIRV-Registry</a></p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-14">
+<div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-16">
+<div class="paragraph">
 <p>Shuo Niu, Intel</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-18">
+<div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-20">
+<div class="paragraph">
 <p>Copyright (c) 2022 Intel Corporation. All rights reserved.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-22">
+<div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-24">
+<div class="paragraph">
 <p>Final Draft</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-26">
+<div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all data-line-29" style="width: 40%;">
+<table class="tableblock frame-all grid-all" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -492,7 +100,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2023-01-24</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-02-08</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -502,65 +110,65 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </table>
 </div>
 </div>
-<div class="sect1 data-line-34">
+<div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-36">
+<div class="paragraph">
 <p>This extension is written against the SPIR-V Specification,
 Version 1.6 Revision 2.</p>
 </div>
-<div class="paragraph data-line-39">
+<div class="paragraph">
 <p>This extension requires SPIR-V 1.0.</p>
 </div>
-<div class="paragraph data-line-41">
+<div class="paragraph">
 <p>This extension specifies interaction with the SPV_INTEL_blocking_pipes extension.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-43">
+<div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-45">
+<div class="paragraph">
 <p>This extension adds two decorations to represent latency controls on the pointer accessed by load, store, pipe read and pipe write instructions.</p>
 </div>
-<div class="paragraph data-line-47">
+<div class="paragraph">
 <p>The behavior is implementation-defined if the combination of constraints specified by the decorations cannot be satisfied. For example, if one constraint specifies instruction A should be scheduled after instruction B, while another constraint specifies instruction B should be scheduled after instruction A then that set of constraints is unsatisfiable.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-49">
+<div class="sect1">
 <h2 id="_extension_name">Extension Name</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-50">
+<div class="paragraph">
 <p>To use this extension within a SPIR-V module, the following <strong>OpExtension</strong> must be present in the module:</p>
 </div>
-<div class="listingblock data-line-52">
+<div class="listingblock">
 <div class="content">
 <pre>OpExtension "SPV_INTEL_fpga_latency_control"</pre>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-56">
+<div class="sect1">
 <h2 id="_new_capabilities">New Capabilities</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-58">
+<div class="paragraph">
 <p>This extension introduces a new capability:</p>
 </div>
-<div class="listingblock data-line-60">
+<div class="listingblock">
 <div class="content">
 <pre>FPGALatencyControlINTEL</pre>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-64">
+<div class="sect1">
 <h2 id="_new_decorations">New Decorations</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-66">
+<div class="paragraph">
 <p>Decorations added under the <strong>FPGALatencyControlINTEL</strong> capability:</p>
 </div>
-<div class="listingblock data-line-68">
+<div class="listingblock">
 <div class="content">
 <pre>LatencyControlLabelINTEL
 LatencyControlConstraintINTEL</pre>
@@ -568,12 +176,12 @@ LatencyControlConstraintINTEL</pre>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-73">
+<div class="sect1">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<div class="openblock data-line-75">
+<div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-rows data-line-79" style="width: 40%;">
+<table class="tableblock frame-all grid-rows" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -597,17 +205,17 @@ LatencyControlConstraintINTEL</pre>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-86">
+<div class="sect1">
 <h2 id="_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification, Version 1.6</h2>
 <div class="sectionbody">
-<div class="sect2 data-line-88">
+<div class="sect2">
 <h3 id="_decoration">Decoration</h3>
-<div class="paragraph data-line-89">
+<div class="paragraph">
 <p>Modify Section 3.20, Decoration, adding these rows to the Decoration table:</p>
 </div>
-<div class="openblock data-line-91">
+<div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch data-line-93">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -656,18 +264,18 @@ Apply to an object of type OpTypePointer or OpTypePipe. If that object is used a
 </table>
 </div>
 </div>
-<div class="paragraph data-line-128">
+<div class="paragraph">
 <p><strong>Note</strong> that both of these decorations are ignored for target devices that are not FPGA.</p>
 </div>
 </div>
-<div class="sect2 data-line-130">
+<div class="sect2">
 <h3 id="_capability">Capability</h3>
-<div class="paragraph data-line-132">
+<div class="paragraph">
 <p>Modify Section 3.31, Capability, adding a row to the Capability table:</p>
 </div>
-<div class="openblock data-line-133">
+<div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch data-line-135">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -692,18 +300,18 @@ Apply to an object of type OpTypePointer or OpTypePipe. If that object is used a
 </div>
 </div>
 </div>
-<div class="sect1 data-line-141">
+<div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-143">
+<div class="paragraph">
 <p>None.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-145">
+<div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch data-line-150">
+<table class="tableblock frame-all grid-rows stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">
@@ -728,11 +336,6 @@ Apply to an object of type OpTypePointer or OpTypePipe. If that object is used a
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2023-01-24 16:53:12 -0800
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_fpga_loop_controls.html
+++ b/extensions/INTEL/SPV_INTEL_fpga_loop_controls.html
@@ -4,441 +4,45 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.10">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_fpga_loop_controls</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
-/* Uncomment @import statement to use as custom stylesheet */
-/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
-article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}
-audio,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
-a{background:none}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-abbr[title]{border-bottom:1px dotted}
-b,strong{font-weight:bold}
-dfn{font-style:italic}
-hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:0}
-p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
-abbr{text-transform:none}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
-blockquote cite::before{content:"\2014 \0020"}
-blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
-:not(pre)>code.nobreak{word-wrap:normal}
-:not(pre)>code.nowrap{white-space:nowrap}
-pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
-pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
-pre>code{display:block}
-pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:100%;background:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #e7e7e9}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details>summary:first-of-type{cursor:pointer;display:list-item;outline:none;margin-bottom:.75em}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:inherit}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border-style:solid;border-width:1px;border-color:#dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;-webkit-border-radius:4px;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
-@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
-.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
-.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.prettyprint{background:#f7f7f8}
-pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
-pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
-pre.prettyprint li code[data-lang]::before{opacity:1}
-pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
-table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
-table.linenotable td.code{padding-left:.75em}
-table.linenotable td.linenos{border-right:1px solid currentColor;opacity:.35;padding-right:.5em}
-pre.pygments .lineno{border-right:1px solid currentColor;opacity:.35;display:inline-block;margin-right:.75em}
-pre.pygments .lineno::before{content:"";margin-right:-.125em}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
-.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
-.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
-.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
-table.tableblock{max-width:100%;border-collapse:separate}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-td.tableblock>.content>:last-child.sidebarblock{margin-bottom:0}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
-table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
-table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
-table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
-table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
-table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
-table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
-table.frame-all{border-width:1px}
-table.frame-sides{border-width:0 1px}
-table.frame-topbot,table.frame-ends{border-width:1px 0}
-table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-ul.checklist{margin-left:.625em}
-ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
-ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
-.imageblock.left{margin:.25em .625em 1.25em 0}
-.imageblock.right{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
-.gist .file-data>table td.line-data{width:99%}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background:#00fafa}
-.black{color:#000}
-.black-background{background:#000}
-.blue{color:#0000bf}
-.blue-background{background:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background:#fa00fa}
-.gray{color:#606060}
-.gray-background{background:#7d7d7d}
-.green{color:#006000}
-.green-background{background:#007d00}
-.lime{color:#00bf00}
-.lime-background{background:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background:#7d0000}
-.navy{color:#000060}
-.navy-background{background:#00007d}
-.olive{color:#606000}
-.olive-background{background:#7d7d00}
-.purple{color:#600060}
-.purple-background{background:#7d007d}
-.red{color:#bf0000}
-.red-background{background:#fa0000}
-.silver{color:#909090}
-.silver-background{background:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_fpga_loop_controls</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New capabilities</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_4">Modifications to the SPIR-V Specification, Version 1.4</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
 <div class="sect1">
@@ -481,7 +85,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <p>Mark Mendell, Intel<br></p>
 </li>
 <li>
-<p>Ci Tian, Intel</p>
+<p>Ci Tian, Intel<br></p>
 </li>
 <li>
 <p>Bowen Xue, Intel</p>
@@ -667,8 +271,7 @@ Specify minimum, maximum and expected iteration counts of the loop. There are th
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">0x2000000</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>MaxReinvocationDelayINTEL</strong><br>
-Request to implement this loop with a maximum limit on the delay between launching the last iteration of a loop invocation and launching the first iteration of the next loop invocation. A subsequent positive 32-bit integer literal operand specifies the budget for the maximum reinvocation delay allowed. A value of 1 indicates that the first iteration of the next invocation should start immediately following the start of the last iteration of the previous loop invocation.
-</p></td>
+Request to implement this loop with a maximum limit on the delay between launching the last iteration of a loop invocation and launching the first iteration of the next loop invocation. A subsequent positive 32-bit integer literal operand specifies the budget for the maximum reinvocation delay allowed. A value of 1 indicates that the first iteration of the next invocation should start immediately following the start of the last iteration of the previous loop invocation.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>FPGALoopControlsINTEL</strong></p></td>
 </tr>
 </tbody>
@@ -798,11 +401,6 @@ Request to implement this loop with a maximum limit on the delay between launchi
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2022-10-13 15:14:22 -0300
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_fpga_memory_accesses.html
+++ b/extensions/INTEL/SPV_INTEL_fpga_memory_accesses.html
@@ -2,425 +2,48 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 1.5.5">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_fpga_memory_accesses</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
-/* Remove comment around @import statement below when using as a custom stylesheet */
-/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
-article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
-audio,canvas,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-[hidden],template{display:none}
-script{display:none!important}
-html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
-a{background:transparent}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-abbr[title]{border-bottom:1px dotted}
-b,strong{font-weight:bold}
-dfn{font-style:italic}
-hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
-input[type="search"]{-webkit-appearance:textfield;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;box-sizing:content-box}
-input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,*:before,*:after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.center{margin-left:auto;margin-right:auto}
-.spread{width:100%}
-p.lead,.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{font-size:1.21875em;line-height:1.6}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:none}
-p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #ddddd8;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol,ul.no-bullet,ol.no-bullet{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ul.no-bullet{list-style:none}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
-abbr{text-transform:none}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
-blockquote cite:before{content:"\2014 \0020"}
-blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media only screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
-table thead,table tfoot{background:#f7f8f7;font-weight:bold}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.clearfix:before,.clearfix:after,.float-group:before,.float-group:after{content:" ";display:table}
-.clearfix:after,.float-group:after{clear:both}
-*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
-*:not(pre)>code.nobreak{word-wrap:normal}
-*:not(pre)>code.nowrap{white-space:nowrap}
-pre,pre>code{line-height:1.45;color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;text-rendering:optimizeSpeed}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menu{color:rgba(0,0,0,.8)}
-b.button:before,b.button:after{position:relative;top:-1px;font-weight:400}
-b.button:before{content:"[";padding:0 3px 0 2px}
-b.button:after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header:before,#header:after,#content:before,#content:after,#footnotes:before,#footnotes:after,#footer:before,#footer:after{content:" ";display:table}
-#header:after,#content:after,#footnotes:after,#footer:after{clear:both}
-#content{margin-top:1.25em}
-#content:before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #ddddd8}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #ddddd8;padding-bottom:8px}
-#header .details{border-bottom:1px solid #ddddd8;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span:before{content:"\00a0\2013\00a0"}
-#header .details br+span.author:before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark:before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber:after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #ddddd8;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #efefed;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media only screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background-color:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #efefed;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #efefed;left:auto;right:0}}
-@media only screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:100%;background-color:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
-.sect1{padding-bottom:.625em}
-@media only screen and (min-width:768px){.sect1{padding-bottom:1.25em}}
-.sect1+.sect1{border-top:1px solid #efefed}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor:before,h2>a.anchor:before,h3>a.anchor:before,#toctitle>a.anchor:before,.sidebarblock>.content>.title>a.anchor:before,h4>a.anchor:before,h5>a.anchor:before,h6>a.anchor:before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock>caption.title{white-space:nowrap;overflow:visible;max-width:0}
-.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{color:rgba(0,0,0,.85)}
-table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inherit}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color:rgba(0,0,0,.6)}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock pre:not(.highlight),.listingblock pre[class="highlight"],.listingblock pre[class^="highlight "],.listingblock pre.CodeRay,.listingblock pre.prettyprint{background:#f7f7f8}
-.sidebarblock .literalblock pre,.sidebarblock .listingblock pre:not(.highlight),.sidebarblock .listingblock pre[class="highlight"],.sidebarblock .listingblock pre[class^="highlight "],.sidebarblock .listingblock pre.CodeRay,.sidebarblock .listingblock pre.prettyprint{background:#f2f1f1}
-.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;padding:1em;font-size:.8125em}
-.literalblock pre.nowrap,.literalblock pre[class].nowrap,.listingblock pre.nowrap,.listingblock pre[class].nowrap{overflow-x:auto;white-space:pre;word-wrap:normal}
-@media only screen and (min-width:768px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:.90625em}}
-@media only screen and (min-width:1280px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:1em}}
-.literalblock.output pre{color:#f7f7f8;background-color:rgba(0,0,0,.9)}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]:before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:#999}
-.listingblock:hover code[data-lang]:before{display:block}
-.listingblock.terminal pre .command:before{content:attr(data-prompt);padding-right:.5em;color:#999}
-.listingblock.terminal pre .command:not([data-prompt]):before{content:"$"}
-table.pyhltable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.pyhltable td{vertical-align:top;padding-top:0;padding-bottom:0;line-height:1.45}
-table.pyhltable td.code{padding-left:.75em;padding-right:0}
-pre.pygments .lineno,table.pyhltable td:not(.code){color:#999;padding-left:0;padding-right:.5em;border-right:1px solid #ddddd8}
-pre.pygments .lineno{display:inline-block;margin-right:.25em}
-table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock blockquote p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote:before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.5em;margin-right:.5ex;text-align:right}
-.quoteblock .quoteblock{margin-left:0;margin-right:0;padding:.5em 0;border-left:3px solid rgba(0,0,0,.6)}
-.quoteblock .quoteblock blockquote{padding:0 0 0 .75em}
-.quoteblock .quoteblock blockquote:before{display:none}
-.verseblock{margin:0 1em 1.25em 1em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract{margin:0 0 1.25em 0;display:block}
-.quoteblock.abstract blockquote,.quoteblock.abstract blockquote p{text-align:left;word-spacing:0}
-.quoteblock.abstract blockquote:before,.quoteblock.abstract blockquote p:first-of-type:before{display:none}
-table.tableblock{max-width:100%;border-collapse:separate}
-table.tableblock td>.paragraph:last-child p>p:last-child,table.tableblock th>p:last-child,table.tableblock td>p:last-child{margin-bottom:0}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all th.tableblock,table.grid-all td.tableblock{border-width:0 1px 1px 0}
-table.grid-all tfoot>tr>th.tableblock,table.grid-all tfoot>tr>td.tableblock{border-width:1px 1px 0 0}
-table.grid-cols th.tableblock,table.grid-cols td.tableblock{border-width:0 1px 0 0}
-table.grid-all *>tr>.tableblock:last-child,table.grid-cols *>tr>.tableblock:last-child{border-right-width:0}
-table.grid-rows th.tableblock,table.grid-rows td.tableblock{border-width:0 0 1px 0}
-table.grid-all tbody>tr:last-child>th.tableblock,table.grid-all tbody>tr:last-child>td.tableblock,table.grid-all thead:last-child>tr>th.tableblock,table.grid-rows tbody>tr:last-child>th.tableblock,table.grid-rows tbody>tr:last-child>td.tableblock,table.grid-rows thead:last-child>tr>th.tableblock{border-bottom-width:0}
-table.grid-rows tfoot>tr>th.tableblock,table.grid-rows tfoot>tr>td.tableblock{border-width:1px 0 0 0}
-table.frame-all{border-width:1px}
-table.frame-sides{border-width:0 1px}
-table.frame-topbot{border-width:1px 0}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-td>div.verse{white-space:pre}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.unstyled,ol.unnumbered,ul.checklist,ul.none{list-style-type:none}
-ul.unstyled,ol.unnumbered,ul.checklist{margin-left:.625em}
-ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1em;font-size:.85em}
-ul.checklist li>p:first-child>input[type="checkbox"]:first-child{width:1em;position:relative;top:1px}
-ul.inline{margin:0 auto .625em auto;margin-left:-1.375em;margin-right:0;padding:0;list-style:none;overflow:hidden}
-ul.inline>li{list-style:none;float:left;margin-left:1.375em;display:block}
-ul.inline>li>*{display:block}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist>table tr>td:first-of-type{padding:0 .75em;line-height:1}
-.colist>table tr>td:last-of-type{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
-.imageblock.left,.imageblock[style*="float: left"]{margin:.25em .625em 1.25em 0}
-.imageblock.right,.imageblock[style*="float: right"]{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em 0;border-width:1px 0 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;text-indent:-1.05em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
-.gist .file-data>table td.line-data{width:99%}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background-color:#00fafa}
-.black{color:#000}
-.black-background{background-color:#000}
-.blue{color:#0000bf}
-.blue-background{background-color:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background-color:#fa00fa}
-.gray{color:#606060}
-.gray-background{background-color:#7d7d7d}
-.green{color:#006000}
-.green-background{background-color:#007d00}
-.lime{color:#00bf00}
-.lime-background{background-color:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background-color:#7d0000}
-.navy{color:#000060}
-.navy-background{background-color:#00007d}
-.olive{color:#606000}
-.olive-background{background-color:#7d7d00}
-.purple{color:#600060}
-.purple-background{background-color:#7d007d}
-.red{color:#bf0000}
-.red-background{background-color:#fa0000}
-.silver{color:#909090}
-.silver-background{background-color:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background-color:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background-color:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background-color:#fafa00}
-span.icon>.fa{cursor:default}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note:before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip:before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning:before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution:before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important:before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background-color:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]:after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background-color:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@media print{@page{margin:1.25cm .75cm}
-*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare):after,a[href^="https:"]:not(.bare):after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]:after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #ddddd8!important;padding-bottom:0!important}
-.sect1{padding-bottom:0!important}
-.sect1+.sect1{border:0!important}
-#header>h1:first-child{margin-top:1.25rem}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em 0}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span:before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]:before{display:block}
-#footer{background:none!important;padding:0 .9375em}
-#footer-text{color:rgba(0,0,0,.6)!important;font-size:.9em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_fpga_memory_accesses</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New capabilities</a></li>
+<li><a href="#_new_decorations">New Decorations</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_5">Modifications to the SPIR-V Specification, Version 1.5</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
 <div class="sect1">
@@ -490,7 +113,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2020-03-13</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-02-02</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -609,7 +232,7 @@ PrefetchINTEL</pre>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all spread">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -667,7 +290,7 @@ Apply to a pointer. Request, to the extent possible, that a prefetcher of the sp
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all spread">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -709,7 +332,7 @@ Apply to a pointer. Request, to the extent possible, that a prefetcher of the sp
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows spread">
+<table class="tableblock frame-all grid-rows stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">
@@ -734,11 +357,6 @@ Apply to a pointer. Request, to the extent possible, that a prefetcher of the sp
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2020-03-13 10:21:00 ADT
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_fpga_memory_attributes.html
+++ b/extensions/INTEL/SPV_INTEL_fpga_memory_attributes.html
@@ -4,441 +4,46 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.17">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_fpga_memory_attributes</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
-/* Uncomment the following line when using as a custom stylesheet */
-/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
-html{font-family:sans-serif;-webkit-text-size-adjust:100%}
-a{background:none}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-b,strong{font-weight:bold}
-abbr{font-size:.9em}
-abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
-dfn{font-style:italic}
-hr{height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-audio,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type=checkbox],input[type=radio]{padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,::before,::after{box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:0}
-p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-:not(pre).nobreak{word-wrap:normal}
-:not(pre).nowrap{white-space:nowrap}
-:not(pre).pre-wrap{white-space:pre-wrap}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
-pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
-pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
-pre>code{display:block}
-pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #e7e7e9}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details{margin-left:1.25rem}
-details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
-details>summary::-webkit-details-marker{display:none}
-details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
-details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
-details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
-@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
-.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
-.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.prettyprint{background:#f7f7f8}
-pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
-pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
-pre.prettyprint li code[data-lang]::before{opacity:1}
-pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
-table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
-table.linenotable td.code{padding-left:.75em}
-table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
-pre.pygments span.linenos{display:inline-block;margin-right:.75em}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
-.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
-.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
-.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
-td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>*>tr>*{border-width:1px}
-table.grid-cols>*>tr>*{border-width:0 1px}
-table.grid-rows>*>tr>*{border-width:1px 0}
-table.frame-all{border-width:1px}
-table.frame-ends{border-width:1px 0}
-table.frame-sides{border-width:0 1px}
-table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
-table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
-table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
-table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
-table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-li>p:empty:only-child::before{content:"";display:inline-block}
-ul.checklist>li>p:first-child{margin-left:-1em}
-ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
-ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-td.hdlist2{word-wrap:anywhere}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
-.imageblock.left{margin:.25em .625em 1.25em 0}
-.imageblock.right{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background:#00fafa}
-.black{color:#000}
-.black-background{background:#000}
-.blue{color:#0000bf}
-.blue-background{background:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background:#fa00fa}
-.gray{color:#606060}
-.gray-background{background:#7d7d7d}
-.green{color:#006000}
-.green-background{background:#007d00}
-.lime{color:#00bf00}
-.lime-background{background:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background:#7d0000}
-.navy{color:#000060}
-.navy-background{background:#00007d}
-.olive{color:#606000}
-.olive-background{background:#7d7d00}
-.purple{color:#600060}
-.purple-background{background:#7d007d}
-.red{color:#bf0000}
-.red-background{background:#fa0000}
-.silver{color:#909090}
-.silver-background{background:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]{border-bottom:1px dotted}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#header,#content,#footnotes,#footer{max-width:none}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_fpga_memory_attributes</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New capabilities</a></li>
+<li><a href="#_new_decorations">New Decorations</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_5">Modifications to the SPIR-V Specification, Version 1.5</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
 <div class="sect1">
@@ -514,7 +119,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2023-10-03</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-09</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -964,11 +569,6 @@ Apply to a variable or a structure-type member. Request, to the extent possible,
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2023-10-03 12:47:13 -0700
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_fpga_reg.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_fpga_reg.asciidoc
@@ -94,7 +94,7 @@ Modify Section 3.31, Capability, adding a row to the Capability table:
 In section 3.32.1, Miscellaneous Instructions, add a new instruction, *OpFPGARegINTEL*, as follows:
 [cols="5", width="100%"]
 |=====
-4+^|*OpFPGARegINTEL* +
+4+|*OpFPGARegINTEL* +
 
 Used to indicate to FPGA backends that pipelining registers should be inserted between the definition of _Input_ and uses of _Result_.  The value passed in as _Input_ is returned in _Result_. This instruction is strictly an optimization hint and thus it would be functionally correct for a consumer to treat it as an assignment.  
 

--- a/extensions/INTEL/SPV_INTEL_fpga_reg.html
+++ b/extensions/INTEL/SPV_INTEL_fpga_reg.html
@@ -2,437 +2,48 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 1.5.7">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_fpga_reg</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
-/* Uncomment @import statement below to use as custom stylesheet */
-/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
-article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
-audio,canvas,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-script{display:none!important}
-html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
-a{background:transparent}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-abbr[title]{border-bottom:1px dotted}
-b,strong{font-weight:bold}
-dfn{font-style:italic}
-hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:none}
-p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #ddddd8;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
-abbr{text-transform:none}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
-blockquote cite::before{content:"\2014 \0020"}
-blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
-*:not(pre)>code.nobreak{word-wrap:normal}
-*:not(pre)>code.nowrap{white-space:nowrap}
-pre,pre>code{line-height:1.45;color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;text-rendering:optimizeSpeed}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #ddddd8}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #ddddd8;padding-bottom:8px}
-#header .details{border-bottom:1px solid #ddddd8;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #ddddd8;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #efefed;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background-color:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #efefed;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #efefed;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:100%;background-color:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #efefed}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inherit}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color:rgba(0,0,0,.6)}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock pre:not(.highlight),.listingblock pre[class="highlight"],.listingblock pre[class^="highlight "],.listingblock pre.CodeRay,.listingblock pre.prettyprint{background:#f7f7f8}
-.sidebarblock .literalblock pre,.sidebarblock .listingblock pre:not(.highlight),.sidebarblock .listingblock pre[class="highlight"],.sidebarblock .listingblock pre[class^="highlight "],.sidebarblock .listingblock pre.CodeRay,.sidebarblock .listingblock pre.prettyprint{background:#f2f1f1}
-.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;padding:1em;font-size:.8125em}
-.literalblock pre.nowrap,.literalblock pre[class].nowrap,.listingblock pre.nowrap,.listingblock pre[class].nowrap{overflow-x:auto;white-space:pre;word-wrap:normal}
-@media screen and (min-width:768px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:1em}}
-.literalblock.output pre{color:#f7f7f8;background-color:rgba(0,0,0,.9)}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:#999}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:#999}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-table.pyhltable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.pyhltable td{vertical-align:top;padding-top:0;padding-bottom:0;line-height:1.45}
-table.pyhltable td.code{padding-left:.75em;padding-right:0}
-pre.pygments .lineno,table.pyhltable td:not(.code){color:#999;padding-left:0;padding-right:.5em;border-right:1px solid #ddddd8}
-pre.pygments .lineno{display:inline-block;margin-right:.25em}
-table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock blockquote p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.5em;margin-right:.5ex;text-align:right}
-.quoteblock .quoteblock{margin-left:0;margin-right:0;padding:.5em 0;border-left:3px solid rgba(0,0,0,.6)}
-.quoteblock .quoteblock blockquote{padding:0 0 0 .75em}
-.quoteblock .quoteblock blockquote::before{display:none}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.abstract blockquote,.quoteblock.abstract blockquote p{word-spacing:0;line-height:1.6}
-.quoteblock.abstract blockquote::before,.quoteblock.abstract p::before{display:none}
-table.tableblock{max-width:100%;border-collapse:separate}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content{margin-bottom:-1.25em}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
-table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
-table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
-table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
-table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
-table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
-table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
-table.frame-all{border-width:1px}
-table.frame-sides{border-width:0 1px}
-table.frame-topbot,table.frame-ends{border-width:1px 0}
-table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd){background:#f8f8f7}
-table.stripes-none tr,table.stripes-odd tr:nth-of-type(even){background:none}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-td>div.verse{white-space:pre}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-ul.checklist{margin-left:.625em}
-ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
-ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
-.imageblock.left,.imageblock[style*="float: left"]{margin:.25em .625em 1.25em 0}
-.imageblock.right,.imageblock[style*="float: right"]{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
-.gist .file-data>table td.line-data{width:99%}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background-color:#00fafa}
-.black{color:#000}
-.black-background{background-color:#000}
-.blue{color:#0000bf}
-.blue-background{background-color:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background-color:#fa00fa}
-.gray{color:#606060}
-.gray-background{background-color:#7d7d7d}
-.green{color:#006000}
-.green-background{background-color:#007d00}
-.lime{color:#00bf00}
-.lime-background{background-color:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background-color:#7d0000}
-.navy{color:#000060}
-.navy-background{background-color:#00007d}
-.olive{color:#606000}
-.olive-background{background-color:#7d7d00}
-.purple{color:#600060}
-.purple-background{background-color:#7d007d}
-.red{color:#bf0000}
-.red-background{background-color:#fa0000}
-.silver{color:#909090}
-.silver-background{background-color:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background-color:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background-color:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background-color:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background-color:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background-color:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #ddddd8!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_fpga_reg</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New capabilities</a></li>
+<li><a href="#_new_instructions">New Instructions</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_4">Modifications to the SPIR-V Specification, Version 1.4</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
 <div class="sect1">
@@ -496,7 +107,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2019-07-12</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-21</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -638,7 +249,7 @@ Version 1.4 Revision 1.</p>
 </colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-center valign-top" colspan="4"><p class="tableblock"><strong>OpFPGARegINTEL</strong><br></p>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><strong>OpFPGARegINTEL</strong><br></p>
 <p class="tableblock">Used to indicate to FPGA backends that pipelining registers should be inserted between the definition of <em>Input</em> and uses of <em>Result</em>.  The value passed in as <em>Input</em> is returned in <em>Result</em>. This instruction is strictly an optimization hint and thus it would be functionally correct for a consumer to treat it as an assignment.</p>
 <p class="tableblock"><em>Result Type</em> can be any type and is the type of both <em>Result</em> and <em>Input</em>.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Capability:
@@ -699,11 +310,6 @@ Result Type</p></td>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2019-07-12 12:13:51 EDT
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_global_variable_fpga_decorations.html
+++ b/extensions/INTEL/SPV_INTEL_global_variable_fpga_decorations.html
@@ -4,441 +4,45 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.17">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_global_variable_fpga_decorations</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
-/* Uncomment the following line when using as a custom stylesheet */
-/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
-html{font-family:sans-serif;-webkit-text-size-adjust:100%}
-a{background:none}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-b,strong{font-weight:bold}
-abbr{font-size:.9em}
-abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
-dfn{font-style:italic}
-hr{height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-audio,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type=checkbox],input[type=radio]{padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,::before,::after{box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:0}
-p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-:not(pre).nobreak{word-wrap:normal}
-:not(pre).nowrap{white-space:nowrap}
-:not(pre).pre-wrap{white-space:pre-wrap}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
-pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
-pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
-pre>code{display:block}
-pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #e7e7e9}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details{margin-left:1.25rem}
-details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
-details>summary::-webkit-details-marker{display:none}
-details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
-details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
-details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
-@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
-.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
-.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.prettyprint{background:#f7f7f8}
-pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
-pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
-pre.prettyprint li code[data-lang]::before{opacity:1}
-pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
-table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
-table.linenotable td.code{padding-left:.75em}
-table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
-pre.pygments span.linenos{display:inline-block;margin-right:.75em}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
-.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
-.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
-.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
-td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>*>tr>*{border-width:1px}
-table.grid-cols>*>tr>*{border-width:0 1px}
-table.grid-rows>*>tr>*{border-width:1px 0}
-table.frame-all{border-width:1px}
-table.frame-ends{border-width:1px 0}
-table.frame-sides{border-width:0 1px}
-table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
-table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
-table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
-table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
-table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-li>p:empty:only-child::before{content:"";display:inline-block}
-ul.checklist>li>p:first-child{margin-left:-1em}
-ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
-ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-td.hdlist2{word-wrap:anywhere}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
-.imageblock.left{margin:.25em .625em 1.25em 0}
-.imageblock.right{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background:#00fafa}
-.black{color:#000}
-.black-background{background:#000}
-.blue{color:#0000bf}
-.blue-background{background:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background:#fa00fa}
-.gray{color:#606060}
-.gray-background{background:#7d7d7d}
-.green{color:#006000}
-.green-background{background:#007d00}
-.lime{color:#00bf00}
-.lime-background{background:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background:#7d0000}
-.navy{color:#000060}
-.navy-background{background:#00007d}
-.olive{color:#606000}
-.olive-background{background:#7d7d00}
-.purple{color:#600060}
-.purple-background{background:#7d007d}
-.red{color:#bf0000}
-.red-background{background:#fa0000}
-.silver{color:#909090}
-.silver-background{background:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]{border-bottom:1px dotted}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#header,#content,#footnotes,#footer{max-width:none}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_global_variable_fpga_decorations</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification, Version 1.6</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
 <div class="sect1">
@@ -515,7 +119,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2023-11-02</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-09</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -814,11 +418,6 @@ interface for the variable is implementation defined.</p>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2023-11-02 10:46:00 -0700
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_global_variable_host_access.html
+++ b/extensions/INTEL/SPV_INTEL_global_variable_host_access.html
@@ -4,441 +4,45 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.17">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_global_variable_host_access</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
-/* Uncomment the following line when using as a custom stylesheet */
-/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
-html{font-family:sans-serif;-webkit-text-size-adjust:100%}
-a{background:none}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-b,strong{font-weight:bold}
-abbr{font-size:.9em}
-abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
-dfn{font-style:italic}
-hr{height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-audio,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type=checkbox],input[type=radio]{padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,::before,::after{box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:0}
-p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-:not(pre).nobreak{word-wrap:normal}
-:not(pre).nowrap{white-space:nowrap}
-:not(pre).pre-wrap{white-space:pre-wrap}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
-pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
-pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
-pre>code{display:block}
-pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #e7e7e9}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details{margin-left:1.25rem}
-details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
-details>summary::-webkit-details-marker{display:none}
-details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
-details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
-details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
-@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
-.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
-.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.prettyprint{background:#f7f7f8}
-pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
-pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
-pre.prettyprint li code[data-lang]::before{opacity:1}
-pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
-table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
-table.linenotable td.code{padding-left:.75em}
-table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
-pre.pygments span.linenos{display:inline-block;margin-right:.75em}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
-.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
-.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
-.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
-td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>*>tr>*{border-width:1px}
-table.grid-cols>*>tr>*{border-width:0 1px}
-table.grid-rows>*>tr>*{border-width:1px 0}
-table.frame-all{border-width:1px}
-table.frame-ends{border-width:1px 0}
-table.frame-sides{border-width:0 1px}
-table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
-table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
-table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
-table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
-table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-li>p:empty:only-child::before{content:"";display:inline-block}
-ul.checklist>li>p:first-child{margin-left:-1em}
-ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
-ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-td.hdlist2{word-wrap:anywhere}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
-.imageblock.left{margin:.25em .625em 1.25em 0}
-.imageblock.right{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background:#00fafa}
-.black{color:#000}
-.black-background{background:#000}
-.blue{color:#0000bf}
-.blue-background{background:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background:#fa00fa}
-.gray{color:#606060}
-.gray-background{background:#7d7d7d}
-.green{color:#006000}
-.green-background{background:#007d00}
-.lime{color:#00bf00}
-.lime-background{background:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background:#7d0000}
-.navy{color:#000060}
-.navy-background{background:#00007d}
-.olive{color:#606000}
-.olive-background{background:#7d7d00}
-.purple{color:#600060}
-.purple-background{background:#7d007d}
-.red{color:#bf0000}
-.red-background{background:#fa0000}
-.silver{color:#909090}
-.silver-background{background:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]{border-bottom:1px dotted}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#header,#content,#footnotes,#footer{max-width:none}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_global_variable_host_access</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification, Version 1.6</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
 <div class="sect1">
@@ -515,7 +119,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2023-11-02</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-09</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -809,11 +413,6 @@ have the same <em>Name</em> operand.</p>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2023-11-02 10:44:50 -0700
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_io_pipes.html
+++ b/extensions/INTEL/SPV_INTEL_io_pipes.html
@@ -2,425 +2,48 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 1.5.5">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_io_pipes</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
-/* Remove comment around @import statement below when using as a custom stylesheet */
-/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
-article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
-audio,canvas,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-[hidden],template{display:none}
-script{display:none!important}
-html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
-a{background:transparent}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-abbr[title]{border-bottom:1px dotted}
-b,strong{font-weight:bold}
-dfn{font-style:italic}
-hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
-input[type="search"]{-webkit-appearance:textfield;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;box-sizing:content-box}
-input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,*:before,*:after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.center{margin-left:auto;margin-right:auto}
-.spread{width:100%}
-p.lead,.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{font-size:1.21875em;line-height:1.6}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:none}
-p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #ddddd8;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol,ul.no-bullet,ol.no-bullet{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ul.no-bullet{list-style:none}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
-abbr{text-transform:none}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
-blockquote cite:before{content:"\2014 \0020"}
-blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media only screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
-table thead,table tfoot{background:#f7f8f7;font-weight:bold}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.clearfix:before,.clearfix:after,.float-group:before,.float-group:after{content:" ";display:table}
-.clearfix:after,.float-group:after{clear:both}
-*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
-*:not(pre)>code.nobreak{word-wrap:normal}
-*:not(pre)>code.nowrap{white-space:nowrap}
-pre,pre>code{line-height:1.45;color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;text-rendering:optimizeSpeed}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menu{color:rgba(0,0,0,.8)}
-b.button:before,b.button:after{position:relative;top:-1px;font-weight:400}
-b.button:before{content:"[";padding:0 3px 0 2px}
-b.button:after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header:before,#header:after,#content:before,#content:after,#footnotes:before,#footnotes:after,#footer:before,#footer:after{content:" ";display:table}
-#header:after,#content:after,#footnotes:after,#footer:after{clear:both}
-#content{margin-top:1.25em}
-#content:before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #ddddd8}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #ddddd8;padding-bottom:8px}
-#header .details{border-bottom:1px solid #ddddd8;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span:before{content:"\00a0\2013\00a0"}
-#header .details br+span.author:before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark:before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber:after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #ddddd8;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #efefed;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media only screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background-color:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #efefed;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #efefed;left:auto;right:0}}
-@media only screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:100%;background-color:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
-.sect1{padding-bottom:.625em}
-@media only screen and (min-width:768px){.sect1{padding-bottom:1.25em}}
-.sect1+.sect1{border-top:1px solid #efefed}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor:before,h2>a.anchor:before,h3>a.anchor:before,#toctitle>a.anchor:before,.sidebarblock>.content>.title>a.anchor:before,h4>a.anchor:before,h5>a.anchor:before,h6>a.anchor:before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock>caption.title{white-space:nowrap;overflow:visible;max-width:0}
-.paragraph.lead>p,#preamble>.sectionbody>.paragraph:first-of-type p{color:rgba(0,0,0,.85)}
-table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inherit}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color:rgba(0,0,0,.6)}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock pre:not(.highlight),.listingblock pre[class="highlight"],.listingblock pre[class^="highlight "],.listingblock pre.CodeRay,.listingblock pre.prettyprint{background:#f7f7f8}
-.sidebarblock .literalblock pre,.sidebarblock .listingblock pre:not(.highlight),.sidebarblock .listingblock pre[class="highlight"],.sidebarblock .listingblock pre[class^="highlight "],.sidebarblock .listingblock pre.CodeRay,.sidebarblock .listingblock pre.prettyprint{background:#f2f1f1}
-.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;padding:1em;font-size:.8125em}
-.literalblock pre.nowrap,.literalblock pre[class].nowrap,.listingblock pre.nowrap,.listingblock pre[class].nowrap{overflow-x:auto;white-space:pre;word-wrap:normal}
-@media only screen and (min-width:768px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:.90625em}}
-@media only screen and (min-width:1280px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:1em}}
-.literalblock.output pre{color:#f7f7f8;background-color:rgba(0,0,0,.9)}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]:before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:#999}
-.listingblock:hover code[data-lang]:before{display:block}
-.listingblock.terminal pre .command:before{content:attr(data-prompt);padding-right:.5em;color:#999}
-.listingblock.terminal pre .command:not([data-prompt]):before{content:"$"}
-table.pyhltable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.pyhltable td{vertical-align:top;padding-top:0;padding-bottom:0;line-height:1.45}
-table.pyhltable td.code{padding-left:.75em;padding-right:0}
-pre.pygments .lineno,table.pyhltable td:not(.code){color:#999;padding-left:0;padding-right:.5em;border-right:1px solid #ddddd8}
-pre.pygments .lineno{display:inline-block;margin-right:.25em}
-table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock blockquote p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote:before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.5em;margin-right:.5ex;text-align:right}
-.quoteblock .quoteblock{margin-left:0;margin-right:0;padding:.5em 0;border-left:3px solid rgba(0,0,0,.6)}
-.quoteblock .quoteblock blockquote{padding:0 0 0 .75em}
-.quoteblock .quoteblock blockquote:before{display:none}
-.verseblock{margin:0 1em 1.25em 1em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract{margin:0 0 1.25em 0;display:block}
-.quoteblock.abstract blockquote,.quoteblock.abstract blockquote p{text-align:left;word-spacing:0}
-.quoteblock.abstract blockquote:before,.quoteblock.abstract blockquote p:first-of-type:before{display:none}
-table.tableblock{max-width:100%;border-collapse:separate}
-table.tableblock td>.paragraph:last-child p>p:last-child,table.tableblock th>p:last-child,table.tableblock td>p:last-child{margin-bottom:0}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all th.tableblock,table.grid-all td.tableblock{border-width:0 1px 1px 0}
-table.grid-all tfoot>tr>th.tableblock,table.grid-all tfoot>tr>td.tableblock{border-width:1px 1px 0 0}
-table.grid-cols th.tableblock,table.grid-cols td.tableblock{border-width:0 1px 0 0}
-table.grid-all *>tr>.tableblock:last-child,table.grid-cols *>tr>.tableblock:last-child{border-right-width:0}
-table.grid-rows th.tableblock,table.grid-rows td.tableblock{border-width:0 0 1px 0}
-table.grid-all tbody>tr:last-child>th.tableblock,table.grid-all tbody>tr:last-child>td.tableblock,table.grid-all thead:last-child>tr>th.tableblock,table.grid-rows tbody>tr:last-child>th.tableblock,table.grid-rows tbody>tr:last-child>td.tableblock,table.grid-rows thead:last-child>tr>th.tableblock{border-bottom-width:0}
-table.grid-rows tfoot>tr>th.tableblock,table.grid-rows tfoot>tr>td.tableblock{border-width:1px 0 0 0}
-table.frame-all{border-width:1px}
-table.frame-sides{border-width:0 1px}
-table.frame-topbot{border-width:1px 0}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-td>div.verse{white-space:pre}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.unstyled,ol.unnumbered,ul.checklist,ul.none{list-style-type:none}
-ul.unstyled,ol.unnumbered,ul.checklist{margin-left:.625em}
-ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1em;font-size:.85em}
-ul.checklist li>p:first-child>input[type="checkbox"]:first-child{width:1em;position:relative;top:1px}
-ul.inline{margin:0 auto .625em auto;margin-left:-1.375em;margin-right:0;padding:0;list-style:none;overflow:hidden}
-ul.inline>li{list-style:none;float:left;margin-left:1.375em;display:block}
-ul.inline>li>*{display:block}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist>table tr>td:first-of-type{padding:0 .75em;line-height:1}
-.colist>table tr>td:last-of-type{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
-.imageblock.left,.imageblock[style*="float: left"]{margin:.25em .625em 1.25em 0}
-.imageblock.right,.imageblock[style*="float: right"]{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em 0;border-width:1px 0 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;text-indent:-1.05em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
-.gist .file-data>table td.line-data{width:99%}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background-color:#00fafa}
-.black{color:#000}
-.black-background{background-color:#000}
-.blue{color:#0000bf}
-.blue-background{background-color:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background-color:#fa00fa}
-.gray{color:#606060}
-.gray-background{background-color:#7d7d7d}
-.green{color:#006000}
-.green-background{background-color:#007d00}
-.lime{color:#00bf00}
-.lime-background{background-color:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background-color:#7d0000}
-.navy{color:#000060}
-.navy-background{background-color:#00007d}
-.olive{color:#606000}
-.olive-background{background-color:#7d7d00}
-.purple{color:#600060}
-.purple-background{background-color:#7d007d}
-.red{color:#bf0000}
-.red-background{background-color:#fa0000}
-.silver{color:#909090}
-.silver-background{background-color:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background-color:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background-color:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background-color:#fafa00}
-span.icon>.fa{cursor:default}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note:before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip:before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning:before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution:before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important:before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background-color:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]:after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background-color:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@media print{@page{margin:1.25cm .75cm}
-*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare):after,a[href^="https:"]:not(.bare):after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]:after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #ddddd8!important;padding-bottom:0!important}
-.sect1{padding-bottom:0!important}
-.sect1+.sect1{border:0!important}
-#header>h1:first-child{margin-top:1.25rem}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em 0}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span:before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]:before{display:block}
-#footer{background:none!important;padding:0 .9375em}
-#footer-text{color:rgba(0,0,0,.6)!important;font-size:.9em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_io_pipes</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_new_decorations">New Decorations</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_5">Modifications to the SPIR-V Specification, Version 1.5</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
 <div class="sect1">
@@ -484,7 +107,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2020-02-25</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-02-02</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -588,7 +211,7 @@ Version 1.5 Revision 2.</p>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all spread">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -624,7 +247,7 @@ Apply to a pipe-storage object created from <strong>OpConstantPipeStorage</stron
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all spread">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -666,7 +289,7 @@ Apply to a pipe-storage object created from <strong>OpConstantPipeStorage</stron
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows spread">
+<table class="tableblock frame-all grid-rows stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">
@@ -691,11 +314,6 @@ Apply to a pipe-storage object created from <strong>OpConstantPipeStorage</stron
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2020-02-25 17:29:20 AST
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_kernel_attributes.html
+++ b/extensions/INTEL/SPV_INTEL_kernel_attributes.html
@@ -4,509 +4,114 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.17">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_kernel_attributes</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
-/* Uncomment the following line when using as a custom stylesheet */
-/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
-html{font-family:sans-serif;-webkit-text-size-adjust:100%}
-a{background:none}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-b,strong{font-weight:bold}
-abbr{font-size:.9em}
-abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
-dfn{font-style:italic}
-hr{height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-audio,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type=checkbox],input[type=radio]{padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,::before,::after{box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:0}
-p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-:not(pre).nobreak{word-wrap:normal}
-:not(pre).nowrap{white-space:nowrap}
-:not(pre).pre-wrap{white-space:pre-wrap}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
-pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
-pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
-pre>code{display:block}
-pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #e7e7e9}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details{margin-left:1.25rem}
-details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
-details>summary::-webkit-details-marker{display:none}
-details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
-details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
-details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
-@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
-.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
-.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.prettyprint{background:#f7f7f8}
-pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
-pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
-pre.prettyprint li code[data-lang]::before{opacity:1}
-pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
-table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
-table.linenotable td.code{padding-left:.75em}
-table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
-pre.pygments span.linenos{display:inline-block;margin-right:.75em}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
-.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
-.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
-.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
-td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>*>tr>*{border-width:1px}
-table.grid-cols>*>tr>*{border-width:0 1px}
-table.grid-rows>*>tr>*{border-width:1px 0}
-table.frame-all{border-width:1px}
-table.frame-ends{border-width:1px 0}
-table.frame-sides{border-width:0 1px}
-table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
-table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
-table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
-table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
-table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-li>p:empty:only-child::before{content:"";display:inline-block}
-ul.checklist>li>p:first-child{margin-left:-1em}
-ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
-ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-td.hdlist2{word-wrap:anywhere}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
-.imageblock.left{margin:.25em .625em 1.25em 0}
-.imageblock.right{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background:#00fafa}
-.black{color:#000}
-.black-background{background:#000}
-.blue{color:#0000bf}
-.blue-background{background:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background:#fa00fa}
-.gray{color:#606060}
-.gray-background{background:#7d7d7d}
-.green{color:#006000}
-.green-background{background:#007d00}
-.lime{color:#00bf00}
-.lime-background{background:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background:#7d0000}
-.navy{color:#000060}
-.navy-background{background:#00007d}
-.olive{color:#606000}
-.olive-background{background:#7d7d00}
-.purple{color:#600060}
-.purple-background{background:#7d007d}
-.red{color:#bf0000}
-.red-background{background:#fa0000}
-.silver{color:#909090}
-.silver-background{background:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]{border-bottom:1px dotted}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#header,#content,#footnotes,#footer{max-width:none}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article data-line-1">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_kernel_attributes</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_new_execution_modes">New Execution Modes</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification, Version 1.6</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
-<div class="sect1 data-line-4">
+<div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-6">
+<div class="paragraph">
 <p>SPV_INTEL_kernel_attributes</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-8">
+<div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-10">
+<div class="paragraph">
 <p>To report problems with this extension, please open a new issue at:</p>
 </div>
-<div class="paragraph data-line-12">
-<p><a href="https://github.com/KhronosGroup/SPIRV-Registry" class="undefined" data-href="https://github.com/KhronosGroup/SPIRV-Registry">https://github.com/KhronosGroup/SPIRV-Registry</a></p>
+<div class="paragraph">
+<p><a href="https://github.com/KhronosGroup/SPIRV-Registry" class="bare">https://github.com/KhronosGroup/SPIRV-Registry</a></p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-14">
+<div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="ulist data-line-16">
+<div class="ulist">
 <ul>
-<li class="data-line-16">
+<li>
 <p>Jessica Davies, Intel</p>
 </li>
-<li class="data-line-17">
+<li>
 <p>Joseph Garvey, Intel</p>
 </li>
-<li class="data-line-18">
+<li>
 <p>Ajaykumar Kannan, Intel</p>
 </li>
-<li class="data-line-19">
+<li>
 <p>Michael Kinsner, Intel</p>
 </li>
-<li class="data-line-20">
+<li>
 <p>Ryan Murray, Intel</p>
 </li>
-<li class="data-line-21">
+<li>
 <p>Abhishek Tiwari, Intel</p>
 </li>
 </ul>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-23">
+<div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-25">
+<div class="paragraph">
 <p>Copyright (c) 2019-2022 Intel Corporation.  All rights reserved.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-27">
+<div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-29">
+<div class="paragraph">
 <p>Final Draft</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-31">
+<div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all data-line-34" style="width: 40%;">
+<table class="tableblock frame-all grid-all" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -524,46 +129,46 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </table>
 </div>
 </div>
-<div class="sect1 data-line-39">
+<div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-41">
+<div class="paragraph">
 <p>This extension is written against the SPIR-V Specification,
 Version 1.6 Revision 2.</p>
 </div>
-<div class="paragraph data-line-44">
+<div class="paragraph">
 <p>This extension requires SPIR-V 1.0.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-46">
+<div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-48">
+<div class="paragraph">
 <p>This extension adds a variety of new execution modes, both general and target-specific. The target-specific execution modes are guarded by separate capabilities.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-50">
+<div class="sect1">
 <h2 id="_extension_name">Extension Name</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-51">
+<div class="paragraph">
 <p>To use this extension within a SPIR-V module, the following <strong>OpExtension</strong> must be present in the module:</p>
 </div>
-<div class="listingblock data-line-53">
+<div class="listingblock">
 <div class="content">
 <pre>OpExtension "SPV_INTEL_kernel_attributes"</pre>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-57">
+<div class="sect1">
 <h2 id="_new_capabilities">New Capabilities</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-58">
+<div class="paragraph">
 <p>This extension introduces new capabilities:</p>
 </div>
-<div class="listingblock data-line-60">
+<div class="listingblock">
 <div class="content">
 <pre>KernelAttributesINTEL
 FPGAKernelAttributesINTEL
@@ -572,10 +177,10 @@ FPGAKernelAttributesv2INTEL</pre>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-66">
+<div class="sect1">
 <h2 id="_new_execution_modes">New Execution Modes</h2>
 <div class="sectionbody">
-<div class="listingblock data-line-68">
+<div class="listingblock">
 <div class="content">
 <pre>MaxWorkgroupSizeINTEL
 MaxWorkDimINTEL
@@ -588,12 +193,12 @@ RegisterMapInterfaceINTEL</pre>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-78">
+<div class="sect1">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<div class="openblock data-line-80">
+<div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-rows data-line-84" style="width: 40%;">
+<table class="tableblock frame-all grid-rows" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -645,17 +250,17 @@ RegisterMapInterfaceINTEL</pre>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-98">
+<div class="sect1">
 <h2 id="_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification, Version 1.6</h2>
 <div class="sectionbody">
-<div class="sect2 data-line-100">
+<div class="sect2">
 <h3 id="_execution_mode">Execution Mode</h3>
-<div class="paragraph data-line-102">
+<div class="paragraph">
 <p>Modify Section 3.6, Execution Mode, adding these rows to the Execution Mode table:</p>
 </div>
-<div class="openblock data-line-104">
+<div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch data-line-106">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -745,14 +350,14 @@ If <em>WaitForDoneWrite</em> is <code>true</code>, it indicates that the kernel 
 </div>
 </div>
 </div>
-<div class="sect2 data-line-166">
+<div class="sect2">
 <h3 id="_capability">Capability</h3>
-<div class="paragraph data-line-168">
+<div class="paragraph">
 <p>Modify Section 3.31, Capability, adding the following rows to the Capability table:</p>
 </div>
-<div class="openblock data-line-169">
+<div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch data-line-171">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -785,26 +390,26 @@ If <em>WaitForDoneWrite</em> is <code>true</code>, it indicates that the kernel 
 </div>
 </div>
 </div>
-<div class="sect2 data-line-179">
+<div class="sect2">
 <h3 id="_validation_rules">Validation Rules</h3>
-<div class="paragraph data-line-181">
+<div class="paragraph">
 <p>It is illegal to specify both <strong>StreamingInterfaceINTEL</strong> and <strong>RegisterMapInterfaceINTEL</strong> modes on the same entry point.</p>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-183">
+<div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-185">
+<div class="paragraph">
 <p>None.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-187">
+<div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch data-line-192">
+<table class="tableblock frame-all grid-rows stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">
@@ -847,11 +452,6 @@ If <em>WaitForDoneWrite</em> is <code>true</code>, it indicates that the kernel 
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2022-12-08 08:30:43 -0800
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_long_composites.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_long_composites.asciidoc
@@ -101,7 +101,7 @@ _Member types_ follow the same rules as defined for _Member types_ of
 | Capability:
 *CapabilityLongCompositesINTEL*
 
-| 2 + variable | 6090 | _<id>, <id>, ... Member N type, member N + 1 type_|
+| 2 + variable | 6090 | _<id>, <id>, ... Member N type, member N + 1 type_
 |=====
 
 Modify the description of *OpTypeStruct* instruction, adding the
@@ -130,7 +130,7 @@ elements of an array, or components of a vector, or columns of a matrix.
 | Capability:
 *CapabilityLongCompositesINTEL*
 
-| 2 + variable | 6091 | _<id>, <id>, ... Constituents_ |
+| 2 + variable | 6091 | _<id>, <id>, ... Constituents_
 |=====
 [cols="3", width="100%"]
 |=====
@@ -154,7 +154,7 @@ See <<Specialization, Specialization>>.
 | Capability:
 *CapabilityLongCompositesINTEL*
 
-| 2 + variable | 6092 | _<id>, <id>, ... Constituents_ |
+| 2 + variable | 6092 | _<id>, <id>, ... Constituents_
 |=====
 
 Modify the description of *OpConstantComposite* instruction, adding the
@@ -199,7 +199,7 @@ elements of an array, or components of a vector, or columns of a matrix.
 | Capability:
 *CapabilityLongCompositesINTEL*
 
-| 2 + variable | 6096 | _<id>, <id>, ... Constituents_ |
+| 2 + variable | 6096 | _<id>, <id>, ... Constituents_
 |=====
 
 Validation Rules

--- a/extensions/INTEL/SPV_INTEL_long_composites.html
+++ b/extensions/INTEL/SPV_INTEL_long_composites.html
@@ -1,853 +1,124 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta name="generator" content="AsciiDoc 9.1.0">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_long_composites</title>
-<style type="text/css">
-/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
-
-/* Default font. */
-body {
-  font-family: Georgia,serif;
-}
-
-/* Title font. */
-h1, h2, h3, h4, h5, h6,
-div.title, caption.title,
-thead, p.table.header,
-#toctitle,
-#author, #revnumber, #revdate, #revremark,
-#footer {
-  font-family: Arial,Helvetica,sans-serif;
-}
-
-body {
-  margin: 1em 5% 1em 5%;
-}
-
-a {
-  color: blue;
-  text-decoration: underline;
-}
-a:visited {
-  color: fuchsia;
-}
-
-em {
-  font-style: italic;
-  color: navy;
-}
-
-strong {
-  font-weight: bold;
-  color: #083194;
-}
-
-h1, h2, h3, h4, h5, h6 {
-  color: #527bbd;
-  margin-top: 1.2em;
-  margin-bottom: 0.5em;
-  line-height: 1.3;
-}
-
-h1, h2, h3 {
-  border-bottom: 2px solid silver;
-}
-h2 {
-  padding-top: 0.5em;
-}
-h3 {
-  float: left;
-}
-h3 + * {
-  clear: left;
-}
-h5 {
-  font-size: 1.0em;
-}
-
-div.sectionbody {
-  margin-left: 0;
-}
-
-hr {
-  border: 1px solid silver;
-}
+<style>
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
 
 p {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
 }
 
-ul, ol, li > p {
-  margin-top: 0;
-}
-ul > li     { color: #aaa; }
-ul > li > * { color: black; }
-
-.monospaced, code, pre {
-  font-family: "Courier New", Courier, monospace;
-  font-size: inherit;
-  color: navy;
-  padding: 0;
-  margin: 0;
-}
-pre {
-  white-space: pre-wrap;
-}
-
-#author {
-  color: #527bbd;
-  font-weight: bold;
-  font-size: 1.1em;
-}
-#email {
-}
-#revnumber, #revdate, #revremark {
-}
-
-#footer {
-  font-size: small;
-  border-top: 2px solid silver;
-  padding-top: 0.5em;
-  margin-top: 4.0em;
-}
-#footer-text {
-  float: left;
-  padding-bottom: 0.5em;
-}
-#footer-badges {
-  float: right;
-  padding-bottom: 0.5em;
-}
-
-#preamble {
-  margin-top: 1.5em;
-  margin-bottom: 1.5em;
-}
-div.imageblock, div.exampleblock, div.verseblock,
-div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
-div.admonitionblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.admonitionblock {
-  margin-top: 2.0em;
-  margin-bottom: 2.0em;
-  margin-right: 10%;
-  color: #606060;
-}
-
-div.content { /* Block element content. */
-  padding: 0;
-}
-
-/* Block element titles. */
-div.title, caption.title {
-  color: #527bbd;
-  font-weight: bold;
-  text-align: left;
-  margin-top: 1.0em;
-  margin-bottom: 0.5em;
-}
-div.title + * {
-  margin-top: 0;
-}
-
-td div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content + div.title {
-  margin-top: 0.0em;
-}
-
-div.sidebarblock > div.content {
-  background: #ffffee;
-  border: 1px solid #dddddd;
-  border-left: 4px solid #f0f0f0;
-  padding: 0.5em;
-}
-
-div.listingblock > div.content {
-  border: 1px solid #dddddd;
-  border-left: 5px solid #f0f0f0;
-  background: #f8f8f8;
-  padding: 0.5em;
-}
-
-div.quoteblock, div.verseblock {
-  padding-left: 1.0em;
-  margin-left: 1.0em;
-  margin-right: 10%;
-  border-left: 5px solid #f0f0f0;
-  color: #888;
-}
-
-div.quoteblock > div.attribution {
-  padding-top: 0.5em;
-  text-align: right;
-}
-
-div.verseblock > pre.content {
-  font-family: inherit;
-  font-size: inherit;
-}
-div.verseblock > div.attribution {
-  padding-top: 0.75em;
-  text-align: left;
-}
-/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
-div.verseblock + div.attribution {
-  text-align: left;
-}
-
-div.admonitionblock .icon {
-  vertical-align: top;
-  font-size: 1.1em;
-  font-weight: bold;
-  text-decoration: underline;
-  color: #527bbd;
-  padding-right: 0.5em;
-}
-div.admonitionblock td.content {
-  padding-left: 0.5em;
-  border-left: 3px solid #dddddd;
-}
-
-div.exampleblock > div.content {
-  border-left: 3px solid #dddddd;
-  padding-left: 0.5em;
-}
-
-div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; vertical-align: text-bottom; }
-a.image:visited { color: white; }
-
-dl {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-dt {
-  margin-top: 0.5em;
-  margin-bottom: 0;
-  font-style: normal;
-  color: navy;
-}
-dd > *:first-child {
-  margin-top: 0.1em;
-}
-
-ul, ol {
-    list-style-position: outside;
-}
-ol.arabic {
-  list-style-type: decimal;
-}
-ol.loweralpha {
-  list-style-type: lower-alpha;
-}
-ol.upperalpha {
-  list-style-type: upper-alpha;
-}
-ol.lowerroman {
-  list-style-type: lower-roman;
-}
-ol.upperroman {
-  list-style-type: upper-roman;
-}
-
-div.compact ul, div.compact ol,
-div.compact p, div.compact p,
-div.compact div, div.compact div {
-  margin-top: 0.1em;
-  margin-bottom: 0.1em;
-}
-
-tfoot {
-  font-weight: bold;
-}
-td > div.verse {
-  white-space: pre;
-}
-
-div.hdlist {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-div.hdlist tr {
-  padding-bottom: 15px;
-}
-dt.hdlist1.strong, td.hdlist1.strong {
-  font-weight: bold;
-}
-td.hdlist1 {
-  vertical-align: top;
-  font-style: normal;
-  padding-right: 0.8em;
-  color: navy;
-}
-td.hdlist2 {
-  vertical-align: top;
-}
-div.hdlist.compact tr {
-  margin: 0;
-  padding-bottom: 0;
-}
-
-.comment {
-  background: yellow;
-}
-
-.footnote, .footnoteref {
-  font-size: 0.8em;
-}
-
-span.footnote, span.footnoteref {
-  vertical-align: super;
-}
-
-#footnotes {
-  margin: 20px 0 20px 0;
-  padding: 7px 0 0 0;
-}
-
-#footnotes div.footnote {
-  margin: 0 0 5px 0;
-}
-
-#footnotes hr {
-  border: none;
-  border-top: 1px solid silver;
-  height: 1px;
-  text-align: left;
-  margin-left: 0;
-  width: 20%;
-  min-width: 100px;
-}
-
-div.colist td {
-  padding-right: 0.5em;
-  padding-bottom: 0.3em;
-  vertical-align: top;
-}
-div.colist td img {
-  margin-top: 0.3em;
-}
-
-@media print {
-  #footer-badges { display: none; }
-}
-
-#toc {
-  margin-bottom: 2.5em;
-}
-
-#toctitle {
-  color: #527bbd;
-  font-size: 1.1em;
-  font-weight: bold;
-  margin-top: 1.0em;
-  margin-bottom: 0.1em;
-}
-
-div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-div.toclevel2 {
-  margin-left: 2em;
-  font-size: 0.9em;
-}
-div.toclevel3 {
-  margin-left: 4em;
-  font-size: 0.9em;
-}
-div.toclevel4 {
-  margin-left: 6em;
-  font-size: 0.9em;
-}
-
-span.aqua { color: aqua; }
-span.black { color: black; }
-span.blue { color: blue; }
-span.fuchsia { color: fuchsia; }
-span.gray { color: gray; }
-span.green { color: green; }
-span.lime { color: lime; }
-span.maroon { color: maroon; }
-span.navy { color: navy; }
-span.olive { color: olive; }
-span.purple { color: purple; }
-span.red { color: red; }
-span.silver { color: silver; }
-span.teal { color: teal; }
-span.white { color: white; }
-span.yellow { color: yellow; }
-
-span.aqua-background { background: aqua; }
-span.black-background { background: black; }
-span.blue-background { background: blue; }
-span.fuchsia-background { background: fuchsia; }
-span.gray-background { background: gray; }
-span.green-background { background: green; }
-span.lime-background { background: lime; }
-span.maroon-background { background: maroon; }
-span.navy-background { background: navy; }
-span.olive-background { background: olive; }
-span.purple-background { background: purple; }
-span.red-background { background: red; }
-span.silver-background { background: silver; }
-span.teal-background { background: teal; }
-span.white-background { background: white; }
-span.yellow-background { background: yellow; }
-
-span.big { font-size: 2em; }
-span.small { font-size: 0.6em; }
-
-span.underline { text-decoration: underline; }
-span.overline { text-decoration: overline; }
-span.line-through { text-decoration: line-through; }
-
-div.unbreakable { page-break-inside: avoid; }
-
-
-/*
- * xhtml11 specific
- *
- * */
-
-div.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.tableblock > table {
-  border: 3px solid #527bbd;
-}
-thead, p.table.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.table {
-  margin-top: 0;
-}
-/* Because the table frame attribute is overridden by CSS in most browsers. */
-div.tableblock > table[frame="void"] {
-  border-style: none;
-}
-div.tableblock > table[frame="hsides"] {
-  border-left-style: none;
-  border-right-style: none;
-}
-div.tableblock > table[frame="vsides"] {
-  border-top-style: none;
-  border-bottom-style: none;
-}
-
-
-/*
- * html5 specific
- *
- * */
-
-table.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-thead, p.tableblock.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.tableblock {
-  margin-top: 0;
-}
-table.tableblock {
-  border-width: 3px;
-  border-spacing: 0px;
-  border-style: solid;
-  border-color: #527bbd;
-  border-collapse: collapse;
-}
-th.tableblock, td.tableblock {
-  border-width: 1px;
-  padding: 4px;
-  border-style: solid;
-  border-color: #527bbd;
-}
-
-table.tableblock.frame-topbot {
-  border-left-style: hidden;
-  border-right-style: hidden;
-}
-table.tableblock.frame-sides {
-  border-top-style: hidden;
-  border-bottom-style: hidden;
-}
-table.tableblock.frame-none {
-  border-style: hidden;
-}
-
-th.tableblock.halign-left, td.tableblock.halign-left {
-  text-align: left;
-}
-th.tableblock.halign-center, td.tableblock.halign-center {
-  text-align: center;
-}
-th.tableblock.halign-right, td.tableblock.halign-right {
-  text-align: right;
-}
-
-th.tableblock.valign-top, td.tableblock.valign-top {
-  vertical-align: top;
-}
-th.tableblock.valign-middle, td.tableblock.valign-middle {
-  vertical-align: middle;
-}
-th.tableblock.valign-bottom, td.tableblock.valign-bottom {
-  vertical-align: bottom;
-}
-
-
-/*
- * manpage specific
- *
- * */
-
-body.manpage h1 {
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
-  border-top: 2px solid silver;
-  border-bottom: 2px solid silver;
-}
-body.manpage h2 {
-  border-style: none;
-}
-body.manpage div.sectionbody {
-  margin-left: 3em;
-}
-
-@media print {
-  body.manpage div#toc { display: none; }
-}
-
-
-@media screen {
-  body {
-    max-width: 50em; /* approximately 80 characters wide */
-    margin-left: 16em;
-  }
-
-  #toc {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 13em;
-    padding: 0.5em;
-    padding-bottom: 1.5em;
-    margin: 0;
-    overflow: auto;
-    border-right: 3px solid #f8f8f8;
-    background-color: white;
-  }
-
-  #toc .toclevel1 {
-    margin-top: 0.5em;
-  }
-
-  #toc .toclevel2 {
-    margin-top: 0.25em;
-    display: list-item;
-    color: #aaaaaa;
-  }
-
-  #toctitle {
-    margin-top: 0.5em;
-  }
-}
 </style>
-<script type="text/javascript">
-/*<![CDATA[*/
-var asciidoc = {  // Namespace.
-
-/////////////////////////////////////////////////////////////////////
-// Table Of Contents generator
-/////////////////////////////////////////////////////////////////////
-
-/* Author: Mihai Bazon, September 2002
- * http://students.infoiasi.ro/~mishoo
- *
- * Table Of Content generator
- * Version: 0.4
- *
- * Feel free to use this script under the terms of the GNU General Public
- * License, as long as you do not remove or alter this notice.
- */
-
- /* modified by Troy D. Hanson, September 2006. License: GPL */
- /* modified by Stuart Rackham, 2006, 2009. License: GPL */
-
-// toclevels = 1..4.
-toc: function (toclevels) {
-
-  function getText(el) {
-    var text = "";
-    for (var i = el.firstChild; i != null; i = i.nextSibling) {
-      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
-        text += i.data;
-      else if (i.firstChild != null)
-        text += getText(i);
-    }
-    return text;
-  }
-
-  function TocEntry(el, text, toclevel) {
-    this.element = el;
-    this.text = text;
-    this.toclevel = toclevel;
-  }
-
-  function tocEntries(el, toclevels) {
-    var result = new Array;
-    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
-    // Function that scans the DOM tree for header elements (the DOM2
-    // nodeIterator API would be a better technique but not supported by all
-    // browsers).
-    var iterate = function (el) {
-      for (var i = el.firstChild; i != null; i = i.nextSibling) {
-        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
-          var mo = re.exec(i.tagName);
-          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
-            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
-          }
-          iterate(i);
-        }
-      }
-    }
-    iterate(el);
-    return result;
-  }
-
-  var toc = document.getElementById("toc");
-  if (!toc) {
-    return;
-  }
-
-  // Delete existing TOC entries in case we're reloading the TOC.
-  var tocEntriesToRemove = [];
-  var i;
-  for (i = 0; i < toc.childNodes.length; i++) {
-    var entry = toc.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div'
-     && entry.getAttribute("class")
-     && entry.getAttribute("class").match(/^toclevel/))
-      tocEntriesToRemove.push(entry);
-  }
-  for (i = 0; i < tocEntriesToRemove.length; i++) {
-    toc.removeChild(tocEntriesToRemove[i]);
-  }
-
-  // Rebuild TOC entries.
-  var entries = tocEntries(document.getElementById("content"), toclevels);
-  for (var i = 0; i < entries.length; ++i) {
-    var entry = entries[i];
-    if (entry.element.id == "")
-      entry.element.id = "_toc_" + i;
-    var a = document.createElement("a");
-    a.href = "#" + entry.element.id;
-    a.appendChild(document.createTextNode(entry.text));
-    var div = document.createElement("div");
-    div.appendChild(a);
-    div.className = "toclevel" + entry.toclevel;
-    toc.appendChild(div);
-  }
-  if (entries.length == 0)
-    toc.parentNode.removeChild(toc);
-},
-
-
-/////////////////////////////////////////////////////////////////////
-// Footnotes generator
-/////////////////////////////////////////////////////////////////////
-
-/* Based on footnote generation code from:
- * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
- */
-
-footnotes: function () {
-  // Delete existing footnote entries in case we're reloading the footnodes.
-  var i;
-  var noteholder = document.getElementById("footnotes");
-  if (!noteholder) {
-    return;
-  }
-  var entriesToRemove = [];
-  for (i = 0; i < noteholder.childNodes.length; i++) {
-    var entry = noteholder.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
-      entriesToRemove.push(entry);
-  }
-  for (i = 0; i < entriesToRemove.length; i++) {
-    noteholder.removeChild(entriesToRemove[i]);
-  }
-
-  // Rebuild footnote entries.
-  var cont = document.getElementById("content");
-  var spans = cont.getElementsByTagName("span");
-  var refs = {};
-  var n = 0;
-  for (i=0; i<spans.length; i++) {
-    if (spans[i].className == "footnote") {
-      n++;
-      var note = spans[i].getAttribute("data-note");
-      if (!note) {
-        // Use [\s\S] in place of . so multi-line matches work.
-        // Because JavaScript has no s (dotall) regex flag.
-        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
-        spans[i].innerHTML =
-          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-        spans[i].setAttribute("data-note", note);
-      }
-      noteholder.innerHTML +=
-        "<div class='footnote' id='_footnote_" + n + "'>" +
-        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
-        n + "</a>. " + note + "</div>";
-      var id =spans[i].getAttribute("id");
-      if (id != null) refs["#"+id] = n;
-    }
-  }
-  if (n == 0)
-    noteholder.parentNode.removeChild(noteholder);
-  else {
-    // Process footnoterefs.
-    for (i=0; i<spans.length; i++) {
-      if (spans[i].className == "footnoteref") {
-        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
-        href = href.match(/#.*/)[0];  // Because IE return full URL.
-        n = refs[href];
-        spans[i].innerHTML =
-          "[<a href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-      }
-    }
-  }
-},
-
-install: function(toclevels) {
-  var timerId;
-
-  function reinstall() {
-    asciidoc.footnotes();
-    if (toclevels) {
-      asciidoc.toc(toclevels);
-    }
-  }
-
-  function reinstallAndRemoveTimer() {
-    clearInterval(timerId);
-    reinstall();
-  }
-
-  timerId = setInterval(reinstall, 500);
-  if (document.addEventListener)
-    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
-  else
-    window.onload = reinstallAndRemoveTimer;
-}
-
-}
-asciidoc.install(1);
-/*]]>*/
-</script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_long_composites</h1>
-<div id="toc">
-  <div id="toctitle">Table of Contents</div>
-  <noscript><p><b>JavaScript must be enabled in your browser to display the table of contents.</b></p></noscript>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_5">Modifications to the SPIR-V Specification, Version 1.5</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
 </div>
 </div>
 <div id="content">
 <div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>SPV_INTEL_long_composites</p></div>
+<div class="paragraph">
+<p>SPV_INTEL_long_composites</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>To report problems with this extension, please open a new issue at:</p></div>
-<div class="paragraph"><p><a href="https://github.com/KhronosGroup/SPIRV-Headers">https://github.com/KhronosGroup/SPIRV-Headers</a></p></div>
+<div class="paragraph">
+<p>To report problems with this extension, please open a new issue at:</p>
+</div>
+<div class="paragraph">
+<p><a href="https://github.com/KhronosGroup/SPIRV-Headers" class="bare">https://github.com/KhronosGroup/SPIRV-Headers</a></p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Mariya Podchishchaeva, Intel
-</p>
+<p>Mariya Podchishchaeva, Intel</p>
 </li>
 <li>
-<p>
-Alexey Sotkin, Intel
-</p>
+<p>Alexey Sotkin, Intel</p>
 </li>
 <li>
-<p>
-Ben Ashbaugh, Intel
-</p>
+<p>Ben Ashbaugh, Intel</p>
 </li>
 <li>
-<p>
-Alexey Sachkov, Intel
-</p>
+<p>Alexey Sachkov, Intel</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Copyright (c) 2023 Intel Corporation. All rights reserved.</p></div>
+<div class="paragraph">
+<p>Copyright (c) 2023 Intel Corporation. All rights reserved.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Shipping.
-</p>
+<p>Shipping.</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all"
-style="
-width:40%;
-">
-<col style="width:50%;">
-<col style="width:50%;">
+<table class="tableblock frame-all grid-all" style="width: 40%;">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2023-03-22</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-03-22</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
 </tr>
 </tbody>
 </table>
@@ -856,28 +127,37 @@ width:40%;
 <div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension is written against the SPIR-V Specification,
-Version 1.6 Revision 2, Unified</p></div>
-<div class="paragraph"><p>This extension requires SPIR-V 1.0.</p></div>
+<div class="paragraph">
+<p>This extension is written against the SPIR-V Specification,
+Version 1.6 Revision 2, Unified</p>
+</div>
+<div class="paragraph">
+<p>This extension requires SPIR-V 1.0.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension adds new capability and instructions to allow to represent
+<div class="paragraph">
+<p>This extension adds new capability and instructions to allow to represent
 composites with number of Constituents greater than the maximum
-possible WordCount.</p></div>
+possible WordCount.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_extension_name">Extension Name</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>To use this extension within a SPIR-V module, the following
-<strong>OpExtension</strong> must be present in the module:</p></div>
+<div class="paragraph">
+<p>To use this extension within a SPIR-V module, the following
+<strong>OpExtension</strong> must be present in the module:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpExtension "SPV_INTEL_long_composites"</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -885,81 +165,87 @@ possible WordCount.</p></div>
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_capabilities">Capabilities</h3>
-<div class="paragraph"><p>Modify Section 3.31, "Capability", adding these rows to the Capability table:</p></div>
+<div class="paragraph">
+<p>Modify Section 3.31, "Capability", adding these rows to the Capability table:</p>
+</div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:6%;">
-<col style="width:48%;">
-<col style="width:45%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 6.0606%;">
+<col style="width: 48.4848%;">
+<col style="width: 45.4546%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-center valign-middle" colspan="2" > Capability </th>
-<th class="tableblock halign-center valign-top" > Implicitly Declares</th>
+<th class="tableblock halign-center valign-middle" colspan="2">Capability</th>
+<th class="tableblock halign-center valign-top">Implicitly Declares</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-center valign-middle" ><p class="tableblock">6089</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>CapabilityLongCompositesINTEL</strong><br>
+<td class="tableblock halign-center valign-middle"><p class="tableblock">6089</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>CapabilityLongCompositesINTEL</strong><br>
 Allow to use <strong>OpTypeStructContinuedINTEL</strong>, <strong>OpConstantCompositeContinuedINTEL</strong>,
 <strong>OpCompositeConstructContinuedINTEL</strong> and <strong>OpSpecConstantCompositeContinuedINTEL</strong> instructions</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
+<td class="tableblock halign-left valign-top"></td>
 </tr>
 </tbody>
 </table>
-</div></div>
+</div>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_instructions">Instructions</h3>
-<div class="paragraph"><p>In section 3.42.6. Type-Declaration Instructions add the new instruction</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:33%;">
-<col style="width:33%;">
+<div class="paragraph">
+<p>In section 3.42.6. Type-Declaration Instructions add the new instruction</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="2" ><p class="tableblock"><strong>OpTypeStructContinuedINTEL</strong><br></p>
+<td class="tableblock halign-left valign-top" colspan="2"><p class="tableblock"><strong>OpTypeStructContinuedINTEL</strong><br></p>
 <p class="tableblock">Continue specifying an <strong>OpTypeStruct</strong> with number of <em>Member types</em>
 greater than the maximum possible WordCount.</p>
 <p class="tableblock">The previous instruction must be an <strong>OpTypeStruct</strong> or an
 <strong>OpTypeStructContinuedINTEL</strong> instruction.</p>
 <p class="tableblock"><em>Member types</em> follow the same rules as defined for <em>Member types</em> of
 <strong>OpTypeStruct</strong>.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:
 <strong>CapabilityLongCompositesINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2 + variable</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6090</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;, &lt;id&gt;, &#8230; Member N type, member N + 1 type</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2 + variable</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6090</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;, &lt;id&gt;, &#8230;&#8203; Member N type, member N + 1 type</em></p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>Modify the description of <strong>OpTypeStruct</strong> instruction, adding the
+<div class="paragraph">
+<p>Modify the description of <strong>OpTypeStruct</strong> instruction, adding the
 following sentence to the end:
 In case if it is not possible to specify all the <em>member types</em> of the structure
 by one <strong>OpTypeStruct</strong> instruction, i.e. if number of members of the
 <em>Result type</em> is greater than the maximum possible WordCount, the remaining
 <em>member types</em> are specified by the following <strong>OpTypeStructContinuedINTEL</strong>
-instructions.</p></div>
-<div class="paragraph"><p>In section 3.42.7. Constant-Creation Instructions, add the new instructions</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:33%;">
-<col style="width:33%;">
+instructions.</p>
+</div>
+<div class="paragraph">
+<p>In section 3.42.7. Constant-Creation Instructions, add the new instructions</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="2" ><p class="tableblock"><strong>OpConstantCompositeContinuedINTEL</strong><br></p>
+<td class="tableblock halign-left valign-top" colspan="2"><p class="tableblock"><strong>OpConstantCompositeContinuedINTEL</strong><br></p>
 <p class="tableblock">Continue specifying an <strong>OpConstantComposite</strong> instruction with number of
 <em>Constituents</em> greater than the maximum possible WordCount.</p>
 <p class="tableblock">The previous instruction must be an <strong>OpConstantComposite</strong> or an
@@ -967,26 +253,25 @@ width:100%;
 <p class="tableblock"><em>Constituents</em> follow the same rules as defined for <em>Constituents</em> of
 <strong>OpConstantComposite</strong> instruction and specify members of a structure, or
 elements of an array, or components of a vector, or columns of a matrix.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:
 <strong>CapabilityLongCompositesINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2 + variable</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6091</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;, &lt;id&gt;, &#8230; Constituents</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2 + variable</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6091</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;, &lt;id&gt;, &#8230;&#8203; Constituents</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:33%;">
-<col style="width:33%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="2" ><p class="tableblock"><strong>OpSpecConstantCompositeContinuedINTEL</strong><br></p>
+<td class="tableblock halign-left valign-top" colspan="2"><p class="tableblock"><strong>OpSpecConstantCompositeContinuedINTEL</strong><br></p>
 <p class="tableblock">Continue specifying an <strong>OpSpecConstantComposite</strong> instruction with number of
 <em>Constituents</em> greater than the maximum possible WordCount.</p>
 <p class="tableblock">The previous instruction must be an <strong>OpSpecConstantComposite</strong> or an
@@ -997,48 +282,55 @@ elements of an array, or components of a vector, or columns of a matrix.</p>
 <p class="tableblock">This instruction will be specialized to an <strong>OpConstantCompositeContinuedINTEL</strong>
 instruction.</p>
 <p class="tableblock">See <a href="#Specialization">Specialization</a>.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:
 <strong>CapabilityLongCompositesINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2 + variable</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6092</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;, &lt;id&gt;, &#8230; Constituents</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2 + variable</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6092</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;, &lt;id&gt;, &#8230;&#8203; Constituents</em></p></td>
 </tr>
 </tbody>
 </table>
-<div class="paragraph"><p>Modify the description of <strong>OpConstantComposite</strong> instruction, adding the
+<div class="paragraph">
+<p>Modify the description of <strong>OpConstantComposite</strong> instruction, adding the
 following sentence to the end:
 In case if it is not possible to specify all the <em>Constituents</em> by one
 <strong>OpConstantComposite</strong> instruction, i.e. if number of members of the
 <em>Result type</em> and corresponding <em>Constituents</em> is greater than the maximum
 possible WordCount, the remaining <em>Constituents</em> are specified by the following
-<strong>OpConstantCompositeContinuedINTEL</strong> instructions.</p></div>
-<div class="paragraph"><p>Modify the description of <strong>OpSpecConstantComposite</strong> instruction, adding the
+<strong>OpConstantCompositeContinuedINTEL</strong> instructions.</p>
+</div>
+<div class="paragraph">
+<p>Modify the description of <strong>OpSpecConstantComposite</strong> instruction, adding the
 following sentence to the end:
 In case if it is not possible to specify all the <em>Constituents</em> by one
 <strong>OpSpecConstantComposite</strong> instruction, i.e. if number of members of the
 <em>Result type</em> and corresponding <em>Constituents</em> is greater than the maximum
 possible WordCount, the remaining <em>Constituents</em> are specified by the following
-<strong>OpSpecConstantCompositeContinuedINTEL</strong> instructions.</p></div>
-<div class="paragraph"><p>Modify the description of <strong>OpCompositeConstruct</strong> instruction, adding the
+<strong>OpSpecConstantCompositeContinuedINTEL</strong> instructions.</p>
+</div>
+<div class="paragraph">
+<p>Modify the description of <strong>OpCompositeConstruct</strong> instruction, adding the
 following sentence to the end:
 In case if it is not possible to specify all the <em>Constituents</em> by one
 <strong>CompositeConstruct</strong> instruction, i.e. if number of members of the
 <em>Result type</em> and corresponding <em>Constituents</em> is greater than the maximum
 possible WordCount, the remaining <em>Constituents</em> are specified by the following
-<strong>OpCompositeConstructContinuedINTEL</strong> instructions.</p></div>
-<div class="paragraph"><p>In section 3.42.12. Composite Instructions, add the new instruction</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:33%;">
-<col style="width:33%;">
+<strong>OpCompositeConstructContinuedINTEL</strong> instructions.</p>
+</div>
+<div class="paragraph">
+<p>In section 3.42.12. Composite Instructions, add the new instruction</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="2" ><p class="tableblock"><strong>OpCompositeConstructContinuedINTEL</strong><br></p>
+<td class="tableblock halign-left valign-top" colspan="2"><p class="tableblock"><strong>OpCompositeConstructContinuedINTEL</strong><br></p>
 <p class="tableblock">Continue specifying an <strong>OpCompositeConstruct</strong> instruction with number of
 <em>Constituents</em> greater than the maximum possible WordCount.</p>
 <p class="tableblock">The previous instruction must be an <strong>OpCompositeConstruct</strong> or an
@@ -1046,81 +338,93 @@ width:100%;
 <p class="tableblock"><em>Constituents</em> follow the same rules as defined for <em>Constituents</em> of
 <strong>OpCompositeConstruct</strong> instruction and specify members of a structure, or
 elements of an array, or components of a vector, or columns of a matrix.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:
 <strong>CapabilityLongCompositesINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2 + variable</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6096</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;, &lt;id&gt;, &#8230; Constituents</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2 + variable</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6096</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;, &lt;id&gt;, &#8230;&#8203; Constituents</em></p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect2">
 <h3 id="_validation_rules">Validation Rules</h3>
-<div class="paragraph"><p>Previous instruction to <strong>OpTypeStructContinuedINTEL</strong> must be <strong>OpTypeStruct</strong> or <strong>OpTypeStructContinuedINTEL</strong>.<br>
+<div class="paragraph">
+<p>Previous instruction to <strong>OpTypeStructContinuedINTEL</strong> must be <strong>OpTypeStruct</strong> or <strong>OpTypeStructContinuedINTEL</strong>.<br>
 Previous instruction to <strong>OpConstantCompositeContinuedINTEL</strong> must be <strong>OpConstantComposite</strong> or <strong>OpConstantCompositeContinuedINTEL</strong>.<br>
 Previous instruction to <strong>OpCompositeConstructContinuedINTEL</strong> must be <strong>OpCompositeConstruct</strong> or <strong>OpCompositeConstructContinuedINTEL</strong>.<br>
-Previous instruction to <strong>OpSpecConstantCompositeContinuedINTEL</strong> must be <strong>OpSpecConstantComposite</strong> or <strong>OpSpecConstantCompositeContinuedINTEL</strong>.<br></p></div>
+Previous instruction to <strong>OpSpecConstantCompositeContinuedINTEL</strong> must be <strong>OpSpecConstantComposite</strong> or <strong>OpSpecConstantCompositeContinuedINTEL</strong>.<br></p>
+</div>
 </div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>1) Do we need to define additional validation rules?</p></div>
-<div class="paragraph"><p>Resolution:</p></div>
-<div class="paragraph"><p>Yes, added the validation rules for the new instructions.</p></div>
-<div class="paragraph"><p>2) Do we need modifications of the OpConstantComposite/OpSpecConstantComposite
-instruction description?</p></div>
-<div class="paragraph"><p>Resolution:</p></div>
-<div class="paragraph"><p>Yes, it seems that description of these instructions defines one to one match
+<div class="paragraph">
+<p>1) Do we need to define additional validation rules?</p>
+</div>
+<div class="paragraph">
+<p>Resolution:</p>
+</div>
+<div class="paragraph">
+<p>Yes, added the validation rules for the new instructions.</p>
+</div>
+<div class="paragraph">
+<p>2) Do we need modifications of the OpConstantComposite/OpSpecConstantComposite
+instruction description?</p>
+</div>
+<div class="paragraph">
+<p>Resolution:</p>
+</div>
+<div class="paragraph">
+<p>Yes, it seems that description of these instructions defines one to one match
 between composite type members and Constituents by the sentence:
 "There must be exactly one Constituent for each top-level
-member/element/component/column of the result." Done.</p></div>
-<div class="paragraph"><p>3) We also might want to modify OpAccessChain to clarify how it works on large
-constants.</p></div>
-<div class="paragraph"><p>Resolution:</p></div>
-<div class="paragraph"><p>No. Already existing description of OpAccessChain in code SPIR-V spec is good enough.</p></div>
+member/element/component/column of the result." Done.</p>
+</div>
+<div class="paragraph">
+<p>3) We also might want to modify OpAccessChain to clarify how it works on large
+constants.</p>
+</div>
+<div class="paragraph">
+<p>Resolution:</p>
+</div>
+<div class="paragraph">
+<p>No. Already existing description of OpAccessChain in code SPIR-V spec is good enough.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:100%;
-">
-<col style="width:4%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:66%;">
+<table class="tableblock frame-all grid-rows stretch">
+<colgroup>
+<col style="width: 4.7619%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" >Rev</th>
-<th class="tableblock halign-left valign-top" >Date</th>
-<th class="tableblock halign-left valign-top" >Author</th>
-<th class="tableblock halign-left valign-top" >Changes</th>
+<th class="tableblock halign-left valign-top">Rev</th>
+<th class="tableblock halign-left valign-top">Date</th>
+<th class="tableblock halign-left valign-top">Author</th>
+<th class="tableblock halign-left valign-top">Changes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2023-03-22</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Mariya Podchishchaeva</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Initial revision</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-03-22</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Mariya Podchishchaeva</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Initial revision</p></td>
 </tr>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footnotes"><hr></div>
-<div id="footer">
-<div id="footer-text">
-Last updated
- 2023-11-29 08:24:58 PST
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_loop_fuse.html
+++ b/extensions/INTEL/SPV_INTEL_loop_fuse.html
@@ -4,441 +4,46 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.10">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_loop_fuse</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
-/* Uncomment @import statement to use as custom stylesheet */
-/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
-article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}
-audio,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
-a{background:none}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-abbr[title]{border-bottom:1px dotted}
-b,strong{font-weight:bold}
-dfn{font-style:italic}
-hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:0}
-p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
-abbr{text-transform:none}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
-blockquote cite::before{content:"\2014 \0020"}
-blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
-:not(pre)>code.nobreak{word-wrap:normal}
-:not(pre)>code.nowrap{white-space:nowrap}
-pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
-pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
-pre>code{display:block}
-pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:100%;background:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #e7e7e9}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details>summary:first-of-type{cursor:pointer;display:list-item;outline:none;margin-bottom:.75em}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:inherit}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border-style:solid;border-width:1px;border-color:#dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;-webkit-border-radius:4px;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
-@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
-.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
-.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.prettyprint{background:#f7f7f8}
-pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
-pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
-pre.prettyprint li code[data-lang]::before{opacity:1}
-pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
-table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
-table.linenotable td.code{padding-left:.75em}
-table.linenotable td.linenos{border-right:1px solid currentColor;opacity:.35;padding-right:.5em}
-pre.pygments .lineno{border-right:1px solid currentColor;opacity:.35;display:inline-block;margin-right:.75em}
-pre.pygments .lineno::before{content:"";margin-right:-.125em}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
-.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
-.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
-.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
-table.tableblock{max-width:100%;border-collapse:separate}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-td.tableblock>.content>:last-child.sidebarblock{margin-bottom:0}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
-table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
-table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
-table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
-table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
-table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
-table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
-table.frame-all{border-width:1px}
-table.frame-sides{border-width:0 1px}
-table.frame-topbot,table.frame-ends{border-width:1px 0}
-table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-ul.checklist{margin-left:.625em}
-ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
-ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
-.imageblock.left{margin:.25em .625em 1.25em 0}
-.imageblock.right{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
-.gist .file-data>table td.line-data{width:99%}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background:#00fafa}
-.black{color:#000}
-.black-background{background:#000}
-.blue{color:#0000bf}
-.blue-background{background:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background:#fa00fa}
-.gray{color:#606060}
-.gray-background{background:#7d7d7d}
-.green{color:#006000}
-.green-background{background:#007d00}
-.lime{color:#00bf00}
-.lime-background{background:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background:#7d0000}
-.navy{color:#000060}
-.navy-background{background:#00007d}
-.olive{color:#606000}
-.olive-background{background:#7d7d00}
-.purple{color:#600060}
-.purple-background{background:#7d007d}
-.red{color:#bf0000}
-.red-background{background:#fa0000}
-.silver{color:#909090}
-.silver-background{background:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_loop_fuse</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New capabilities</a></li>
+<li><a href="#_new_decorations">New Decorations</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_5">Modifications to the SPIR-V Specification, Version 1.5</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
 <div class="sect1">
@@ -708,11 +313,6 @@ Only valid on OpFunction. Request, to the extent possible, that loops in the fun
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2020-12-04 17:12:51 -0400
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_masked_gather_scatter.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_masked_gather_scatter.asciidoc
@@ -175,35 +175,35 @@ Add the following new entries:
 Reads values from a vector of pointers gathering them into one vector. Returns the gathered vector. Memory access
 is specified by a mask instruction parameter. +
  +
-'Result Type' is a type of the gathered vector. Its _Component Type_ must be the same as the base type of
-'PtrVector'.
+_Result Type_ is a type of the gathered vector. Its _Component Type_ must be the same as the base type of
+_PtrVector_.
  +
-'PtrVector' is a _vector_ with _physical pointer type_ _Component Type_, containing addresses from where the instruction reads. +
+_PtrVector_ is a _vector_ with _physical pointer type_ _Component Type_, containing addresses from where the instruction reads. +
  +
-'Alignment' is an unsigned 32-bit integer literal whose value is
+_Alignment_ is an unsigned 32-bit integer literal whose value is
 either 0 or a power of two. When the value is not 0, it is an assertion that
-each pointer value in 'PtrVector' has this alignment. The behavior is undefined if
-any pointer value in 'PtrVector' does not have this alignment. +
+each pointer value in _PtrVector_ has this alignment. The behavior is undefined if
+any pointer value in _PtrVector_ does not have this alignment. +
  +
-'Mask' is a vector of boolean values with the same number of elements as the _Result Type_. It specifies which elements of
-'PtrVector' should be gathered. +
+_Mask_ is a vector of boolean values with the same number of elements as the _Result Type_. It specifies which elements of
+_PtrVector_ should be gathered. +
  +
-'FillEmpty' is used to fill the masked-off lanes of the result. It must be of the same type as the _Component Type_ of _Result Type_. +
+_FillEmpty_ is used to fill the masked-off lanes of the result. It must be of the same type as the _Component Type_ of _Result Type_. +
 
 1+|Capability: +
 *{capability_name}*
 1+| 7 | {OpMaskedGatherINTEL_token}
-| '<id>' +
-'Result Type'
-|'Result <id>'
-| '<id>' +
-'PtrVector'
-| '<literal>' +
-'Alignment'
-| '<id>' +
-'Mask'
-| '<id>' +
-'FillEmpty'
+| _<id>_ +
+_Result Type_
+|_Result <id>_
+| _<id>_ +
+_PtrVector_
+| _<literal>_ +
+_Alignment_
+| _<id>_ +
+_Mask_
+| _<id>_ +
+_FillEmpty_
 |=====
 
 [cols="1,1,4*3",width="100%"]
@@ -213,29 +213,29 @@ any pointer value in 'PtrVector' does not have this alignment. +
 Writes values from a vector to the corresponding memory address of the given vector of pointers. Memory access
 is specified by a mask instruction parameter. +
  +
-'InputVector' is a _vector_ of values to scatter. +
+_InputVector_ is a _vector_ of values to scatter. +
  +
-'PtrVector' is a _vector_ with _physical pointer type_ _Component Type_, containing addresses where the instruction stores the scattered values. +
+_PtrVector_ is a _vector_ with _physical pointer type_ _Component Type_, containing addresses where the instruction stores the scattered values. +
  +
-'Alignment' is an unsigned 32-bit integer literal whose value is
+_Alignment_ is an unsigned 32-bit integer literal whose value is
 either 0 or a power of two. When the value is not 0, it is an assertion that
-each pointer value in 'PtrVector' has this alignment. The behavior is undefined if
-any pointer value in 'PtrVector' does not have this alignment. +
+each pointer value in _PtrVector_ has this alignment. The behavior is undefined if
+any pointer value in _PtrVector_ does not have this alignment. +
  +
-'Mask' is a vector of boolean values with the same number of elements as the _InputVector_. It specifies which elements of
-'InputVector' should be scattered. +
+_Mask_ is a vector of boolean values with the same number of elements as the _InputVector_. It specifies which elements of
+_InputVector_ should be scattered. +
 
 1+|Capability: +
 *{capability_name}*
 1+| 5 | {OpMaskedScatterINTEL_token}
-| '<id>' +
-'InputVector'
-| '<id>' +
-'PtrVector'
-| '<literal>' +
-'Alignment'
-| '<id>' +
-'Mask'
+| _<id>_ +
+_InputVector_
+| _<id>_ +
+_PtrVector_
+| _<literal>_ +
+_Alignment_
+| _<id>_ +
+_Mask_
 |=====
 
 

--- a/extensions/INTEL/SPV_INTEL_masked_gather_scatter.html
+++ b/extensions/INTEL/SPV_INTEL_masked_gather_scatter.html
@@ -1,848 +1,123 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta name="generator" content="AsciiDoc 9.1.0">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_masked_gather_scatter</title>
-<style type="text/css">
-/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
-
-/* Default font. */
-body {
-  font-family: Georgia,serif;
-}
-
-/* Title font. */
-h1, h2, h3, h4, h5, h6,
-div.title, caption.title,
-thead, p.table.header,
-#toctitle,
-#author, #revnumber, #revdate, #revremark,
-#footer {
-  font-family: Arial,Helvetica,sans-serif;
-}
-
-body {
-  margin: 1em 5% 1em 5%;
-}
-
-a {
-  color: blue;
-  text-decoration: underline;
-}
-a:visited {
-  color: fuchsia;
-}
-
-em {
-  font-style: italic;
-  color: navy;
-}
-
-strong {
-  font-weight: bold;
-  color: #083194;
-}
-
-h1, h2, h3, h4, h5, h6 {
-  color: #527bbd;
-  margin-top: 1.2em;
-  margin-bottom: 0.5em;
-  line-height: 1.3;
-}
-
-h1, h2, h3 {
-  border-bottom: 2px solid silver;
-}
-h2 {
-  padding-top: 0.5em;
-}
-h3 {
-  float: left;
-}
-h3 + * {
-  clear: left;
-}
-h5 {
-  font-size: 1.0em;
-}
-
-div.sectionbody {
-  margin-left: 0;
-}
-
-hr {
-  border: 1px solid silver;
-}
+<style>
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
 
 p {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
 }
 
-ul, ol, li > p {
-  margin-top: 0;
-}
-ul > li     { color: #aaa; }
-ul > li > * { color: black; }
-
-.monospaced, code, pre {
-  font-family: "Courier New", Courier, monospace;
-  font-size: inherit;
-  color: navy;
-  padding: 0;
-  margin: 0;
-}
-pre {
-  white-space: pre-wrap;
-}
-
-#author {
-  color: #527bbd;
-  font-weight: bold;
-  font-size: 1.1em;
-}
-#email {
-}
-#revnumber, #revdate, #revremark {
-}
-
-#footer {
-  font-size: small;
-  border-top: 2px solid silver;
-  padding-top: 0.5em;
-  margin-top: 4.0em;
-}
-#footer-text {
-  float: left;
-  padding-bottom: 0.5em;
-}
-#footer-badges {
-  float: right;
-  padding-bottom: 0.5em;
-}
-
-#preamble {
-  margin-top: 1.5em;
-  margin-bottom: 1.5em;
-}
-div.imageblock, div.exampleblock, div.verseblock,
-div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
-div.admonitionblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.admonitionblock {
-  margin-top: 2.0em;
-  margin-bottom: 2.0em;
-  margin-right: 10%;
-  color: #606060;
-}
-
-div.content { /* Block element content. */
-  padding: 0;
-}
-
-/* Block element titles. */
-div.title, caption.title {
-  color: #527bbd;
-  font-weight: bold;
-  text-align: left;
-  margin-top: 1.0em;
-  margin-bottom: 0.5em;
-}
-div.title + * {
-  margin-top: 0;
-}
-
-td div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content + div.title {
-  margin-top: 0.0em;
-}
-
-div.sidebarblock > div.content {
-  background: #ffffee;
-  border: 1px solid #dddddd;
-  border-left: 4px solid #f0f0f0;
-  padding: 0.5em;
-}
-
-div.listingblock > div.content {
-  border: 1px solid #dddddd;
-  border-left: 5px solid #f0f0f0;
-  background: #f8f8f8;
-  padding: 0.5em;
-}
-
-div.quoteblock, div.verseblock {
-  padding-left: 1.0em;
-  margin-left: 1.0em;
-  margin-right: 10%;
-  border-left: 5px solid #f0f0f0;
-  color: #888;
-}
-
-div.quoteblock > div.attribution {
-  padding-top: 0.5em;
-  text-align: right;
-}
-
-div.verseblock > pre.content {
-  font-family: inherit;
-  font-size: inherit;
-}
-div.verseblock > div.attribution {
-  padding-top: 0.75em;
-  text-align: left;
-}
-/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
-div.verseblock + div.attribution {
-  text-align: left;
-}
-
-div.admonitionblock .icon {
-  vertical-align: top;
-  font-size: 1.1em;
-  font-weight: bold;
-  text-decoration: underline;
-  color: #527bbd;
-  padding-right: 0.5em;
-}
-div.admonitionblock td.content {
-  padding-left: 0.5em;
-  border-left: 3px solid #dddddd;
-}
-
-div.exampleblock > div.content {
-  border-left: 3px solid #dddddd;
-  padding-left: 0.5em;
-}
-
-div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; vertical-align: text-bottom; }
-a.image:visited { color: white; }
-
-dl {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-dt {
-  margin-top: 0.5em;
-  margin-bottom: 0;
-  font-style: normal;
-  color: navy;
-}
-dd > *:first-child {
-  margin-top: 0.1em;
-}
-
-ul, ol {
-    list-style-position: outside;
-}
-ol.arabic {
-  list-style-type: decimal;
-}
-ol.loweralpha {
-  list-style-type: lower-alpha;
-}
-ol.upperalpha {
-  list-style-type: upper-alpha;
-}
-ol.lowerroman {
-  list-style-type: lower-roman;
-}
-ol.upperroman {
-  list-style-type: upper-roman;
-}
-
-div.compact ul, div.compact ol,
-div.compact p, div.compact p,
-div.compact div, div.compact div {
-  margin-top: 0.1em;
-  margin-bottom: 0.1em;
-}
-
-tfoot {
-  font-weight: bold;
-}
-td > div.verse {
-  white-space: pre;
-}
-
-div.hdlist {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-div.hdlist tr {
-  padding-bottom: 15px;
-}
-dt.hdlist1.strong, td.hdlist1.strong {
-  font-weight: bold;
-}
-td.hdlist1 {
-  vertical-align: top;
-  font-style: normal;
-  padding-right: 0.8em;
-  color: navy;
-}
-td.hdlist2 {
-  vertical-align: top;
-}
-div.hdlist.compact tr {
-  margin: 0;
-  padding-bottom: 0;
-}
-
-.comment {
-  background: yellow;
-}
-
-.footnote, .footnoteref {
-  font-size: 0.8em;
-}
-
-span.footnote, span.footnoteref {
-  vertical-align: super;
-}
-
-#footnotes {
-  margin: 20px 0 20px 0;
-  padding: 7px 0 0 0;
-}
-
-#footnotes div.footnote {
-  margin: 0 0 5px 0;
-}
-
-#footnotes hr {
-  border: none;
-  border-top: 1px solid silver;
-  height: 1px;
-  text-align: left;
-  margin-left: 0;
-  width: 20%;
-  min-width: 100px;
-}
-
-div.colist td {
-  padding-right: 0.5em;
-  padding-bottom: 0.3em;
-  vertical-align: top;
-}
-div.colist td img {
-  margin-top: 0.3em;
-}
-
-@media print {
-  #footer-badges { display: none; }
-}
-
-#toc {
-  margin-bottom: 2.5em;
-}
-
-#toctitle {
-  color: #527bbd;
-  font-size: 1.1em;
-  font-weight: bold;
-  margin-top: 1.0em;
-  margin-bottom: 0.1em;
-}
-
-div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-div.toclevel2 {
-  margin-left: 2em;
-  font-size: 0.9em;
-}
-div.toclevel3 {
-  margin-left: 4em;
-  font-size: 0.9em;
-}
-div.toclevel4 {
-  margin-left: 6em;
-  font-size: 0.9em;
-}
-
-span.aqua { color: aqua; }
-span.black { color: black; }
-span.blue { color: blue; }
-span.fuchsia { color: fuchsia; }
-span.gray { color: gray; }
-span.green { color: green; }
-span.lime { color: lime; }
-span.maroon { color: maroon; }
-span.navy { color: navy; }
-span.olive { color: olive; }
-span.purple { color: purple; }
-span.red { color: red; }
-span.silver { color: silver; }
-span.teal { color: teal; }
-span.white { color: white; }
-span.yellow { color: yellow; }
-
-span.aqua-background { background: aqua; }
-span.black-background { background: black; }
-span.blue-background { background: blue; }
-span.fuchsia-background { background: fuchsia; }
-span.gray-background { background: gray; }
-span.green-background { background: green; }
-span.lime-background { background: lime; }
-span.maroon-background { background: maroon; }
-span.navy-background { background: navy; }
-span.olive-background { background: olive; }
-span.purple-background { background: purple; }
-span.red-background { background: red; }
-span.silver-background { background: silver; }
-span.teal-background { background: teal; }
-span.white-background { background: white; }
-span.yellow-background { background: yellow; }
-
-span.big { font-size: 2em; }
-span.small { font-size: 0.6em; }
-
-span.underline { text-decoration: underline; }
-span.overline { text-decoration: overline; }
-span.line-through { text-decoration: line-through; }
-
-div.unbreakable { page-break-inside: avoid; }
-
-
-/*
- * xhtml11 specific
- *
- * */
-
-div.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.tableblock > table {
-  border: 3px solid #527bbd;
-}
-thead, p.table.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.table {
-  margin-top: 0;
-}
-/* Because the table frame attribute is overridden by CSS in most browsers. */
-div.tableblock > table[frame="void"] {
-  border-style: none;
-}
-div.tableblock > table[frame="hsides"] {
-  border-left-style: none;
-  border-right-style: none;
-}
-div.tableblock > table[frame="vsides"] {
-  border-top-style: none;
-  border-bottom-style: none;
-}
-
-
-/*
- * html5 specific
- *
- * */
-
-table.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-thead, p.tableblock.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.tableblock {
-  margin-top: 0;
-}
-table.tableblock {
-  border-width: 3px;
-  border-spacing: 0px;
-  border-style: solid;
-  border-color: #527bbd;
-  border-collapse: collapse;
-}
-th.tableblock, td.tableblock {
-  border-width: 1px;
-  padding: 4px;
-  border-style: solid;
-  border-color: #527bbd;
-}
-
-table.tableblock.frame-topbot {
-  border-left-style: hidden;
-  border-right-style: hidden;
-}
-table.tableblock.frame-sides {
-  border-top-style: hidden;
-  border-bottom-style: hidden;
-}
-table.tableblock.frame-none {
-  border-style: hidden;
-}
-
-th.tableblock.halign-left, td.tableblock.halign-left {
-  text-align: left;
-}
-th.tableblock.halign-center, td.tableblock.halign-center {
-  text-align: center;
-}
-th.tableblock.halign-right, td.tableblock.halign-right {
-  text-align: right;
-}
-
-th.tableblock.valign-top, td.tableblock.valign-top {
-  vertical-align: top;
-}
-th.tableblock.valign-middle, td.tableblock.valign-middle {
-  vertical-align: middle;
-}
-th.tableblock.valign-bottom, td.tableblock.valign-bottom {
-  vertical-align: bottom;
-}
-
-
-/*
- * manpage specific
- *
- * */
-
-body.manpage h1 {
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
-  border-top: 2px solid silver;
-  border-bottom: 2px solid silver;
-}
-body.manpage h2 {
-  border-style: none;
-}
-body.manpage div.sectionbody {
-  margin-left: 3em;
-}
-
-@media print {
-  body.manpage div#toc { display: none; }
-}
-
-
-@media screen {
-  body {
-    max-width: 50em; /* approximately 80 characters wide */
-    margin-left: 16em;
-  }
-
-  #toc {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 13em;
-    padding: 0.5em;
-    padding-bottom: 1.5em;
-    margin: 0;
-    overflow: auto;
-    border-right: 3px solid #f8f8f8;
-    background-color: white;
-  }
-
-  #toc .toclevel1 {
-    margin-top: 0.5em;
-  }
-
-  #toc .toclevel2 {
-    margin-top: 0.25em;
-    display: list-item;
-    color: #aaaaaa;
-  }
-
-  #toctitle {
-    margin-top: 0.5em;
-  }
-}
 </style>
-<script type="text/javascript">
-/*<![CDATA[*/
-var asciidoc = {  // Namespace.
-
-/////////////////////////////////////////////////////////////////////
-// Table Of Contents generator
-/////////////////////////////////////////////////////////////////////
-
-/* Author: Mihai Bazon, September 2002
- * http://students.infoiasi.ro/~mishoo
- *
- * Table Of Content generator
- * Version: 0.4
- *
- * Feel free to use this script under the terms of the GNU General Public
- * License, as long as you do not remove or alter this notice.
- */
-
- /* modified by Troy D. Hanson, September 2006. License: GPL */
- /* modified by Stuart Rackham, 2006, 2009. License: GPL */
-
-// toclevels = 1..4.
-toc: function (toclevels) {
-
-  function getText(el) {
-    var text = "";
-    for (var i = el.firstChild; i != null; i = i.nextSibling) {
-      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
-        text += i.data;
-      else if (i.firstChild != null)
-        text += getText(i);
-    }
-    return text;
-  }
-
-  function TocEntry(el, text, toclevel) {
-    this.element = el;
-    this.text = text;
-    this.toclevel = toclevel;
-  }
-
-  function tocEntries(el, toclevels) {
-    var result = new Array;
-    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
-    // Function that scans the DOM tree for header elements (the DOM2
-    // nodeIterator API would be a better technique but not supported by all
-    // browsers).
-    var iterate = function (el) {
-      for (var i = el.firstChild; i != null; i = i.nextSibling) {
-        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
-          var mo = re.exec(i.tagName);
-          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
-            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
-          }
-          iterate(i);
-        }
-      }
-    }
-    iterate(el);
-    return result;
-  }
-
-  var toc = document.getElementById("toc");
-  if (!toc) {
-    return;
-  }
-
-  // Delete existing TOC entries in case we're reloading the TOC.
-  var tocEntriesToRemove = [];
-  var i;
-  for (i = 0; i < toc.childNodes.length; i++) {
-    var entry = toc.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div'
-     && entry.getAttribute("class")
-     && entry.getAttribute("class").match(/^toclevel/))
-      tocEntriesToRemove.push(entry);
-  }
-  for (i = 0; i < tocEntriesToRemove.length; i++) {
-    toc.removeChild(tocEntriesToRemove[i]);
-  }
-
-  // Rebuild TOC entries.
-  var entries = tocEntries(document.getElementById("content"), toclevels);
-  for (var i = 0; i < entries.length; ++i) {
-    var entry = entries[i];
-    if (entry.element.id == "")
-      entry.element.id = "_toc_" + i;
-    var a = document.createElement("a");
-    a.href = "#" + entry.element.id;
-    a.appendChild(document.createTextNode(entry.text));
-    var div = document.createElement("div");
-    div.appendChild(a);
-    div.className = "toclevel" + entry.toclevel;
-    toc.appendChild(div);
-  }
-  if (entries.length == 0)
-    toc.parentNode.removeChild(toc);
-},
-
-
-/////////////////////////////////////////////////////////////////////
-// Footnotes generator
-/////////////////////////////////////////////////////////////////////
-
-/* Based on footnote generation code from:
- * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
- */
-
-footnotes: function () {
-  // Delete existing footnote entries in case we're reloading the footnodes.
-  var i;
-  var noteholder = document.getElementById("footnotes");
-  if (!noteholder) {
-    return;
-  }
-  var entriesToRemove = [];
-  for (i = 0; i < noteholder.childNodes.length; i++) {
-    var entry = noteholder.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
-      entriesToRemove.push(entry);
-  }
-  for (i = 0; i < entriesToRemove.length; i++) {
-    noteholder.removeChild(entriesToRemove[i]);
-  }
-
-  // Rebuild footnote entries.
-  var cont = document.getElementById("content");
-  var spans = cont.getElementsByTagName("span");
-  var refs = {};
-  var n = 0;
-  for (i=0; i<spans.length; i++) {
-    if (spans[i].className == "footnote") {
-      n++;
-      var note = spans[i].getAttribute("data-note");
-      if (!note) {
-        // Use [\s\S] in place of . so multi-line matches work.
-        // Because JavaScript has no s (dotall) regex flag.
-        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
-        spans[i].innerHTML =
-          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-        spans[i].setAttribute("data-note", note);
-      }
-      noteholder.innerHTML +=
-        "<div class='footnote' id='_footnote_" + n + "'>" +
-        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
-        n + "</a>. " + note + "</div>";
-      var id =spans[i].getAttribute("id");
-      if (id != null) refs["#"+id] = n;
-    }
-  }
-  if (n == 0)
-    noteholder.parentNode.removeChild(noteholder);
-  else {
-    // Process footnoterefs.
-    for (i=0; i<spans.length; i++) {
-      if (spans[i].className == "footnoteref") {
-        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
-        href = href.match(/#.*/)[0];  // Because IE return full URL.
-        n = refs[href];
-        spans[i].innerHTML =
-          "[<a href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-      }
-    }
-  }
-},
-
-install: function(toclevels) {
-  var timerId;
-
-  function reinstall() {
-    asciidoc.footnotes();
-    if (toclevels) {
-      asciidoc.toc(toclevels);
-    }
-  }
-
-  function reinstallAndRemoveTimer() {
-    clearInterval(timerId);
-    reinstall();
-  }
-
-  timerId = setInterval(reinstall, 500);
-  if (document.addEventListener)
-    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
-  else
-    window.onload = reinstallAndRemoveTimer;
-}
-
-}
-asciidoc.install(1);
-/*]]>*/
-</script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_masked_gather_scatter</h1>
-<div id="toc">
-  <div id="toctitle">Table of Contents</div>
-  <noscript><p><b>JavaScript must be enabled in your browser to display the table of contents.</b></p></noscript>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_new_instructions">New Instructions</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_5">Modifications to the SPIR-V Specification, Version 1.5</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
 </div>
 </div>
 <div id="content">
 <div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>SPV_INTEL_masked_gather_scatter</p></div>
+<div class="paragraph">
+<p>SPV_INTEL_masked_gather_scatter</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>To report problems with this extension, please open a new issue at:</p></div>
-<div class="paragraph"><p><a href="https://github.com/KhronosGroup/SPIRV-Registry">https://github.com/KhronosGroup/SPIRV-Registry</a></p></div>
+<div class="paragraph">
+<p>To report problems with this extension, please open a new issue at:</p>
+</div>
+<div class="paragraph">
+<p><a href="https://github.com/KhronosGroup/SPIRV-Registry" class="bare">https://github.com/KhronosGroup/SPIRV-Registry</a></p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Dmitry Sidorov, Intel<br>
-</p>
+<p>Dmitry Sidorov, Intel<br></p>
 </li>
 <li>
-<p>
-Ben Ashbaugh, Intel<br>
-</p>
+<p>Ben Ashbaugh, Intel<br></p>
 </li>
 <li>
-<p>
-Arvind Sudarsanam, Intel<br>
-</p>
+<p>Arvind Sudarsanam, Intel<br></p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Copyright (c) 2023 Intel Corporation.  All rights reserved.</p></div>
+<div class="paragraph">
+<p>Copyright (c) 2023 Intel Corporation.  All rights reserved.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Shipping.
-</p>
+<p>Shipping.</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all"
-style="
-width:40%;
-">
-<col style="width:50%;">
-<col style="width:50%;">
+<table class="tableblock frame-all grid-all" style="width: 40%;">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2023-09-05</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-09-05</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
 </tr>
 </tbody>
 </table>
@@ -851,71 +126,85 @@ width:40%;
 <div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension is written against the SPIR-V Specification,
-Version 1.6 Revision 2.</p></div>
-<div class="paragraph"><p>This extension requires SPIR-V 1.0.</p></div>
+<div class="paragraph">
+<p>This extension is written against the SPIR-V Specification,
+Version 1.6 Revision 2.</p>
+</div>
+<div class="paragraph">
+<p>This extension requires SPIR-V 1.0.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension allows <strong>OpTypeVector</strong> to have a <em>physical pointer type</em> <em>Component Type</em> and introduces gather/scatter instructions.
-These are important operations for many explicitly vectorized kernels.</p></div>
+<div class="paragraph">
+<p>This extension allows <strong>OpTypeVector</strong> to have a <em>physical pointer type</em> <em>Component Type</em> and introduces gather/scatter instructions.
+These are important operations for many explicitly vectorized kernels.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_extension_name">Extension Name</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>To use this extension within a SPIR-V module, the appropriate <strong>OpExtension</strong> must
-be present in the module:</p></div>
+<div class="paragraph">
+<p>To use this extension within a SPIR-V module, the appropriate <strong>OpExtension</strong> must
+be present in the module:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpExtension "SPV_INTEL_masked_gather_scatter"</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_capabilities">New Capabilities</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension introduces new capabilities:</p></div>
+<div class="paragraph">
+<p>This extension introduces new capabilities:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>MaskedGatherScatterINTEL</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_instructions">New Instructions</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Instructions added under the <strong>MaskedGatherScatterINTEL</strong> capability:</p></div>
+<div class="paragraph">
+<p>Instructions added under the <strong>MaskedGatherScatterINTEL</strong> capability:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpMaskedGatherINTEL
 OpMaskedScatterINTEL</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:40%;
-">
-<col style="width:70%;">
-<col style="width:30%;">
+<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<colgroup>
+<col style="width: 70%;">
+<col style="width: 30%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>MaskedGatherScatterINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6427</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>MaskedGatherScatterINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6427</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>OpMaskedGatherINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6428</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>OpMaskedGatherINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6428</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>OpMaskedScatterINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6429</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>OpMaskedScatterINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6429</p></td>
 </tr>
 </tbody>
 </table>
@@ -926,105 +215,126 @@ width:40%;
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_2_2_2_types">2.2.2. Types</h3>
-<div class="paragraph"><p>Update the definition of <em>Vector</em>, adding pointers to the set of supported component types:
+<div class="paragraph">
+<p>Update the definition of <em>Vector</em>, adding pointers to the set of supported component types:
 An ordered homogeneous collection of two or more <em>scalars</em> or pointers of <em>physical pointer type</em>.
-Vector sizes are quite restrictive and dependent on the execution model.</p></div>
+Vector sizes are quite restrictive and dependent on the execution model.</p>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_2_16_1_universal_validation_rules">2.16.1. Universal Validation Rules</h3>
-<div class="paragraph"><p>Modify Data rules section, replacing following segment:</p></div>
-<div class="ulist"><ul>
+<div class="paragraph">
+<p>Modify Data rules section, replacing following segment:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Vector types must be parameterized only with numerical types or the <strong>OpTypeBool</strong> type.
-</p>
+<p>Vector types must be parameterized only with numerical types or the <strong>OpTypeBool</strong> type.</p>
 </li>
-</ul></div>
-<div class="paragraph"><p>with:</p></div>
-<div class="ulist"><ul>
+</ul>
+</div>
+<div class="paragraph">
+<p>with:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Vector types must be parameterized only with numerical types or the <strong>OpTypeBool</strong> type. They can also
- be parameterized with <em>physical pointer type</em> types under <strong>MaskedGatherScatterINTEL</strong> capability.
-</p>
+<p>Vector types must be parameterized only with numerical types or the <strong>OpTypeBool</strong> type. They can also
+be parameterized with <em>physical pointer type</em> types under <strong>MaskedGatherScatterINTEL</strong> capability.</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_capabilities">Capabilities</h3>
-<div class="paragraph"><p>Modify Section 3.31, Capability, adding rows to the Capability table:</p></div>
+<div class="paragraph">
+<p>Modify Section 3.31, Capability, adding rows to the Capability table:</p>
+</div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:33%;">
-<col style="width:33%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-center valign-top" colspan="2" > Capability </th>
-<th class="tableblock halign-center valign-top" > Implicitly Declares</th>
+<th class="tableblock halign-center valign-top" colspan="2">Capability</th>
+<th class="tableblock halign-center valign-top">Implicitly Declares</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6427</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>MaskedGatherScatterINTEL</strong><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6427</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>MaskedGatherScatterINTEL</strong><br>
 <br>
 Allow <strong>OpTypeVector</strong> to have a <em>physical pointer type</em> <em>Component Type</em>.<br>
 <br>
 See also extension: <strong>SPV_INTEL_masked_gather_scatter</strong><br></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>Addresses</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Addresses</strong></p></td>
 </tr>
 </tbody>
 </table>
-</div></div>
+</div>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_3_42_6_type_declaration_instructions">3.42.6. Type-Declaration Instructions</h3>
-<div class="paragraph"><p>Modify <strong>OpTypeVector</strong>, changing the description of <em>Component Type</em> to:
-  <em>Component Type</em> is the type of each component in the resulting type. It must be a <em>scalar type</em> or <em>physical pointer type</em>.</p></div>
+<div class="paragraph">
+<p>Modify <strong>OpTypeVector</strong>, changing the description of <em>Component Type</em> to:
+  <em>Component Type</em> is the type of each component in the resulting type. It must be a <em>scalar type</em> or <em>physical pointer type</em>.</p>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_3_42_7_constant_creation_instructions">3.42.7. Constant-Creation Instructions</h3>
-<div class="paragraph"><p>Modify <strong>OpConstantNull</strong>, allowing <em>Result Type</em> to be a vector of <em>physical pointer type</em>.</p></div>
+<div class="paragraph">
+<p>Modify <strong>OpConstantNull</strong>, allowing <em>Result Type</em> to be a vector of <em>physical pointer type</em>.</p>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_3_42_8_memory_instructions">3.42.8. Memory Instructions</h3>
-<div class="paragraph"><p>Allow <em>vector</em> of <em>physical pointer type</em> to be used by <strong>OpVariable</strong>, <strong>OpAccessChain</strong>, <strong>OpInBoundsAccessChain</strong>,
+<div class="paragraph">
+<p>Allow <em>vector</em> of <em>physical pointer type</em> to be used by <strong>OpVariable</strong>, <strong>OpAccessChain</strong>, <strong>OpInBoundsAccessChain</strong>,
 <strong>OpPtrAccessChain</strong>, <strong>OpInBoundsPtrAccessChain</strong>, <strong>OpPtrEqual</strong>, <strong>OpPtrNotEqual</strong> and <strong>OpPtrDiff</strong> instructions. When <em>vector</em> of
 <em>physical pointer type</em> is allowed for <strong>OpVariable</strong> it is implicitly possible to be used by <strong>OpStore</strong> and <strong>OpLoad</strong> which can
-store/load through a pointer to this vector.</p></div>
-<div class="paragraph"><p>Change the <em>Overview</em> of <strong>OpVariable</strong> as follows:
+store/load through a pointer to this vector.</p>
+</div>
+<div class="paragraph">
+<p>Change the <em>Overview</em> of <strong>OpVariable</strong> as follows:
 Allocate an object or a vector of objects in memory, resulting in a pointer or appropriately a vector of pointers to it,
 which can be used with <strong>OpLoad</strong> and <strong>OpStore</strong>.
 Change the <em>Result Type</em> of <strong>OpVariable</strong> as follows:
 <em>Result Type</em> must be an <strong>OpTypePointer</strong> or a <em>vector</em> with <em>physical pointer type</em> <em>Component Type</em>.
-Its <em>Type</em> operand is the type of object or vector of objects in memory.</p></div>
-<div class="paragraph"><p>Modify <strong>OpAccessChain</strong> (implicitly modifies <strong>OpInBoundsAccessChain</strong>, <strong>OpPtrAccessChain</strong> and <strong>OpInBoundsPtrAccessChain</strong> instructions)
+Its <em>Type</em> operand is the type of object or vector of objects in memory.</p>
+</div>
+<div class="paragraph">
+<p>Modify <strong>OpAccessChain</strong> (implicitly modifies <strong>OpInBoundsAccessChain</strong>, <strong>OpPtrAccessChain</strong> and <strong>OpInBoundsPtrAccessChain</strong> instructions)
 Change the <em>Base</em> as follows:
-<em>Base</em> must be a pointer, pointing to the base of a composite object or a <em>vector</em> of <em>physical pointer type</em>.</p></div>
-<div class="paragraph"><p>Allow <em>vector</em> of <em>physical pointer type</em> to be the type of <em>Operand 1</em> and <em>Operand 2</em> of <strong>OpPtrEqual</strong>, <strong>OpPtrNotEqual</strong> and
+<em>Base</em> must be a pointer, pointing to the base of a composite object or a <em>vector</em> of <em>physical pointer type</em>.</p>
+</div>
+<div class="paragraph">
+<p>Allow <em>vector</em> of <em>physical pointer type</em> to be the type of <em>Operand 1</em> and <em>Operand 2</em> of <strong>OpPtrEqual</strong>, <strong>OpPtrNotEqual</strong> and
 <strong>OpPtrDiff</strong> instructions. If operands are vectors of pointers, then the <em>Result Type</em> of <strong>OpPtrEqual</strong> and <strong>OpPtrNotEqual</strong> is a
-vector with boolean <em>Component Type</em> and <em>Result Type</em> of <strong>OpPtrDiff</strong> is a vector with integer <em>Component Type</em>.</p></div>
-<div class="paragraph"><p>Add the following new entries:</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:5%;">
-<col style="width:5%;">
-<col style="width:15%;">
-<col style="width:15%;">
-<col style="width:15%;">
-<col style="width:15%;">
-<col style="width:15%;">
-<col style="width:15%;">
+vector with boolean <em>Component Type</em> and <em>Result Type</em> of <strong>OpPtrDiff</strong> is a vector with integer <em>Component Type</em>.</p>
+</div>
+<div class="paragraph">
+<p>Add the following new entries:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 5%;">
+<col style="width: 5%;">
+<col style="width: 15%;">
+<col style="width: 15%;">
+<col style="width: 15%;">
+<col style="width: 15%;">
+<col style="width: 15%;">
+<col style="width: 15%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="7" ><p class="tableblock"><a id="OpMaskedGatherINTEL"></a><strong>OpMaskedGatherINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="7"><p class="tableblock"><a id="OpMaskedGatherINTEL"></a><strong>OpMaskedGatherINTEL</strong><br>
 <br>
 Reads values from a vector of pointers gathering them into one vector. Returns the gathered vector. Memory access
 is specified by a mask instruction parameter.<br>
@@ -1043,39 +353,38 @@ any pointer value in <em>PtrVector</em> does not have this alignment.<br>
 <em>PtrVector</em> should be gathered.<br>
 <br>
 <em>FillEmpty</em> is used to fill the masked-off lanes of the result. It must be of the same type as the <em>Component Type</em> of <em>Result Type</em>.<br></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>MaskedGatherScatterINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6428</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6428</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>PtrVector</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;literal&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;literal&gt;</em><br>
 <em>Alignment</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Mask</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>FillEmpty</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:7%;">
-<col style="width:7%;">
-<col style="width:21%;">
-<col style="width:21%;">
-<col style="width:21%;">
-<col style="width:21%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 7.1428%;">
+<col style="width: 7.1428%;">
+<col style="width: 21.4285%;">
+<col style="width: 21.4285%;">
+<col style="width: 21.4285%;">
+<col style="width: 21.4289%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><p class="tableblock"><a id="OpMaskedScatterINTEL"></a><strong>OpMaskedScatterINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><a id="OpMaskedScatterINTEL"></a><strong>OpMaskedScatterINTEL</strong><br>
 <br>
 Writes values from a vector to the corresponding memory address of the given vector of pointers. Memory access
 is specified by a mask instruction parameter.<br>
@@ -1091,19 +400,19 @@ any pointer value in <em>PtrVector</em> does not have this alignment.<br>
 <br>
 <em>Mask</em> is a vector of boolean values with the same number of elements as the <em>InputVector</em>. It specifies which elements of
 <em>InputVector</em> should be scattered.<br></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>MaskedGatherScatterINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6429</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6429</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>InputVector</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>PtrVector</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;literal&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;literal&gt;</em><br>
 <em>Alignment</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Mask</em></p></td>
 </tr>
 </tbody>
@@ -1111,74 +420,84 @@ any pointer value in <em>PtrVector</em> does not have this alignment.<br>
 </div>
 <div class="sect2">
 <h3 id="_3_42_11_conversion_instructions">3.42.11. Conversion Instructions</h3>
-<div class="paragraph"><p>Allow <strong>OpTypeVector</strong> to be <em>Result Type</em> and type of an input for <strong>OpConvertPtrToU</strong>, <strong>OpConvertUToPtr</strong> instructions:
+<div class="paragraph">
+<p>Allow <strong>OpTypeVector</strong> to be <em>Result Type</em> and type of an input for <strong>OpConvertPtrToU</strong>, <strong>OpConvertUToPtr</strong> instructions:
 Change the <em>Result Type</em> of <strong>OpConvertPtrToU</strong> as follows:
-<em>Result Type</em> must be a scalar or vector of <em>integer type</em>, whose Signedness operand is 0.</p></div>
-<div class="paragraph"><p>Change the  <em>Pointer</em> of <strong>OpConvertPtrToU</strong> as follows:
+<em>Result Type</em> must be a scalar or vector of <em>integer type</em>, whose Signedness operand is 0.</p>
+</div>
+<div class="paragraph">
+<p>Change the  <em>Pointer</em> of <strong>OpConvertPtrToU</strong> as follows:
 <em>Pointer</em> must be a <em>physical pointer type</em> or a <em>vector</em> with <em>physical pointer type</em> <em>Component Type</em>.
 If the bit width of <em>Pointer</em> is smaller than that of <em>Result Type</em>, the conversion zero-extends <em>Pointer</em>.
 If the bit width of <em>Pointer</em> is larger than that of <em>Result Type</em>, the conversion truncates Pointer. For
-same bit width Pointer and <em>Result Type</em>, this is the same as <strong>OpBitcast</strong>.</p></div>
-<div class="paragraph"><p>Change the <em>Result Type</em> of <strong>OpConvertUToPtr</strong> as follows:
-<em>Result Type</em> must be a <em>physical pointer type</em> or a <em>vector</em> with <em>physical pointer type</em> <em>Component Type</em>.</p></div>
-<div class="paragraph"><p>Change the <em>Integer Value</em> of <strong>OpConvertUToPtr</strong> as follows:
+same bit width Pointer and <em>Result Type</em>, this is the same as <strong>OpBitcast</strong>.</p>
+</div>
+<div class="paragraph">
+<p>Change the <em>Result Type</em> of <strong>OpConvertUToPtr</strong> as follows:
+<em>Result Type</em> must be a <em>physical pointer type</em> or a <em>vector</em> with <em>physical pointer type</em> <em>Component Type</em>.</p>
+</div>
+<div class="paragraph">
+<p>Change the <em>Integer Value</em> of <strong>OpConvertUToPtr</strong> as follows:
 <em>Integer Value</em> must be a scalar or vector of <em>integer type</em>, whose Signedness operand is 0.
 If the bit width of <em>Integer Value</em> is smaller than that of <em>Result Type</em>, the
 conversion zero-extends <em>Integer Value</em>. If the bit width of <em>Integer Value</em> is larger
 than that of <em>Result Type</em>, the conversion truncates Integer Value. For same width <em>Integer Value</em> and <em>Result Type</em>,
-this is the same as <strong>OpBitcast</strong>.</p></div>
-<div class="paragraph"><p>Allow <em>vector</em> of <em>physical pointer type</em> to be <em>Result Type</em> and type of a <em>Pointer</em> for
-<strong>OpPtrCastToGeneric</strong>, <strong>OpGenericCastToPtr</strong> and <strong>OpGenericCastToPtrExplicit</strong> instructions.</p></div>
-<div class="paragraph"><p>Allow <em>vector</em> of <em>physical pointer type</em> to be <em>Result Type</em> and type of an <em>Operand</em> for <strong>OpBitcast</strong> instruction.</p></div>
+this is the same as <strong>OpBitcast</strong>.</p>
+</div>
+<div class="paragraph">
+<p>Allow <em>vector</em> of <em>physical pointer type</em> to be <em>Result Type</em> and type of a <em>Pointer</em> for
+<strong>OpPtrCastToGeneric</strong>, <strong>OpGenericCastToPtr</strong> and <strong>OpGenericCastToPtrExplicit</strong> instructions.</p>
+</div>
+<div class="paragraph">
+<p>Allow <em>vector</em> of <em>physical pointer type</em> to be <em>Result Type</em> and type of an <em>Operand</em> for <strong>OpBitcast</strong> instruction.</p>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_3_42_12_composite_instructions">3.42.12. Composite Instructions</h3>
-<div class="paragraph"><p>Most of the Composite Instructions that are supposed to work with vector type do not have any restrictions about <em>Component Type</em>.
-This extension allows these instructions to operate on <em>vector</em> of <em>physical pointer type</em>.</p></div>
-<div class="paragraph"><p>Allow <em>physical pointer type</em> to be a <em>Result Type</em> of <strong>OpVectorExtractDynamic</strong>.</p></div>
+<div class="paragraph">
+<p>Most of the Composite Instructions that are supposed to work with vector type do not have any restrictions about <em>Component Type</em>.
+This extension allows these instructions to operate on <em>vector</em> of <em>physical pointer type</em>.</p>
+</div>
+<div class="paragraph">
+<p>Allow <em>physical pointer type</em> to be a <em>Result Type</em> of <strong>OpVectorExtractDynamic</strong>.</p>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_issues">Issues</h3>
-<div class="paragraph"><p>None</p></div>
+<div class="paragraph">
+<p>None</p>
+</div>
 </div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:100%;
-">
-<col style="width:4%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:66%;">
+<table class="tableblock frame-all grid-rows stretch">
+<colgroup>
+<col style="width: 4.7619%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" >Rev</th>
-<th class="tableblock halign-left valign-top" >Date</th>
-<th class="tableblock halign-left valign-top" >Author</th>
-<th class="tableblock halign-left valign-top" >Changes</th>
+<th class="tableblock halign-left valign-top">Rev</th>
+<th class="tableblock halign-left valign-top">Date</th>
+<th class="tableblock halign-left valign-top">Author</th>
+<th class="tableblock halign-left valign-top">Changes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2023-09-05</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Dmitry Sidorov</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Prepare to ship</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-09-05</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Dmitry Sidorov</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Prepare to ship</p></td>
 </tr>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footnotes"><hr></div>
-<div id="footer">
-<div id="footer-text">
-Last updated
- 2023-11-29 04:15:40 PST
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_maximum_registers.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_maximum_registers.asciidoc
@@ -101,17 +101,17 @@ invocation.
 This is a performance hint only.
 If the specified number of registers is not supported then the compiler may
 choose the closest number of supported registers or may ignore the request.
-3+| 'Literal' +
-'Number of Registers'
+3+| _Literal_ +
+_Number of Registers_
 | *RegisterLimitsINTEL*
 
 | {maximum_registers_id_token} | *MaximumRegistersIdINTEL* +
-Same as the *MaximumRegistersINTEL* execution mode but using an '<id>'
+Same as the *MaximumRegistersINTEL* execution mode but using an _<id>_
 operand instead of a literal.
 The operand must be an integer type scalar and is interpreted as an unsigned
 value.
-3+| '<id>' +
-'Number of Registers'
+3+| _<id>_ +
+_Number of Registers_
 | *RegisterLimitsINTEL*
 
 | {named_maximum_registers_token} | *NamedMaximumRegistersINTEL* +
@@ -119,8 +119,8 @@ Specifies the maximum number of registers to be allocated to a single invocation
 using a named policy rather than a specific numeric number of registers.
 This is a performance hint only.
 If the named policy is not supported then the compiler may ignore the request.
-3+| <<NamedMaxNumberOfRegisters,'Named Maximum Number of Registers'>> +
-'Named Maximum Number of Registers'
+3+| <<NamedMaxNumberOfRegisters,_Named Maximum Number of Registers_>> +
+_Named Maximum Number of Registers_
 | *RegisterLimitsINTEL*
 |====
 
@@ -145,7 +145,7 @@ Choose the maximum number of registers automatically to minimize register spills
 
 == Issues
 
-. Do we need to support both the 'literal' and '<id>' execution modes?
+. Do we need to support both the _literal_ and _<id>_ execution modes?
 +
 --
 *RESOLVED*: Because different devices may support differently sized register

--- a/extensions/INTEL/SPV_INTEL_maximum_registers.html
+++ b/extensions/INTEL/SPV_INTEL_maximum_registers.html
@@ -1,843 +1,118 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta name="generator" content="AsciiDoc 10.2.0">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_maximum_registers</title>
-<style type="text/css">
-/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
-
-/* Default font. */
-body {
-  font-family: Georgia,serif;
-}
-
-/* Title font. */
-h1, h2, h3, h4, h5, h6,
-div.title, caption.title,
-thead, p.table.header,
-#toctitle,
-#author, #revnumber, #revdate, #revremark,
-#footer {
-  font-family: Arial,Helvetica,sans-serif;
-}
-
-body {
-  margin: 1em 5% 1em 5%;
-}
-
-a {
-  color: blue;
-  text-decoration: underline;
-}
-a:visited {
-  color: fuchsia;
-}
-
-em {
-  font-style: italic;
-  color: navy;
-}
-
-strong {
-  font-weight: bold;
-  color: #083194;
-}
-
-h1, h2, h3, h4, h5, h6 {
-  color: #527bbd;
-  margin-top: 1.2em;
-  margin-bottom: 0.5em;
-  line-height: 1.3;
-}
-
-h1, h2, h3 {
-  border-bottom: 2px solid silver;
-}
-h2 {
-  padding-top: 0.5em;
-}
-h3 {
-  float: left;
-}
-h3 + * {
-  clear: left;
-}
-h5 {
-  font-size: 1.0em;
-}
-
-div.sectionbody {
-  margin-left: 0;
-}
-
-hr {
-  border: 1px solid silver;
-}
+<style>
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
 
 p {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
 }
 
-ul, ol, li > p {
-  margin-top: 0;
-}
-ul > li     { color: #aaa; }
-ul > li > * { color: black; }
-
-.monospaced, code, pre {
-  font-family: "Courier New", Courier, monospace;
-  font-size: inherit;
-  color: navy;
-  padding: 0;
-  margin: 0;
-}
-pre {
-  white-space: pre-wrap;
-}
-
-#author {
-  color: #527bbd;
-  font-weight: bold;
-  font-size: 1.1em;
-}
-#email {
-}
-#revnumber, #revdate, #revremark {
-}
-
-#footer {
-  font-size: small;
-  border-top: 2px solid silver;
-  padding-top: 0.5em;
-  margin-top: 4.0em;
-}
-#footer-text {
-  float: left;
-  padding-bottom: 0.5em;
-}
-#footer-badges {
-  float: right;
-  padding-bottom: 0.5em;
-}
-
-#preamble {
-  margin-top: 1.5em;
-  margin-bottom: 1.5em;
-}
-div.imageblock, div.exampleblock, div.verseblock,
-div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
-div.admonitionblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.admonitionblock {
-  margin-top: 2.0em;
-  margin-bottom: 2.0em;
-  margin-right: 10%;
-  color: #606060;
-}
-
-div.content { /* Block element content. */
-  padding: 0;
-}
-
-/* Block element titles. */
-div.title, caption.title {
-  color: #527bbd;
-  font-weight: bold;
-  text-align: left;
-  margin-top: 1.0em;
-  margin-bottom: 0.5em;
-}
-div.title + * {
-  margin-top: 0;
-}
-
-td div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content + div.title {
-  margin-top: 0.0em;
-}
-
-div.sidebarblock > div.content {
-  background: #ffffee;
-  border: 1px solid #dddddd;
-  border-left: 4px solid #f0f0f0;
-  padding: 0.5em;
-}
-
-div.listingblock > div.content {
-  border: 1px solid #dddddd;
-  border-left: 5px solid #f0f0f0;
-  background: #f8f8f8;
-  padding: 0.5em;
-}
-
-div.quoteblock, div.verseblock {
-  padding-left: 1.0em;
-  margin-left: 1.0em;
-  margin-right: 10%;
-  border-left: 5px solid #f0f0f0;
-  color: #888;
-}
-
-div.quoteblock > div.attribution {
-  padding-top: 0.5em;
-  text-align: right;
-}
-
-div.verseblock > pre.content {
-  font-family: inherit;
-  font-size: inherit;
-}
-div.verseblock > div.attribution {
-  padding-top: 0.75em;
-  text-align: left;
-}
-/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
-div.verseblock + div.attribution {
-  text-align: left;
-}
-
-div.admonitionblock .icon {
-  vertical-align: top;
-  font-size: 1.1em;
-  font-weight: bold;
-  text-decoration: underline;
-  color: #527bbd;
-  padding-right: 0.5em;
-}
-div.admonitionblock td.content {
-  padding-left: 0.5em;
-  border-left: 3px solid #dddddd;
-}
-
-div.exampleblock > div.content {
-  border-left: 3px solid #dddddd;
-  padding-left: 0.5em;
-}
-
-div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; vertical-align: text-bottom; }
-a.image:visited { color: white; }
-
-dl {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-dt {
-  margin-top: 0.5em;
-  margin-bottom: 0;
-  font-style: normal;
-  color: navy;
-}
-dd > *:first-child {
-  margin-top: 0.1em;
-}
-
-ul, ol {
-    list-style-position: outside;
-}
-ol.arabic {
-  list-style-type: decimal;
-}
-ol.loweralpha {
-  list-style-type: lower-alpha;
-}
-ol.upperalpha {
-  list-style-type: upper-alpha;
-}
-ol.lowerroman {
-  list-style-type: lower-roman;
-}
-ol.upperroman {
-  list-style-type: upper-roman;
-}
-
-div.compact ul, div.compact ol,
-div.compact p, div.compact p,
-div.compact div, div.compact div {
-  margin-top: 0.1em;
-  margin-bottom: 0.1em;
-}
-
-tfoot {
-  font-weight: bold;
-}
-td > div.verse {
-  white-space: pre;
-}
-
-div.hdlist {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-div.hdlist tr {
-  padding-bottom: 15px;
-}
-dt.hdlist1.strong, td.hdlist1.strong {
-  font-weight: bold;
-}
-td.hdlist1 {
-  vertical-align: top;
-  font-style: normal;
-  padding-right: 0.8em;
-  color: navy;
-}
-td.hdlist2 {
-  vertical-align: top;
-}
-div.hdlist.compact tr {
-  margin: 0;
-  padding-bottom: 0;
-}
-
-.comment {
-  background: yellow;
-}
-
-.footnote, .footnoteref {
-  font-size: 0.8em;
-}
-
-span.footnote, span.footnoteref {
-  vertical-align: super;
-}
-
-#footnotes {
-  margin: 20px 0 20px 0;
-  padding: 7px 0 0 0;
-}
-
-#footnotes div.footnote {
-  margin: 0 0 5px 0;
-}
-
-#footnotes hr {
-  border: none;
-  border-top: 1px solid silver;
-  height: 1px;
-  text-align: left;
-  margin-left: 0;
-  width: 20%;
-  min-width: 100px;
-}
-
-div.colist td {
-  padding-right: 0.5em;
-  padding-bottom: 0.3em;
-  vertical-align: top;
-}
-div.colist td img {
-  margin-top: 0.3em;
-}
-
-@media print {
-  #footer-badges { display: none; }
-}
-
-#toc {
-  margin-bottom: 2.5em;
-}
-
-#toctitle {
-  color: #527bbd;
-  font-size: 1.1em;
-  font-weight: bold;
-  margin-top: 1.0em;
-  margin-bottom: 0.1em;
-}
-
-div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-div.toclevel2 {
-  margin-left: 2em;
-  font-size: 0.9em;
-}
-div.toclevel3 {
-  margin-left: 4em;
-  font-size: 0.9em;
-}
-div.toclevel4 {
-  margin-left: 6em;
-  font-size: 0.9em;
-}
-
-span.aqua { color: aqua; }
-span.black { color: black; }
-span.blue { color: blue; }
-span.fuchsia { color: fuchsia; }
-span.gray { color: gray; }
-span.green { color: green; }
-span.lime { color: lime; }
-span.maroon { color: maroon; }
-span.navy { color: navy; }
-span.olive { color: olive; }
-span.purple { color: purple; }
-span.red { color: red; }
-span.silver { color: silver; }
-span.teal { color: teal; }
-span.white { color: white; }
-span.yellow { color: yellow; }
-
-span.aqua-background { background: aqua; }
-span.black-background { background: black; }
-span.blue-background { background: blue; }
-span.fuchsia-background { background: fuchsia; }
-span.gray-background { background: gray; }
-span.green-background { background: green; }
-span.lime-background { background: lime; }
-span.maroon-background { background: maroon; }
-span.navy-background { background: navy; }
-span.olive-background { background: olive; }
-span.purple-background { background: purple; }
-span.red-background { background: red; }
-span.silver-background { background: silver; }
-span.teal-background { background: teal; }
-span.white-background { background: white; }
-span.yellow-background { background: yellow; }
-
-span.big { font-size: 2em; }
-span.small { font-size: 0.6em; }
-
-span.underline { text-decoration: underline; }
-span.overline { text-decoration: overline; }
-span.line-through { text-decoration: line-through; }
-
-div.unbreakable { page-break-inside: avoid; }
-
-
-/*
- * xhtml11 specific
- *
- * */
-
-div.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.tableblock > table {
-  border: 3px solid #527bbd;
-}
-thead, p.table.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.table {
-  margin-top: 0;
-}
-/* Because the table frame attribute is overridden by CSS in most browsers. */
-div.tableblock > table[frame="void"] {
-  border-style: none;
-}
-div.tableblock > table[frame="hsides"] {
-  border-left-style: none;
-  border-right-style: none;
-}
-div.tableblock > table[frame="vsides"] {
-  border-top-style: none;
-  border-bottom-style: none;
-}
-
-
-/*
- * html5 specific
- *
- * */
-
-table.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-thead, p.tableblock.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.tableblock {
-  margin-top: 0;
-}
-table.tableblock {
-  border-width: 3px;
-  border-spacing: 0px;
-  border-style: solid;
-  border-color: #527bbd;
-  border-collapse: collapse;
-}
-th.tableblock, td.tableblock {
-  border-width: 1px;
-  padding: 4px;
-  border-style: solid;
-  border-color: #527bbd;
-}
-
-table.tableblock.frame-topbot {
-  border-left-style: hidden;
-  border-right-style: hidden;
-}
-table.tableblock.frame-sides {
-  border-top-style: hidden;
-  border-bottom-style: hidden;
-}
-table.tableblock.frame-none {
-  border-style: hidden;
-}
-
-th.tableblock.halign-left, td.tableblock.halign-left {
-  text-align: left;
-}
-th.tableblock.halign-center, td.tableblock.halign-center {
-  text-align: center;
-}
-th.tableblock.halign-right, td.tableblock.halign-right {
-  text-align: right;
-}
-
-th.tableblock.valign-top, td.tableblock.valign-top {
-  vertical-align: top;
-}
-th.tableblock.valign-middle, td.tableblock.valign-middle {
-  vertical-align: middle;
-}
-th.tableblock.valign-bottom, td.tableblock.valign-bottom {
-  vertical-align: bottom;
-}
-
-
-/*
- * manpage specific
- *
- * */
-
-body.manpage h1 {
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
-  border-top: 2px solid silver;
-  border-bottom: 2px solid silver;
-}
-body.manpage h2 {
-  border-style: none;
-}
-body.manpage div.sectionbody {
-  margin-left: 3em;
-}
-
-@media print {
-  body.manpage div#toc { display: none; }
-}
-
-
-@media screen {
-  body {
-    max-width: 50em; /* approximately 80 characters wide */
-    margin-left: 16em;
-  }
-
-  #toc {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 13em;
-    padding: 0.5em;
-    padding-bottom: 1.5em;
-    margin: 0;
-    overflow: auto;
-    border-right: 3px solid #f8f8f8;
-    background-color: white;
-  }
-
-  #toc .toclevel1 {
-    margin-top: 0.5em;
-  }
-
-  #toc .toclevel2 {
-    margin-top: 0.25em;
-    display: list-item;
-    color: #aaaaaa;
-  }
-
-  #toctitle {
-    margin-top: 0.5em;
-  }
-}
 </style>
-<script type="text/javascript">
-/*<![CDATA[*/
-var asciidoc = {  // Namespace.
-
-/////////////////////////////////////////////////////////////////////
-// Table Of Contents generator
-/////////////////////////////////////////////////////////////////////
-
-/* Author: Mihai Bazon, September 2002
- * http://students.infoiasi.ro/~mishoo
- *
- * Table Of Content generator
- * Version: 0.4
- *
- * Feel free to use this script under the terms of the GNU General Public
- * License, as long as you do not remove or alter this notice.
- */
-
- /* modified by Troy D. Hanson, September 2006. License: GPL */
- /* modified by Stuart Rackham, 2006, 2009. License: GPL */
-
-// toclevels = 1..4.
-toc: function (toclevels) {
-
-  function getText(el) {
-    var text = "";
-    for (var i = el.firstChild; i != null; i = i.nextSibling) {
-      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
-        text += i.data;
-      else if (i.firstChild != null)
-        text += getText(i);
-    }
-    return text;
-  }
-
-  function TocEntry(el, text, toclevel) {
-    this.element = el;
-    this.text = text;
-    this.toclevel = toclevel;
-  }
-
-  function tocEntries(el, toclevels) {
-    var result = new Array;
-    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
-    // Function that scans the DOM tree for header elements (the DOM2
-    // nodeIterator API would be a better technique but not supported by all
-    // browsers).
-    var iterate = function (el) {
-      for (var i = el.firstChild; i != null; i = i.nextSibling) {
-        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
-          var mo = re.exec(i.tagName);
-          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
-            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
-          }
-          iterate(i);
-        }
-      }
-    }
-    iterate(el);
-    return result;
-  }
-
-  var toc = document.getElementById("toc");
-  if (!toc) {
-    return;
-  }
-
-  // Delete existing TOC entries in case we're reloading the TOC.
-  var tocEntriesToRemove = [];
-  var i;
-  for (i = 0; i < toc.childNodes.length; i++) {
-    var entry = toc.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div'
-     && entry.getAttribute("class")
-     && entry.getAttribute("class").match(/^toclevel/))
-      tocEntriesToRemove.push(entry);
-  }
-  for (i = 0; i < tocEntriesToRemove.length; i++) {
-    toc.removeChild(tocEntriesToRemove[i]);
-  }
-
-  // Rebuild TOC entries.
-  var entries = tocEntries(document.getElementById("content"), toclevels);
-  for (var i = 0; i < entries.length; ++i) {
-    var entry = entries[i];
-    if (entry.element.id == "")
-      entry.element.id = "_toc_" + i;
-    var a = document.createElement("a");
-    a.href = "#" + entry.element.id;
-    a.appendChild(document.createTextNode(entry.text));
-    var div = document.createElement("div");
-    div.appendChild(a);
-    div.className = "toclevel" + entry.toclevel;
-    toc.appendChild(div);
-  }
-  if (entries.length == 0)
-    toc.parentNode.removeChild(toc);
-},
-
-
-/////////////////////////////////////////////////////////////////////
-// Footnotes generator
-/////////////////////////////////////////////////////////////////////
-
-/* Based on footnote generation code from:
- * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
- */
-
-footnotes: function () {
-  // Delete existing footnote entries in case we're reloading the footnodes.
-  var i;
-  var noteholder = document.getElementById("footnotes");
-  if (!noteholder) {
-    return;
-  }
-  var entriesToRemove = [];
-  for (i = 0; i < noteholder.childNodes.length; i++) {
-    var entry = noteholder.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
-      entriesToRemove.push(entry);
-  }
-  for (i = 0; i < entriesToRemove.length; i++) {
-    noteholder.removeChild(entriesToRemove[i]);
-  }
-
-  // Rebuild footnote entries.
-  var cont = document.getElementById("content");
-  var spans = cont.getElementsByTagName("span");
-  var refs = {};
-  var n = 0;
-  for (i=0; i<spans.length; i++) {
-    if (spans[i].className == "footnote") {
-      n++;
-      var note = spans[i].getAttribute("data-note");
-      if (!note) {
-        // Use [\s\S] in place of . so multi-line matches work.
-        // Because JavaScript has no s (dotall) regex flag.
-        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
-        spans[i].innerHTML =
-          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-        spans[i].setAttribute("data-note", note);
-      }
-      noteholder.innerHTML +=
-        "<div class='footnote' id='_footnote_" + n + "'>" +
-        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
-        n + "</a>. " + note + "</div>";
-      var id =spans[i].getAttribute("id");
-      if (id != null) refs["#"+id] = n;
-    }
-  }
-  if (n == 0)
-    noteholder.parentNode.removeChild(noteholder);
-  else {
-    // Process footnoterefs.
-    for (i=0; i<spans.length; i++) {
-      if (spans[i].className == "footnoteref") {
-        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
-        href = href.match(/#.*/)[0];  // Because IE return full URL.
-        n = refs[href];
-        spans[i].innerHTML =
-          "[<a href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-      }
-    }
-  }
-},
-
-install: function(toclevels) {
-  var timerId;
-
-  function reinstall() {
-    asciidoc.footnotes();
-    if (toclevels) {
-      asciidoc.toc(toclevels);
-    }
-  }
-
-  function reinstallAndRemoveTimer() {
-    clearInterval(timerId);
-    reinstall();
-  }
-
-  timerId = setInterval(reinstall, 500);
-  if (document.addEventListener)
-    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
-  else
-    window.onload = reinstallAndRemoveTimer;
-}
-
-}
-asciidoc.install(1);
-/*]]>*/
-</script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_maximum_registers</h1>
-<div id="toc">
-  <div id="toctitle">Table of Contents</div>
-  <noscript><p><b>JavaScript must be enabled in your browser to display the table of contents.</b></p></noscript>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification, Version 1.6</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
 </div>
 </div>
 <div id="content">
 <div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>SPV_INTEL_maximum_registers</p></div>
+<div class="paragraph">
+<p>SPV_INTEL_maximum_registers</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>To report problems with this extension, please open a new issue at:</p></div>
-<div class="paragraph"><p><a href="https://github.com/KhronosGroup/SPIRV-Registry">https://github.com/KhronosGroup/SPIRV-Registry</a></p></div>
+<div class="paragraph">
+<p>To report problems with this extension, please open a new issue at:</p>
+</div>
+<div class="paragraph">
+<p><a href="https://github.com/KhronosGroup/SPIRV-Registry" class="bare">https://github.com/KhronosGroup/SPIRV-Registry</a></p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Ben Ashbaugh, Intel<br>
-</p>
+<p>Ben Ashbaugh, Intel<br></p>
 </li>
 <li>
-<p>
-Greg Lueck, Intel<br>
-</p>
+<p>Greg Lueck, Intel<br></p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Copyright (c) 2024 Intel Corporation.  All rights reserved.</p></div>
+<div class="paragraph">
+<p>Copyright (c) 2024 Intel Corporation.  All rights reserved.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Complete
-</p>
+<p>Complete</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all"
-style="
-width:40%;
-">
-<col style="width:50%;">
-<col style="width:50%;">
+<table class="tableblock frame-all grid-all" style="width: 40%;">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2024-02-12</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-21</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
 </tr>
 </tbody>
 </table>
@@ -846,29 +121,38 @@ width:40%;
 <div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension is written against the SPIR-V Specification, Version 1.6 Revision
-3.</p></div>
-<div class="paragraph"><p>This extension requires SPIR-V 1.0.</p></div>
+<div class="paragraph">
+<p>This extension is written against the SPIR-V Specification, Version 1.6 Revision
+3.</p>
+</div>
+<div class="paragraph">
+<p>This extension requires SPIR-V 1.0.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension adds an execution mode to specify the maximum number of registers
+<div class="paragraph">
+<p>This extension adds an execution mode to specify the maximum number of registers
 a SPIR-V consumer should use when compiling an entry point.
 This is a hint only that does not modify the functional behavior of the program,
-but can change its performance characteristics.</p></div>
+but can change its performance characteristics.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_extension_name">Extension Name</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>To use this extension within a SPIR-V module, the appropriate <strong>OpExtension</strong> must
-be present in the module:</p></div>
+<div class="paragraph">
+<p>To use this extension within a SPIR-V module, the appropriate <strong>OpExtension</strong> must
+be present in the module:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpExtension "SPV_INTEL_maximum_registers"</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -876,232 +160,241 @@ be present in the module:</p></div>
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_validation_rules">Validation Rules</h3>
-<div class="paragraph"><p>Add validation rules to section 2.16.1 Universal Validation Rules under Entry Point:</p></div>
-<div class="ulist"><ul>
+<div class="paragraph">
+<p>Add validation rules to section 2.16.1 Universal Validation Rules under Entry Point:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Each <strong>OpEntryPoint</strong> must contain at most one of the
+<p>Each <strong>OpEntryPoint</strong> must contain at most one of the
 <strong>MaximumRegistersINTEL</strong>, <strong>MaximumRegistersIdINTEL</strong>, or
-<strong>NamedMaximumRegistersINTEL</strong> execution modes.
-</p>
+<strong>NamedMaximumRegistersINTEL</strong> execution modes.</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_capabilities">Capabilities</h3>
-<div class="paragraph"><p>Modify Section 3.31, Capability, adding rows to the Capability table:</p></div>
+<div class="paragraph">
+<p>Modify Section 3.31, Capability, adding rows to the Capability table:</p>
+</div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:11%;">
-<col style="width:55%;">
-<col style="width:33%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 11.1111%;">
+<col style="width: 55.5555%;">
+<col style="width: 33.3334%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-center valign-middle" colspan="2" > Capability </th>
-<th class="tableblock halign-center valign-top" > Implicitly Declares</th>
+<th class="tableblock halign-center valign-middle" colspan="2">Capability</th>
+<th class="tableblock halign-center valign-top">Implicitly Declares</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-center valign-middle" ><p class="tableblock">6460</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>RegisterLimitsINTEL</strong><br>
+<td class="tableblock halign-center valign-middle"><p class="tableblock">6460</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>RegisterLimitsINTEL</strong><br>
 Specifies the maximum number of registers that may be used by an entry point.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
+<td class="tableblock halign-left valign-top"></td>
 </tr>
 </tbody>
 </table>
-</div></div>
+</div>
+</div>
 </div>
 <div class="sect2">
 <h3 id="_execution_modes">Execution Modes</h3>
-<div class="paragraph"><p>Modify Section 3.6, Execution Mode, adding rows to the Execution Mode table:</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:6%;">
-<col style="width:32%;">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:8%;">
-<col style="width:36%;">
+<div class="paragraph">
+<p>Modify Section 3.6, Execution Mode, adding rows to the Execution Mode table:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 6.5573%;">
+<col style="width: 32.7868%;">
+<col style="width: 8.1967%;">
+<col style="width: 8.1967%;">
+<col style="width: 8.1967%;">
+<col style="width: 36.0658%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-center valign-middle" colspan="2" > Execution Mode </th>
-<th class="tableblock halign-left valign-middle" colspan="3" > Extra Operands</th>
-<th class="tableblock halign-left valign-top" > Enabling Capabilities</th>
+<th class="tableblock halign-center valign-middle" colspan="2">Execution Mode</th>
+<th class="tableblock halign-left valign-middle" colspan="3">Extra Operands</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-center valign-top" ><p class="tableblock">6461</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>MaximumRegistersINTEL</strong><br>
+<td class="tableblock halign-center valign-top"><p class="tableblock">6461</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>MaximumRegistersINTEL</strong><br>
 Specifies the maximum number of registers to be allocated to a single
 invocation.
 This is a performance hint only.
 If the specified number of registers is not supported then the compiler may
 choose the closest number of supported registers or may ignore the request.</p></td>
-<td class="tableblock halign-left valign-top" colspan="3" ><p class="tableblock"><em>Literal</em><br>
+<td class="tableblock halign-left valign-top" colspan="3"><p class="tableblock"><em>Literal</em><br>
 <em>Number of Registers</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>RegisterLimitsINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>RegisterLimitsINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-center valign-top" ><p class="tableblock">6462</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>MaximumRegistersIdINTEL</strong><br>
+<td class="tableblock halign-center valign-top"><p class="tableblock">6462</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>MaximumRegistersIdINTEL</strong><br>
 Same as the <strong>MaximumRegistersINTEL</strong> execution mode but using an <em>&lt;id&gt;</em>
 operand instead of a literal.
 The operand must be an integer type scalar and is interpreted as an unsigned
 value.</p></td>
-<td class="tableblock halign-left valign-top" colspan="3" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top" colspan="3"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Number of Registers</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>RegisterLimitsINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>RegisterLimitsINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-center valign-top" ><p class="tableblock">6463</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>NamedMaximumRegistersINTEL</strong><br>
+<td class="tableblock halign-center valign-top"><p class="tableblock">6463</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>NamedMaximumRegistersINTEL</strong><br>
 Specifies the maximum number of registers to be allocated to a single invocation
 using a named policy rather than a specific numeric number of registers.
 This is a performance hint only.
 If the named policy is not supported then the compiler may ignore the request.</p></td>
-<td class="tableblock halign-left valign-top" colspan="3" ><p class="tableblock"><a href="#NamedMaxNumberOfRegisters"><em>Named Maximum Number of Registers</em></a><br>
+<td class="tableblock halign-left valign-top" colspan="3"><p class="tableblock"><a href="#NamedMaxNumberOfRegisters"><em>Named Maximum Number of Registers</em></a><br>
 <em>Named Maximum Number of Registers</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>RegisterLimitsINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>RegisterLimitsINTEL</strong></p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect2">
-<h3 id="_a_id_namedmaxnumberofregisters_a_named_maximum_number_of_registers"><a id="NamedMaxNumberOfRegisters"></a>Named Maximum Number of Registers</h3>
-<div class="paragraph"><p>Add a new Section 3.XX, "Named Maximum Number of Registers":</p></div>
-<div class="paragraph"><p>Specify the maximum number of registers using a named policy.
+<h3 id="_named_maximum_number_of_registers"><a id="NamedMaxNumberOfRegisters"></a>Named Maximum Number of Registers</h3>
+<div class="paragraph">
+<p>Add a new Section 3.XX, "Named Maximum Number of Registers":</p>
+</div>
+<div class="paragraph">
+<p>Specify the maximum number of registers using a named policy.
 A named maximum number of registers policy is a symbolic name describing
 desired properties that may influence the maximum number of registers allocated
-to a single invocation.</p></div>
+to a single invocation.</p>
+</div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:11%;">
-<col style="width:45%;">
-<col style="width:42%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 11.4285%;">
+<col style="width: 45.7142%;">
+<col style="width: 42.8573%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-center valign-middle" colspan="2" > Named Maximum Number of Registers </th>
-<th class="tableblock halign-left valign-top" > Enabling Capabilities</th>
+<th class="tableblock halign-center valign-middle" colspan="2">Named Maximum Number of Registers</th>
+<th class="tableblock halign-left valign-top">Enabling Capabilities</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-center valign-middle" ><p class="tableblock">0</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>AutoINTEL</strong><br>
+<td class="tableblock halign-center valign-middle"><p class="tableblock">0</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>AutoINTEL</strong><br>
 Choose the maximum number of registers automatically to minimize register spills.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>RegisterLimitsINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>RegisterLimitsINTEL</strong></p></td>
 </tr>
 </tbody>
 </table>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="olist arabic"><ol class="arabic">
+<div class="olist arabic">
+<ol class="arabic">
 <li>
-<p>
-Do we need to support both the <em>literal</em> and <em>&lt;id&gt;</em> execution modes?
-</p>
+<p>Do we need to support both the <em>literal</em> and <em>&lt;id&gt;</em> execution modes?</p>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p><strong>RESOLVED</strong>: Because different devices may support differently sized register
+<div class="paragraph">
+<p><strong>RESOLVED</strong>: Because different devices may support differently sized register
 files it is valuable to support specifying the maximum number of registers
-using a specialization constant.</p></div>
-</div></div>
+using a specialization constant.</p>
+</div>
+</div>
+</div>
 </li>
 <li>
-<p>
-Should we support other "performance tuning directives" in addition to the
-maximum number of registers?
-</p>
+<p>Should we support other "performance tuning directives" in addition to the
+maximum number of registers?</p>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p><strong>RESOLVED</strong>: Not in this extension.</p></div>
-</div></div>
+<div class="paragraph">
+<p><strong>RESOLVED</strong>: Not in this extension.</p>
+</div>
+</div>
+</div>
 </li>
 <li>
-<p>
-What should behavior be when no maximum number of registers is specified for
-an entry point?
-</p>
+<p>What should behavior be when no maximum number of registers is specified for
+an entry point?</p>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p><strong>RESOLVED</strong>: This is outside of the scope of this extension, but for informative
+<div class="paragraph">
+<p><strong>RESOLVED</strong>: This is outside of the scope of this extension, but for informative
 purposes: behavior should be considered implementation-defined when no explicit
 maximum number of registers is specified for an entry point.  Some possible
 valid implementations could be: the compiler chooses a fixed number of registers
 for simplicity and predictability, or the compiler chooses a number of registers
-based on heuristics to balance parallelism and register spills.</p></div>
-</div></div>
+based on heuristics to balance parallelism and register spills.</p>
+</div>
+</div>
+</div>
 </li>
 <li>
-<p>
-What should the named maximum number of register policy be in the initial
-version of this extension?
-</p>
+<p>What should the named maximum number of register policy be in the initial
+version of this extension?</p>
 <div class="openblock">
 <div class="content">
-<div class="paragraph"><p><strong>RESOLVED</strong>: The name is colloquially known as "auto" therefore it is the name
-that is used currently.</p></div>
-<div class="paragraph"><p>Note that the behavior is implementation-defined both with this named policy and
+<div class="paragraph">
+<p><strong>RESOLVED</strong>: The name is colloquially known as "auto" therefore it is the name
+that is used currently.</p>
+</div>
+<div class="paragraph">
+<p>Note that the behavior is implementation-defined both with this named policy and
 when the entry point does not describe any specific maximum number of registers,
-although it is a <strong>different</strong> implementation, at least for current Intel GPUs.</p></div>
-</div></div>
+although it is a <strong>different</strong> implementation, at least for current Intel GPUs.</p>
+</div>
+</div>
+</div>
 </li>
-</ol></div>
+</ol>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:100%;
-">
-<col style="width:4%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:66%;">
+<table class="tableblock frame-all grid-rows stretch">
+<colgroup>
+<col style="width: 4.7619%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" >Rev</th>
-<th class="tableblock halign-left valign-top" >Date</th>
-<th class="tableblock halign-left valign-top" >Author</th>
-<th class="tableblock halign-left valign-top" >Changes</th>
+<th class="tableblock halign-left valign-top">Rev</th>
+<th class="tableblock halign-left valign-top">Date</th>
+<th class="tableblock halign-left valign-top">Author</th>
+<th class="tableblock halign-left valign-top">Changes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2024-02-05</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Initial public revision.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-05</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Initial public revision.</p></td>
 </tr>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footnotes"><hr></div>
-<div id="footer">
-<div id="footer-text">
-Last updated
- 2024-02-12 16:25:00 PST
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_media_block_io.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_media_block_io.asciidoc
@@ -112,44 +112,44 @@ Modify Section 3.32.21, Group Instructions, adding to the end of the list of ins
 |=====
 7+|[[OpSubgroupImageMediaBlockReadINTEL]]*OpSubgroupImageMediaBlockReadINTEL* +
  +
-Reads a block of data from a 2D region of the specified 'Image'.
+Reads a block of data from a 2D region of the specified _Image_.
 
-'Image' must be an object whose type is *OpTypeImage* with a 'Sampled' operand of 0 or 2.
+_Image_ must be an object whose type is *OpTypeImage* with a _Sampled_ operand of 0 or 2.
 
-The 'Result Type' is used to compute the maximum size of the 2D region that may be read, and may be a scalar or a vector type.  For this description, the block read 'Component Type' is defined as the 'Result Type' if 'Result Type' is a scalar type, or as the vector 'Component Type' if 'Result Type' is a vector type.
+The _Result Type_ is used to compute the maximum size of the 2D region that may be read, and may be a scalar or a vector type.  For this description, the block read _Component Type_ is defined as the _Result Type_ if _Result Type_ is a scalar type, or as the vector _Component Type_ if _Result Type_ is a vector type.
 
-The size of the 2D region to read is specified by the 'Width' and 'Height' operands.  The 'Width' of the 2D region is expressed in units of the block read 'Component Type', and the 'Height' directly describes the number of rows of the 2D region to read.
+The size of the 2D region to read is specified by the _Width_ and _Height_ operands.  The _Width_ of the 2D region is expressed in units of the block read _Component Type_, and the _Height_ directly describes the number of rows of the 2D region to read.
 
-The 'Coordinate' describes where in the 'Image' to start reading the 2D region, and must be a vector of integer type.  The first component of the 'Coordinate' is a byte coordinate into a row of the 'Image' and is not expressed in units of the block read 'Component Type'.  Remaining coordinates are non-normalized texel coordinates.
+The _Coordinate_ describes where in the _Image_ to start reading the 2D region, and must be a vector of integer type.  The first component of the _Coordinate_ is a byte coordinate into a row of the _Image_ and is not expressed in units of the block read _Component Type_.  Remaining coordinates are non-normalized texel coordinates.
 
-The data read from the 2D region is assigned to 'Result' for each invocation in the subgroup by reorganizing the data read from the 2D region into a different 2D destination region in row major order.  The width of the destination 2D region is equivalent to *SubgroupMaxSize* in units of the 'Component Type', and the height of the destination 2D region is equivalent to one if 'Result Type' is a scalar type, or to the vector 'Component Count' if 'Result Type' is a vector type.  The reorganization assigns rows of the source 2D region to the destination 2D region in row-major order.  If the source 2D region row byte width is not a power-of-two then the source 2D region row is assigned to the destination 2D region with undefined padding values to make a power-of-two row byte width.  Each invocation in the subgroup is then assigned a 'Component Type' column vector of the reorganized 2D region, i.e. each invocation's subsequent data element's index is strided by the *SubgroupMaxSize* in the 2D destination region.
+The data read from the 2D region is assigned to _Result_ for each invocation in the subgroup by reorganizing the data read from the 2D region into a different 2D destination region in row major order.  The width of the destination 2D region is equivalent to *SubgroupMaxSize* in units of the _Component Type_, and the height of the destination 2D region is equivalent to one if _Result Type_ is a scalar type, or to the vector _Component Count_ if _Result Type_ is a vector type.  The reorganization assigns rows of the source 2D region to the destination 2D region in row-major order.  If the source 2D region row byte width is not a power-of-two then the source 2D region row is assigned to the destination 2D region with undefined padding values to make a power-of-two row byte width.  Each invocation in the subgroup is then assigned a _Component Type_ column vector of the reorganized 2D region, i.e. each invocation_s subsequent data element_s index is strided by the *SubgroupMaxSize* in the 2D destination region.
 
-If the size of the requested 2D region to read is smaller than the 2D destination region then some tail components of some 'Result' values will not be assigned values.  If the size of the 2D region to read is larger than the 2D destination region then some parts of the 2D region to read will be not be assigned and will be dropped.
+If the size of the requested 2D region to read is smaller than the 2D destination region then some tail components of some _Result_ values will not be assigned values.  If the size of the 2D region to read is larger than the 2D destination region then some parts of the 2D region to read will be not be assigned and will be dropped.
 1+|Capability: +
 *SubgroupImageMediaBlockIOINTEL*
-| 7 | 5580 | '<id>' 'Result Type' | '<id>' 'Result' |  '<id>' 'Image' | '<id>' 'Coordinate' | '<id>' 'Width' | '<id>' 'Height'
+| 7 | 5580 | _<id>_ _Result Type_ | _<id>_ _Result_ |  _<id>_ _Image_ | _<id>_ _Coordinate_ | _<id>_ _Width_ | _<id>_ _Height_
 |=====
 
 [cols="1,1,5*3",width="100%"]
 |=====
 6+|[[OpSubgroupImageMediaBlockWriteINTEL]]*OpSubgroupImageMediaBlockWriteINTEL* +
  +
-Writes a block of data into a 2D region of the specified 'Image'.
+Writes a block of data into a 2D region of the specified _Image_.
 
-'Image' must be an object whose type is *OpTypeImage* with a 'Sampled' operand of 0 or 2.
+_Image_ must be an object whose type is *OpTypeImage* with a _Sampled_ operand of 0 or 2.
 
-The type of 'Data' is used to compute the maximum size of the 2D region that may be written, and may be a scalar or a vector type.  For this description, the block write 'Component Type' is defined as the type of 'Data' if it is a scalar type, or the vector 'Component Type' if it is a vector type.
+The type of _Data_ is used to compute the maximum size of the 2D region that may be written, and may be a scalar or a vector type.  For this description, the block write _Component Type_ is defined as the type of _Data_ if it is a scalar type, or the vector _Component Type_ if it is a vector type.
 
-The size of the 2D region to write is specified by the 'Width' and 'Height' operands.  The 'Width' of the 2D region is expressed in units of the block write 'Component Type', and the 'Height' directly describes the number of rows of the 2D region to write.
+The size of the 2D region to write is specified by the _Width_ and _Height_ operands.  The _Width_ of the 2D region is expressed in units of the block write _Component Type_, and the _Height_ directly describes the number of rows of the 2D region to write.
 
-The 'Coordinate' describes where in the 'Image' to start writing the 2D region, and must be a vector of integer type.  The first component of the 'Coordinate' is a byte coordinate into a row of the 'Image' and is not expressed in units of the 'Component Type'.  Remaining coordinates are non-normalized texel coordinates.
+The _Coordinate_ describes where in the _Image_ to start writing the 2D region, and must be a vector of integer type.  The first component of the _Coordinate_ is a byte coordinate into a row of the _Image_ and is not expressed in units of the _Component Type_.  Remaining coordinates are non-normalized texel coordinates.
 
-The 'Data' for each invocation in the subgroup collectively forms a 2D source region, where the width of the 2D source region is equivalent to the *SubgroupMaxSize* in units of the block write 'Component Type', and the height of the 2D source region is equivalent to one if the type of 'Data' is a scalar type, or to the vector 'Component Count' if it is a vector type.  This 2D source region is then reorganized into a different 2D region to write.  The reorganization assigns data from the 2D source region to rows of the 2D region to write in row-major order.  If the row byte width of the 2D region to write is not a power-of-two, then some values from the 2D source region are skipped during assignment, so that each row of the 2D region to write begins at an byte offset that is a power-of-two.
+The _Data_ for each invocation in the subgroup collectively forms a 2D source region, where the width of the 2D source region is equivalent to the *SubgroupMaxSize* in units of the block write _Component Type_, and the height of the 2D source region is equivalent to one if the type of _Data_ is a scalar type, or to the vector _Component Count_ if it is a vector type.  This 2D source region is then reorganized into a different 2D region to write.  The reorganization assigns data from the 2D source region to rows of the 2D region to write in row-major order.  If the row byte width of the 2D region to write is not a power-of-two, then some values from the 2D source region are skipped during assignment, so that each row of the 2D region to write begins at an byte offset that is a power-of-two.
 
-If the size of the 2D source region is greater than the size of the 2D region to write then some tail components of some 'Data' values will not be written.  This SPIR-V extension does not require any specific behavior when the size of the 2D source region is smaller than the size of the 2D region to write, but some environments may define behavior for this case.
+If the size of the 2D source region is greater than the size of the 2D region to write then some tail components of some _Data_ values will not be written.  This SPIR-V extension does not require any specific behavior when the size of the 2D source region is smaller than the size of the 2D region to write, but some environments may define behavior for this case.
 1+|Capability: +
 *SubgroupImageMediaBlockIOINTEL*
-| 6 | 5581 |  '<id>' 'Image' | '<id>' 'Coordinate' | '<id>' 'Width' | '<id>' 'Height' | '<id>' 'Data'
+| 6 | 5581 |  _<id>_ _Image_ | _<id>_ _Coordinate_ | _<id>_ _Width_ | _<id>_ _Height_ | _<id>_ _Data_
 |=====
 
 == Validation Rules

--- a/extensions/INTEL/SPV_INTEL_media_block_io.html
+++ b/extensions/INTEL/SPV_INTEL_media_block_io.html
@@ -1,843 +1,122 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta name="generator" content="AsciiDoc 8.6.9">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_media_block_io</title>
-<style type="text/css">
-/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
-
-/* Default font. */
-body {
-  font-family: Georgia,serif;
-}
-
-/* Title font. */
-h1, h2, h3, h4, h5, h6,
-div.title, caption.title,
-thead, p.table.header,
-#toctitle,
-#author, #revnumber, #revdate, #revremark,
-#footer {
-  font-family: Arial,Helvetica,sans-serif;
-}
-
-body {
-  margin: 1em 5% 1em 5%;
-}
-
-a {
-  color: blue;
-  text-decoration: underline;
-}
-a:visited {
-  color: fuchsia;
-}
-
-em {
-  font-style: italic;
-  color: navy;
-}
-
-strong {
-  font-weight: bold;
-  color: #083194;
-}
-
-h1, h2, h3, h4, h5, h6 {
-  color: #527bbd;
-  margin-top: 1.2em;
-  margin-bottom: 0.5em;
-  line-height: 1.3;
-}
-
-h1, h2, h3 {
-  border-bottom: 2px solid silver;
-}
-h2 {
-  padding-top: 0.5em;
-}
-h3 {
-  float: left;
-}
-h3 + * {
-  clear: left;
-}
-h5 {
-  font-size: 1.0em;
-}
-
-div.sectionbody {
-  margin-left: 0;
-}
-
-hr {
-  border: 1px solid silver;
-}
+<style>
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
 
 p {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
 }
 
-ul, ol, li > p {
-  margin-top: 0;
-}
-ul > li     { color: #aaa; }
-ul > li > * { color: black; }
-
-.monospaced, code, pre {
-  font-family: "Courier New", Courier, monospace;
-  font-size: inherit;
-  color: navy;
-  padding: 0;
-  margin: 0;
-}
-pre {
-  white-space: pre-wrap;
-}
-
-#author {
-  color: #527bbd;
-  font-weight: bold;
-  font-size: 1.1em;
-}
-#email {
-}
-#revnumber, #revdate, #revremark {
-}
-
-#footer {
-  font-size: small;
-  border-top: 2px solid silver;
-  padding-top: 0.5em;
-  margin-top: 4.0em;
-}
-#footer-text {
-  float: left;
-  padding-bottom: 0.5em;
-}
-#footer-badges {
-  float: right;
-  padding-bottom: 0.5em;
-}
-
-#preamble {
-  margin-top: 1.5em;
-  margin-bottom: 1.5em;
-}
-div.imageblock, div.exampleblock, div.verseblock,
-div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
-div.admonitionblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.admonitionblock {
-  margin-top: 2.0em;
-  margin-bottom: 2.0em;
-  margin-right: 10%;
-  color: #606060;
-}
-
-div.content { /* Block element content. */
-  padding: 0;
-}
-
-/* Block element titles. */
-div.title, caption.title {
-  color: #527bbd;
-  font-weight: bold;
-  text-align: left;
-  margin-top: 1.0em;
-  margin-bottom: 0.5em;
-}
-div.title + * {
-  margin-top: 0;
-}
-
-td div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content + div.title {
-  margin-top: 0.0em;
-}
-
-div.sidebarblock > div.content {
-  background: #ffffee;
-  border: 1px solid #dddddd;
-  border-left: 4px solid #f0f0f0;
-  padding: 0.5em;
-}
-
-div.listingblock > div.content {
-  border: 1px solid #dddddd;
-  border-left: 5px solid #f0f0f0;
-  background: #f8f8f8;
-  padding: 0.5em;
-}
-
-div.quoteblock, div.verseblock {
-  padding-left: 1.0em;
-  margin-left: 1.0em;
-  margin-right: 10%;
-  border-left: 5px solid #f0f0f0;
-  color: #888;
-}
-
-div.quoteblock > div.attribution {
-  padding-top: 0.5em;
-  text-align: right;
-}
-
-div.verseblock > pre.content {
-  font-family: inherit;
-  font-size: inherit;
-}
-div.verseblock > div.attribution {
-  padding-top: 0.75em;
-  text-align: left;
-}
-/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
-div.verseblock + div.attribution {
-  text-align: left;
-}
-
-div.admonitionblock .icon {
-  vertical-align: top;
-  font-size: 1.1em;
-  font-weight: bold;
-  text-decoration: underline;
-  color: #527bbd;
-  padding-right: 0.5em;
-}
-div.admonitionblock td.content {
-  padding-left: 0.5em;
-  border-left: 3px solid #dddddd;
-}
-
-div.exampleblock > div.content {
-  border-left: 3px solid #dddddd;
-  padding-left: 0.5em;
-}
-
-div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; vertical-align: text-bottom; }
-a.image:visited { color: white; }
-
-dl {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-dt {
-  margin-top: 0.5em;
-  margin-bottom: 0;
-  font-style: normal;
-  color: navy;
-}
-dd > *:first-child {
-  margin-top: 0.1em;
-}
-
-ul, ol {
-    list-style-position: outside;
-}
-ol.arabic {
-  list-style-type: decimal;
-}
-ol.loweralpha {
-  list-style-type: lower-alpha;
-}
-ol.upperalpha {
-  list-style-type: upper-alpha;
-}
-ol.lowerroman {
-  list-style-type: lower-roman;
-}
-ol.upperroman {
-  list-style-type: upper-roman;
-}
-
-div.compact ul, div.compact ol,
-div.compact p, div.compact p,
-div.compact div, div.compact div {
-  margin-top: 0.1em;
-  margin-bottom: 0.1em;
-}
-
-tfoot {
-  font-weight: bold;
-}
-td > div.verse {
-  white-space: pre;
-}
-
-div.hdlist {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-div.hdlist tr {
-  padding-bottom: 15px;
-}
-dt.hdlist1.strong, td.hdlist1.strong {
-  font-weight: bold;
-}
-td.hdlist1 {
-  vertical-align: top;
-  font-style: normal;
-  padding-right: 0.8em;
-  color: navy;
-}
-td.hdlist2 {
-  vertical-align: top;
-}
-div.hdlist.compact tr {
-  margin: 0;
-  padding-bottom: 0;
-}
-
-.comment {
-  background: yellow;
-}
-
-.footnote, .footnoteref {
-  font-size: 0.8em;
-}
-
-span.footnote, span.footnoteref {
-  vertical-align: super;
-}
-
-#footnotes {
-  margin: 20px 0 20px 0;
-  padding: 7px 0 0 0;
-}
-
-#footnotes div.footnote {
-  margin: 0 0 5px 0;
-}
-
-#footnotes hr {
-  border: none;
-  border-top: 1px solid silver;
-  height: 1px;
-  text-align: left;
-  margin-left: 0;
-  width: 20%;
-  min-width: 100px;
-}
-
-div.colist td {
-  padding-right: 0.5em;
-  padding-bottom: 0.3em;
-  vertical-align: top;
-}
-div.colist td img {
-  margin-top: 0.3em;
-}
-
-@media print {
-  #footer-badges { display: none; }
-}
-
-#toc {
-  margin-bottom: 2.5em;
-}
-
-#toctitle {
-  color: #527bbd;
-  font-size: 1.1em;
-  font-weight: bold;
-  margin-top: 1.0em;
-  margin-bottom: 0.1em;
-}
-
-div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-div.toclevel2 {
-  margin-left: 2em;
-  font-size: 0.9em;
-}
-div.toclevel3 {
-  margin-left: 4em;
-  font-size: 0.9em;
-}
-div.toclevel4 {
-  margin-left: 6em;
-  font-size: 0.9em;
-}
-
-span.aqua { color: aqua; }
-span.black { color: black; }
-span.blue { color: blue; }
-span.fuchsia { color: fuchsia; }
-span.gray { color: gray; }
-span.green { color: green; }
-span.lime { color: lime; }
-span.maroon { color: maroon; }
-span.navy { color: navy; }
-span.olive { color: olive; }
-span.purple { color: purple; }
-span.red { color: red; }
-span.silver { color: silver; }
-span.teal { color: teal; }
-span.white { color: white; }
-span.yellow { color: yellow; }
-
-span.aqua-background { background: aqua; }
-span.black-background { background: black; }
-span.blue-background { background: blue; }
-span.fuchsia-background { background: fuchsia; }
-span.gray-background { background: gray; }
-span.green-background { background: green; }
-span.lime-background { background: lime; }
-span.maroon-background { background: maroon; }
-span.navy-background { background: navy; }
-span.olive-background { background: olive; }
-span.purple-background { background: purple; }
-span.red-background { background: red; }
-span.silver-background { background: silver; }
-span.teal-background { background: teal; }
-span.white-background { background: white; }
-span.yellow-background { background: yellow; }
-
-span.big { font-size: 2em; }
-span.small { font-size: 0.6em; }
-
-span.underline { text-decoration: underline; }
-span.overline { text-decoration: overline; }
-span.line-through { text-decoration: line-through; }
-
-div.unbreakable { page-break-inside: avoid; }
-
-
-/*
- * xhtml11 specific
- *
- * */
-
-div.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.tableblock > table {
-  border: 3px solid #527bbd;
-}
-thead, p.table.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.table {
-  margin-top: 0;
-}
-/* Because the table frame attribute is overriden by CSS in most browsers. */
-div.tableblock > table[frame="void"] {
-  border-style: none;
-}
-div.tableblock > table[frame="hsides"] {
-  border-left-style: none;
-  border-right-style: none;
-}
-div.tableblock > table[frame="vsides"] {
-  border-top-style: none;
-  border-bottom-style: none;
-}
-
-
-/*
- * html5 specific
- *
- * */
-
-table.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-thead, p.tableblock.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.tableblock {
-  margin-top: 0;
-}
-table.tableblock {
-  border-width: 3px;
-  border-spacing: 0px;
-  border-style: solid;
-  border-color: #527bbd;
-  border-collapse: collapse;
-}
-th.tableblock, td.tableblock {
-  border-width: 1px;
-  padding: 4px;
-  border-style: solid;
-  border-color: #527bbd;
-}
-
-table.tableblock.frame-topbot {
-  border-left-style: hidden;
-  border-right-style: hidden;
-}
-table.tableblock.frame-sides {
-  border-top-style: hidden;
-  border-bottom-style: hidden;
-}
-table.tableblock.frame-none {
-  border-style: hidden;
-}
-
-th.tableblock.halign-left, td.tableblock.halign-left {
-  text-align: left;
-}
-th.tableblock.halign-center, td.tableblock.halign-center {
-  text-align: center;
-}
-th.tableblock.halign-right, td.tableblock.halign-right {
-  text-align: right;
-}
-
-th.tableblock.valign-top, td.tableblock.valign-top {
-  vertical-align: top;
-}
-th.tableblock.valign-middle, td.tableblock.valign-middle {
-  vertical-align: middle;
-}
-th.tableblock.valign-bottom, td.tableblock.valign-bottom {
-  vertical-align: bottom;
-}
-
-
-/*
- * manpage specific
- *
- * */
-
-body.manpage h1 {
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
-  border-top: 2px solid silver;
-  border-bottom: 2px solid silver;
-}
-body.manpage h2 {
-  border-style: none;
-}
-body.manpage div.sectionbody {
-  margin-left: 3em;
-}
-
-@media print {
-  body.manpage div#toc { display: none; }
-}
-
-
-@media screen {
-  body {
-    max-width: 50em; /* approximately 80 characters wide */
-    margin-left: 16em;
-  }
-
-  #toc {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 13em;
-    padding: 0.5em;
-    padding-bottom: 1.5em;
-    margin: 0;
-    overflow: auto;
-    border-right: 3px solid #f8f8f8;
-    background-color: white;
-  }
-
-  #toc .toclevel1 {
-    margin-top: 0.5em;
-  }
-
-  #toc .toclevel2 {
-    margin-top: 0.25em;
-    display: list-item;
-    color: #aaaaaa;
-  }
-
-  #toctitle {
-    margin-top: 0.5em;
-  }
-}
 </style>
-<script type="text/javascript">
-/*<![CDATA[*/
-var asciidoc = {  // Namespace.
-
-/////////////////////////////////////////////////////////////////////
-// Table Of Contents generator
-/////////////////////////////////////////////////////////////////////
-
-/* Author: Mihai Bazon, September 2002
- * http://students.infoiasi.ro/~mishoo
- *
- * Table Of Content generator
- * Version: 0.4
- *
- * Feel free to use this script under the terms of the GNU General Public
- * License, as long as you do not remove or alter this notice.
- */
-
- /* modified by Troy D. Hanson, September 2006. License: GPL */
- /* modified by Stuart Rackham, 2006, 2009. License: GPL */
-
-// toclevels = 1..4.
-toc: function (toclevels) {
-
-  function getText(el) {
-    var text = "";
-    for (var i = el.firstChild; i != null; i = i.nextSibling) {
-      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
-        text += i.data;
-      else if (i.firstChild != null)
-        text += getText(i);
-    }
-    return text;
-  }
-
-  function TocEntry(el, text, toclevel) {
-    this.element = el;
-    this.text = text;
-    this.toclevel = toclevel;
-  }
-
-  function tocEntries(el, toclevels) {
-    var result = new Array;
-    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
-    // Function that scans the DOM tree for header elements (the DOM2
-    // nodeIterator API would be a better technique but not supported by all
-    // browsers).
-    var iterate = function (el) {
-      for (var i = el.firstChild; i != null; i = i.nextSibling) {
-        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
-          var mo = re.exec(i.tagName);
-          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
-            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
-          }
-          iterate(i);
-        }
-      }
-    }
-    iterate(el);
-    return result;
-  }
-
-  var toc = document.getElementById("toc");
-  if (!toc) {
-    return;
-  }
-
-  // Delete existing TOC entries in case we're reloading the TOC.
-  var tocEntriesToRemove = [];
-  var i;
-  for (i = 0; i < toc.childNodes.length; i++) {
-    var entry = toc.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div'
-     && entry.getAttribute("class")
-     && entry.getAttribute("class").match(/^toclevel/))
-      tocEntriesToRemove.push(entry);
-  }
-  for (i = 0; i < tocEntriesToRemove.length; i++) {
-    toc.removeChild(tocEntriesToRemove[i]);
-  }
-
-  // Rebuild TOC entries.
-  var entries = tocEntries(document.getElementById("content"), toclevels);
-  for (var i = 0; i < entries.length; ++i) {
-    var entry = entries[i];
-    if (entry.element.id == "")
-      entry.element.id = "_toc_" + i;
-    var a = document.createElement("a");
-    a.href = "#" + entry.element.id;
-    a.appendChild(document.createTextNode(entry.text));
-    var div = document.createElement("div");
-    div.appendChild(a);
-    div.className = "toclevel" + entry.toclevel;
-    toc.appendChild(div);
-  }
-  if (entries.length == 0)
-    toc.parentNode.removeChild(toc);
-},
-
-
-/////////////////////////////////////////////////////////////////////
-// Footnotes generator
-/////////////////////////////////////////////////////////////////////
-
-/* Based on footnote generation code from:
- * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
- */
-
-footnotes: function () {
-  // Delete existing footnote entries in case we're reloading the footnodes.
-  var i;
-  var noteholder = document.getElementById("footnotes");
-  if (!noteholder) {
-    return;
-  }
-  var entriesToRemove = [];
-  for (i = 0; i < noteholder.childNodes.length; i++) {
-    var entry = noteholder.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
-      entriesToRemove.push(entry);
-  }
-  for (i = 0; i < entriesToRemove.length; i++) {
-    noteholder.removeChild(entriesToRemove[i]);
-  }
-
-  // Rebuild footnote entries.
-  var cont = document.getElementById("content");
-  var spans = cont.getElementsByTagName("span");
-  var refs = {};
-  var n = 0;
-  for (i=0; i<spans.length; i++) {
-    if (spans[i].className == "footnote") {
-      n++;
-      var note = spans[i].getAttribute("data-note");
-      if (!note) {
-        // Use [\s\S] in place of . so multi-line matches work.
-        // Because JavaScript has no s (dotall) regex flag.
-        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
-        spans[i].innerHTML =
-          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-        spans[i].setAttribute("data-note", note);
-      }
-      noteholder.innerHTML +=
-        "<div class='footnote' id='_footnote_" + n + "'>" +
-        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
-        n + "</a>. " + note + "</div>";
-      var id =spans[i].getAttribute("id");
-      if (id != null) refs["#"+id] = n;
-    }
-  }
-  if (n == 0)
-    noteholder.parentNode.removeChild(noteholder);
-  else {
-    // Process footnoterefs.
-    for (i=0; i<spans.length; i++) {
-      if (spans[i].className == "footnoteref") {
-        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
-        href = href.match(/#.*/)[0];  // Because IE return full URL.
-        n = refs[href];
-        spans[i].innerHTML =
-          "[<a href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-      }
-    }
-  }
-},
-
-install: function(toclevels) {
-  var timerId;
-
-  function reinstall() {
-    asciidoc.footnotes();
-    if (toclevels) {
-      asciidoc.toc(toclevels);
-    }
-  }
-
-  function reinstallAndRemoveTimer() {
-    clearInterval(timerId);
-    reinstall();
-  }
-
-  timerId = setInterval(reinstall, 500);
-  if (document.addEventListener)
-    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
-  else
-    window.onload = reinstallAndRemoveTimer;
-}
-
-}
-asciidoc.install(1);
-/*]]>*/
-</script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_media_block_io</h1>
-<div id="toc">
-  <div id="toctitle">Table of Contents</div>
-  <noscript><p><b>JavaScript must be enabled in your browser to display the table of contents.</b></p></noscript>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_new_instructions">New Instructions</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_2">Modifications to the SPIR-V Specification, Version 1.2</a></li>
+<li><a href="#_validation_rules">Validation Rules</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
 </div>
 </div>
 <div id="content">
 <div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>SPV_INTEL_media_block_io</p></div>
+<div class="paragraph">
+<p>SPV_INTEL_media_block_io</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>To report problems with this extension, please open a new issue at:</p></div>
-<div class="paragraph"><p><a href="https://github.com/KhronosGroup/SPIRV-Registry">https://github.com/KhronosGroup/SPIRV-Registry</a></p></div>
+<div class="paragraph">
+<p>To report problems with this extension, please open a new issue at:</p>
+</div>
+<div class="paragraph">
+<p><a href="https://github.com/KhronosGroup/SPIRV-Registry" class="bare">https://github.com/KhronosGroup/SPIRV-Registry</a></p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Ben Ashbaugh, Intel<br>
-</p>
+<p>Ben Ashbaugh, Intel<br></p>
 </li>
 <li>
-<p>
-Biju George, Intel
-</p>
+<p>Biju George, Intel</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Copyright (c) 2018 Intel Corporation.  All rights reserved.</p></div>
+<div class="paragraph">
+<p>Copyright (c) 2018 Intel Corporation.  All rights reserved.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Final Draft
-</p>
+<p>Final Draft</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all"
-style="
-width:40%;
-">
-<col style="width:50%;">
-<col style="width:50%;">
+<table class="tableblock frame-all grid-all" style="width: 40%;">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2018-11-20</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-21</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
 </tr>
 </tbody>
 </table>
@@ -846,69 +125,83 @@ width:40%;
 <div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension is written against the SPIR-V Specification,
-Version 1.2 Revision 1.</p></div>
-<div class="paragraph"><p>This extension requires SPIR-V 1.0.</p></div>
+<div class="paragraph">
+<p>This extension is written against the SPIR-V Specification,
+Version 1.2 Revision 1.</p>
+</div>
+<div class="paragraph">
+<p>This extension requires SPIR-V 1.0.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension adds additional subgroup block read and write functionality that allow applications to flexibly specify the width and height of the block to read from or write to a 2D image.</p></div>
+<div class="paragraph">
+<p>This extension adds additional subgroup block read and write functionality that allow applications to flexibly specify the width and height of the block to read from or write to a 2D image.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_extension_name">Extension Name</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>To use this extension within a SPIR-V module, the appropriate <strong>OpExtension</strong> must be present in the module:</p></div>
+<div class="paragraph">
+<p>To use this extension within a SPIR-V module, the appropriate <strong>OpExtension</strong> must be present in the module:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpExtension "SPV_INTEL_media_block_io"</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_capabilities">New Capabilities</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension introduces new capabilities:</p></div>
+<div class="paragraph">
+<p>This extension introduces new capabilities:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>SubgroupImageMediaBlockIOINTEL</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_instructions">New Instructions</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Instructions added under the <strong>SubgroupImageMediaBlockIOINTEL</strong> capability:</p></div>
+<div class="paragraph">
+<p>Instructions added under the <strong>SubgroupImageMediaBlockIOINTEL</strong> capability:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpSubgroupImageMediaBlockReadINTEL
 OpSubgroupImageMediaBlockWriteINTEL</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:40%;
-">
-<col style="width:70%;">
-<col style="width:30%;">
+<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<colgroup>
+<col style="width: 70%;">
+<col style="width: 30%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupImageMediaBlockIOINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5579</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupImageMediaBlockIOINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5579</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupImageMediaBlockReadINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5580</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupImageMediaBlockReadINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5580</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupImageMediaBlockWriteINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5581</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupImageMediaBlockWriteINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5581</p></td>
 </tr>
 </tbody>
 </table>
@@ -919,87 +212,88 @@ width:40%;
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_capabilities">Capabilities</h3>
-<div class="paragraph"><p>Modify Section 3.31, Capability, adding rows to the Capability table:</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:5%;">
-<col style="width:52%;">
-<col style="width:21%;">
-<col style="width:21%;">
+<div class="paragraph">
+<p>Modify Section 3.31, Capability, adding rows to the Capability table:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 5.2631%;">
+<col style="width: 52.6315%;">
+<col style="width: 21.0526%;">
+<col style="width: 21.0528%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-center valign-top" colspan="2" > Capability </th>
-<th class="tableblock halign-center valign-top" > Implicitly Declares </th>
-<th class="tableblock halign-center valign-top" > Enabled by Extension</th>
+<th class="tableblock halign-center valign-top" colspan="2">Capability</th>
+<th class="tableblock halign-center valign-top">Implicitly Declares</th>
+<th class="tableblock halign-center valign-top">Enabled by Extension</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5579</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>SubgroupImageMediaBlockIOINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>SPV_INTEL_media_block_io</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5579</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>SubgroupImageMediaBlockIOINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>SPV_INTEL_media_block_io</strong></p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect2">
 <h3 id="_instructions">Instructions</h3>
-<div class="paragraph"><p>Modify Section 3.32.21, Group Instructions, adding to the end of the list of instructions:</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:5%;">
-<col style="width:5%;">
-<col style="width:15%;">
-<col style="width:15%;">
-<col style="width:15%;">
-<col style="width:15%;">
-<col style="width:15%;">
-<col style="width:15%;">
+<div class="paragraph">
+<p>Modify Section 3.32.21, Group Instructions, adding to the end of the list of instructions:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 5%;">
+<col style="width: 5%;">
+<col style="width: 15%;">
+<col style="width: 15%;">
+<col style="width: 15%;">
+<col style="width: 15%;">
+<col style="width: 15%;">
+<col style="width: 15%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="7" ><p class="tableblock"><a id="OpSubgroupImageMediaBlockReadINTEL"></a><strong>OpSubgroupImageMediaBlockReadINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="7"><p class="tableblock"><a id="OpSubgroupImageMediaBlockReadINTEL"></a><strong>OpSubgroupImageMediaBlockReadINTEL</strong><br>
 <br>
 Reads a block of data from a 2D region of the specified <em>Image</em>.</p>
 <p class="tableblock"><em>Image</em> must be an object whose type is <strong>OpTypeImage</strong> with a <em>Sampled</em> operand of 0 or 2.</p>
 <p class="tableblock">The <em>Result Type</em> is used to compute the maximum size of the 2D region that may be read, and may be a scalar or a vector type.  For this description, the block read <em>Component Type</em> is defined as the <em>Result Type</em> if <em>Result Type</em> is a scalar type, or as the vector <em>Component Type</em> if <em>Result Type</em> is a vector type.</p>
 <p class="tableblock">The size of the 2D region to read is specified by the <em>Width</em> and <em>Height</em> operands.  The <em>Width</em> of the 2D region is expressed in units of the block read <em>Component Type</em>, and the <em>Height</em> directly describes the number of rows of the 2D region to read.</p>
 <p class="tableblock">The <em>Coordinate</em> describes where in the <em>Image</em> to start reading the 2D region, and must be a vector of integer type.  The first component of the <em>Coordinate</em> is a byte coordinate into a row of the <em>Image</em> and is not expressed in units of the block read <em>Component Type</em>.  Remaining coordinates are non-normalized texel coordinates.</p>
-<p class="tableblock">The data read from the 2D region is assigned to <em>Result</em> for each invocation in the subgroup by reorganizing the data read from the 2D region into a different 2D destination region in row major order.  The width of the destination 2D region is equivalent to <strong>SubgroupMaxSize</strong> in units of the <em>Component Type</em>, and the height of the destination 2D region is equivalent to one if <em>Result Type</em> is a scalar type, or to the vector <em>Component Count</em> if <em>Result Type</em> is a vector type.  The reorganization assigns rows of the source 2D region to the destination 2D region in row-major order.  If the source 2D region row byte width is not a power-of-two then the source 2D region row is assigned to the destination 2D region with undefined padding values to make a power-of-two row byte width.  Each invocation in the subgroup is then assigned a <em>Component Type</em> column vector of the reorganized 2D region, i.e. each invocation&#8217;s subsequent data element&#8217;s index is strided by the <strong>SubgroupMaxSize</strong> in the 2D destination region.</p>
+<p class="tableblock">The data read from the 2D region is assigned to <em>Result</em> for each invocation in the subgroup by reorganizing the data read from the 2D region into a different 2D destination region in row major order.  The width of the destination 2D region is equivalent to <strong>SubgroupMaxSize</strong> in units of the <em>Component Type</em>, and the height of the destination 2D region is equivalent to one if <em>Result Type</em> is a scalar type, or to the vector <em>Component Count</em> if <em>Result Type</em> is a vector type.  The reorganization assigns rows of the source 2D region to the destination 2D region in row-major order.  If the source 2D region row byte width is not a power-of-two then the source 2D region row is assigned to the destination 2D region with undefined padding values to make a power-of-two row byte width.  Each invocation in the subgroup is then assigned a <em>Component Type</em> column vector of the reorganized 2D region, i.e. each invocation_s subsequent data element_s index is strided by the <strong>SubgroupMaxSize</strong> in the 2D destination region.</p>
 <p class="tableblock">If the size of the requested 2D region to read is smaller than the 2D destination region then some tail components of some <em>Result</em> values will not be assigned values.  If the size of the 2D region to read is larger than the 2D destination region then some parts of the 2D region to read will be not be assigned and will be dropped.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupImageMediaBlockIOINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">7</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5580</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Result</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Image</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Coordinate</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Width</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Height</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5580</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Result Type</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Result</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Image</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Coordinate</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Width</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Height</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:5%;">
-<col style="width:5%;">
-<col style="width:17%;">
-<col style="width:17%;">
-<col style="width:17%;">
-<col style="width:17%;">
-<col style="width:17%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 5.8823%;">
+<col style="width: 5.8823%;">
+<col style="width: 17.647%;">
+<col style="width: 17.647%;">
+<col style="width: 17.647%;">
+<col style="width: 17.647%;">
+<col style="width: 17.6474%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpSubgroupImageMediaBlockWriteINTEL"></a><strong>OpSubgroupImageMediaBlockWriteINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpSubgroupImageMediaBlockWriteINTEL"></a><strong>OpSubgroupImageMediaBlockWriteINTEL</strong><br>
 <br>
 Writes a block of data into a 2D region of the specified <em>Image</em>.</p>
 <p class="tableblock"><em>Image</em> must be an object whose type is <strong>OpTypeImage</strong> with a <em>Sampled</em> operand of 0 or 2.</p>
@@ -1008,17 +302,17 @@ Writes a block of data into a 2D region of the specified <em>Image</em>.</p>
 <p class="tableblock">The <em>Coordinate</em> describes where in the <em>Image</em> to start writing the 2D region, and must be a vector of integer type.  The first component of the <em>Coordinate</em> is a byte coordinate into a row of the <em>Image</em> and is not expressed in units of the <em>Component Type</em>.  Remaining coordinates are non-normalized texel coordinates.</p>
 <p class="tableblock">The <em>Data</em> for each invocation in the subgroup collectively forms a 2D source region, where the width of the 2D source region is equivalent to the <strong>SubgroupMaxSize</strong> in units of the block write <em>Component Type</em>, and the height of the 2D source region is equivalent to one if the type of <em>Data</em> is a scalar type, or to the vector <em>Component Count</em> if it is a vector type.  This 2D source region is then reorganized into a different 2D region to write.  The reorganization assigns data from the 2D source region to rows of the 2D region to write in row-major order.  If the row byte width of the 2D region to write is not a power-of-two, then some values from the 2D source region are skipped during assignment, so that each row of the 2D region to write begins at an byte offset that is a power-of-two.</p>
 <p class="tableblock">If the size of the 2D source region is greater than the size of the 2D region to write then some tail components of some <em>Data</em> values will not be written.  This SPIR-V extension does not require any specific behavior when the size of the 2D source region is smaller than the size of the 2D region to write, but some environments may define behavior for this case.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupImageMediaBlockIOINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5581</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Image</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Coordinate</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Width</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Height</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Data</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5581</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Image</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Coordinate</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Width</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Height</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Data</em></p></td>
 </tr>
 </tbody>
 </table>
@@ -1028,51 +322,47 @@ Writes a block of data into a 2D region of the specified <em>Image</em>.</p>
 <div class="sect1">
 <h2 id="_validation_rules">Validation Rules</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:100%;
-">
-<col style="width:4%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:66%;">
+<table class="tableblock frame-all grid-rows stretch">
+<colgroup>
+<col style="width: 4.7619%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" >Rev</th>
-<th class="tableblock halign-left valign-top" >Date</th>
-<th class="tableblock halign-left valign-top" >Author</th>
-<th class="tableblock halign-left valign-top" >Changes</th>
+<th class="tableblock halign-left valign-top">Rev</th>
+<th class="tableblock halign-left valign-top">Date</th>
+<th class="tableblock halign-left valign-top">Author</th>
+<th class="tableblock halign-left valign-top">Changes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2018-10-29</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>Initial revision</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2018-10-29</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Initial revision</strong></p></td>
 </tr>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footnotes"><hr></div>
-<div id="footer">
-<div id="footer-text">
-Last updated
- 2018-11-20 13:33:29 PST
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_runtime_aligned.html
+++ b/extensions/INTEL/SPV_INTEL_runtime_aligned.html
@@ -4,441 +4,45 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.10">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_runtime_aligned</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
-/* Uncomment @import statement to use as custom stylesheet */
-/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
-article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section{display:block}
-audio,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
-a{background:none}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-abbr[title]{border-bottom:1px dotted}
-b,strong{font-weight:bold}
-dfn{font-style:italic}
-hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:0}
-p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
-abbr{text-transform:none}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
-blockquote cite::before{content:"\2014 \0020"}
-blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
-:not(pre)>code.nobreak{word-wrap:normal}
-:not(pre)>code.nowrap{white-space:nowrap}
-pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
-pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
-pre>code{display:block}
-pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:100%;background:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #e7e7e9}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details>summary:first-of-type{cursor:pointer;display:list-item;outline:none;margin-bottom:.75em}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:inherit}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border-style:solid;border-width:1px;border-color:#dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;-webkit-border-radius:4px;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
-@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
-.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class="highlight"],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
-.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.prettyprint{background:#f7f7f8}
-pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
-pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
-pre.prettyprint li code[data-lang]::before{opacity:1}
-pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
-table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
-table.linenotable td.code{padding-left:.75em}
-table.linenotable td.linenos{border-right:1px solid currentColor;opacity:.35;padding-right:.5em}
-pre.pygments .lineno{border-right:1px solid currentColor;opacity:.35;display:inline-block;margin-right:.75em}
-pre.pygments .lineno::before{content:"";margin-right:-.125em}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
-.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
-.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
-.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
-table.tableblock{max-width:100%;border-collapse:separate}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-td.tableblock>.content>:last-child.sidebarblock{margin-bottom:0}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
-table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
-table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
-table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
-table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
-table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
-table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
-table.frame-all{border-width:1px}
-table.frame-sides{border-width:0 1px}
-table.frame-topbot,table.frame-ends{border-width:1px 0}
-table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd),table.stripes-even tr:nth-of-type(even),table.stripes-hover tr:hover{background:#f8f8f7}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-ul.checklist{margin-left:.625em}
-ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
-ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
-.imageblock.left{margin:.25em .625em 1.25em 0}
-.imageblock.right{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
-.gist .file-data>table td.line-data{width:99%}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background:#00fafa}
-.black{color:#000}
-.black-background{background:#000}
-.blue{color:#0000bf}
-.blue-background{background:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background:#fa00fa}
-.gray{color:#606060}
-.gray-background{background:#7d7d7d}
-.green{color:#006000}
-.green-background{background:#007d00}
-.lime{color:#00bf00}
-.lime-background{background:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background:#7d0000}
-.navy{color:#000060}
-.navy-background{background:#00007d}
-.olive{color:#606000}
-.olive-background{background:#7d7d00}
-.purple{color:#600060}
-.purple-background{background:#7d007d}
-.red{color:#bf0000}
-.red-background{background:#fa0000}
-.silver{color:#909090}
-.silver-background{background:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_runtime_aligned</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New capabilities</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_5_revision_5">Modifications to the SPIR-V Specification, Version 1.5 Revision 5</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
 <div class="sect1">
@@ -684,11 +288,6 @@ Indicates that the pointer comes directly from a runtime allocation and was not 
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2021-06-29 12:48:33 -0300
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_shader_integer_functions2.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_shader_integer_functions2.asciidoc
@@ -129,13 +129,13 @@ Allow this new functionality... |
  +
 Returns the number of leading 0-bits, starting at the most significant bit, in the binary representation of value.  If value is zero, the size in bits of the type of value or component type of value (if value is a vector) will be returned. +
  +
-'Result Type' must be  a scalar or vector of <<Integer,'integer type'>>, whose 'Width' operand is 32 and whose 'Signedness' operand is 0. +
+_Result Type_ must be  a scalar or vector of <<Integer,_integer type_>>, whose _Width_ operand is 32 and whose _Signedness_ operand is 0. +
  +
-The type of 'Operand' must be the same as 'Result Type'.
+The type of _Operand_ must be the same as _Result Type_.
 
-| 4 | 5585 | '<id>' +
-'Result Type' | 'Result <id>' | '<id> +
-Operand'
+| 4 | 5585 | _<id>_ +
+_Result Type_ | _Result <id>_ | _<id> +
+Operand_
 |======
 
 [cols="2*1,3*2"]
@@ -144,77 +144,77 @@ Operand'
  +
 Returns the number of trailing 0-bits, starting at the least significant bit, in the binary representation of value.  If value is zero, the size in bits of the type of value or component type of value (if value is a vector) will be returned. +
  +
-'Result Type' must be  a scalar or vector of <<Integer,'integer type'>>, whose 'Width' operand is 32 and whose 'Signedness' operand is 0. +
+_Result Type_ must be  a scalar or vector of <<Integer,_integer type_>>, whose _Width_ operand is 32 and whose _Signedness_ operand is 0. +
  +
-The type of 'Operand' must be the same as 'Result Type'.
+The type of _Operand_ must be the same as _Result Type_.
 
-| 4 | 5586 | '<id>' +
-'Result Type' | 'Result <id>' | '<id> +
-Operand'
+| 4 | 5586 | _<id>_ +
+_Result Type_ | _Result <id>_ | _<id> +
+Operand_
 |======
 
 [cols="2*1,4*2"]
 |======
 6+|[[OpAbsISub]]*OpAbsISub* +
  +
-Returns \|x - y\| clamped to the range of 'Result Type' (instead of modulo overflowing). +
+Returns \|x - y\| clamped to the range of _Result Type_ (instead of modulo overflowing). +
  +
-'Result Type' must be  a scalar or vector of <<Integer,'integer type'>>, whose 'Signedness' operand is 0. +
+_Result Type_ must be  a scalar or vector of <<Integer,_integer type_>>, whose _Signedness_ operand is 0. +
  +
-The type of 'Operand 1' and 'Operand 2' must be a scalar or vector of <<Integer,'integer type'>>. They must have the same number of components as 'Result Type'. They must have the same component width as 'Result Type'.
+The type of _Operand 1_ and _Operand 2_ must be a scalar or vector of <<Integer,_integer type_>>. They must have the same number of components as _Result Type_. They must have the same component width as _Result Type_.
 
-| 5 | 5587 | '<id>' +
-'Result Type' | 'Result <id>' | '<id> +
-Operand 1' | '<id> +
-Operand 2'
+| 5 | 5587 | _<id>_ +
+_Result Type_ | _Result <id>_ | _<id> +
+Operand 1_ | _<id> +
+Operand 2_
 |======
 
 [cols="2*1,4*2"]
 |======
 6+|[[OpAbsUSub]]*OpAbsUSub* +
  +
-Returns \|x - y\| clamped to the range of 'Result Type' (instead of modulo overflowing). +
+Returns \|x - y\| clamped to the range of _Result Type_ (instead of modulo overflowing). +
  +
-'Result Type' must be  a scalar or vector of <<Integer,'integer type'>>, whose 'Signedness' operand is 0. +
+_Result Type_ must be  a scalar or vector of <<Integer,_integer type_>>, whose _Signedness_ operand is 0. +
  +
-The type of 'Operand 1' and 'Operand 2' must be the same as 'Result Type'.
+The type of _Operand 1_ and _Operand 2_ must be the same as _Result Type_.
 
-| 5 | 5588 | '<id>' +
-'Result Type' | 'Result <id>' | '<id> +
-Operand 1' | '<id> +
-Operand 2'
+| 5 | 5588 | _<id>_ +
+_Result Type_ | _Result <id>_ | _<id> +
+Operand 1_ | _<id> +
+Operand 2_
 |======
 
 [cols="2*1,4*2"]
 |======
 6+|[[OpIAddSat]]*OpIAddSat* +
  +
-Returns x + y clamped to the range of 'Result Type' (instead of modulo overflowing). +
+Returns x + y clamped to the range of _Result Type_ (instead of modulo overflowing). +
  +
-'Result Type' must be  a scalar or vector of <<Integer,'integer type'>>. +
+_Result Type_ must be  a scalar or vector of <<Integer,_integer type_>>. +
  +
-The type of 'Operand 1' and 'Operand 2' must be the same as 'Result Type'.
+The type of _Operand 1_ and _Operand 2_ must be the same as _Result Type_.
 
-| 5 | 5589 | '<id>' +
-'Result Type' | 'Result <id>' | '<id> +
-Operand 1' | '<id> +
-Operand 2'
+| 5 | 5589 | _<id>_ +
+_Result Type_ | _Result <id>_ | _<id> +
+Operand 1_ | _<id> +
+Operand 2_
 |======
 
 [cols="2*1,4*2"]
 |======
 6+|[[OpUAddSat]]*OpUAddSat* +
  +
-Returns x + y clamped to the range of 'Result Type' (instead of modulo overflowing). +
+Returns x + y clamped to the range of _Result Type_ (instead of modulo overflowing). +
  +
-'Result Type' must be  a scalar or vector of <<Integer,'integer type'>>, whose 'Signedness' operand is 0. +
+_Result Type_ must be  a scalar or vector of <<Integer,_integer type_>>, whose _Signedness_ operand is 0. +
  +
-The type of 'Operand 1' and 'Operand 2' must be the same as 'Result Type'.
+The type of _Operand 1_ and _Operand 2_ must be the same as _Result Type_.
 
-| 5 | 5590 | '<id>' +
-'Result Type' | 'Result <id>' | '<id> +
-Operand 1' | '<id> +
-Operand 2'
+| 5 | 5590 | _<id>_ +
+_Result Type_ | _Result <id>_ | _<id> +
+Operand 1_ | _<id> +
+Operand 2_
 |======
 
 [cols="2*1,4*2"]
@@ -223,14 +223,14 @@ Operand 2'
  +
 Returns (x+y) >> 1.  The intermediate sum does not modulo overflow. +
  +
-'Result Type' must be  a scalar or vector of <<Integer,'integer type'>>. +
+_Result Type_ must be  a scalar or vector of <<Integer,_integer type_>>. +
  +
-The type of 'Operand 1' and 'Operand 2' must be the same as 'Result Type'.
+The type of _Operand 1_ and _Operand 2_ must be the same as _Result Type_.
 
-| 5 | 5591 | '<id>' +
-'Result Type' | 'Result <id>' | '<id> +
-Operand 1' | '<id> +
-Operand 2'
+| 5 | 5591 | _<id>_ +
+_Result Type_ | _Result <id>_ | _<id> +
+Operand 1_ | _<id> +
+Operand 2_
 |======
 
 [cols="2*1,4*2"]
@@ -239,14 +239,14 @@ Operand 2'
  +
 Returns (x+y) >> 1.  The intermediate sum does not modulo overflow. +
  +
-'Result Type' must be  a scalar or vector of <<Integer,'integer type'>>, whose 'Signedness' operand is 0. +
+_Result Type_ must be  a scalar or vector of <<Integer,_integer type_>>, whose _Signedness_ operand is 0. +
  +
-The type of 'Operand 1' and 'Operand 2' must be the same as 'Result Type'.
+The type of _Operand 1_ and _Operand 2_ must be the same as _Result Type_.
 
-| 5 | 5592 | '<id>' +
-'Result Type' | 'Result <id>' | '<id> +
-Operand 1' | '<id> +
-Operand 2'
+| 5 | 5592 | _<id>_ +
+_Result Type_ | _Result <id>_ | _<id> +
+Operand 1_ | _<id> +
+Operand 2_
 |======
 
 [cols="2*1,4*2"]
@@ -255,14 +255,14 @@ Operand 2'
  +
 Returns (x+y+1) >> 1.  The intermediate sum does not modulo overflow. +
  +
-'Result Type' must be  a scalar or vector of <<Integer,'integer type'>>. +
+_Result Type_ must be  a scalar or vector of <<Integer,_integer type_>>. +
  +
-The type of 'Operand 1' and 'Operand 2' must be the same as 'Result Type'.
+The type of _Operand 1_ and _Operand 2_ must be the same as _Result Type_.
 
-| 5 | 5593 | '<id>' +
-'Result Type' | 'Result <id>' | '<id> +
-Operand 1' | '<id> +
-Operand 2'
+| 5 | 5593 | _<id>_ +
+_Result Type_ | _Result <id>_ | _<id> +
+Operand 1_ | _<id> +
+Operand 2_
 |======
 
 [cols="2*1,4*2"]
@@ -271,78 +271,78 @@ Operand 2'
  +
 Returns (x+y+1) >> 1.  The intermediate sum does not modulo overflow. +
  +
-'Result Type' must be  a scalar or vector of <<Integer,'integer type'>>, whose 'Signedness' operand is 0. +
+_Result Type_ must be  a scalar or vector of <<Integer,_integer type_>>, whose _Signedness_ operand is 0. +
  +
-The type of 'Operand 1' and 'Operand 2' must be the same as 'Result Type'.
+The type of _Operand 1_ and _Operand 2_ must be the same as _Result Type_.
 
-| 5 | 5594 | '<id>' +
-'Result Type' | 'Result <id>' | '<id> +
-Operand 1' | '<id> +
-Operand 2'
+| 5 | 5594 | _<id>_ +
+_Result Type_ | _Result <id>_ | _<id> +
+Operand 1_ | _<id> +
+Operand 2_
 |======
 
 [cols="2*1,4*2"]
 |======
 6+|[[OpISubSat]]*OpISubSat* +
  +
-Returns x - y clamped to the range of 'Result Type' (instead of modulo overflowing). +
+Returns x - y clamped to the range of _Result Type_ (instead of modulo overflowing). +
  +
-'Result Type' must be  a scalar or vector of <<Integer,'integer type'>>. +
+_Result Type_ must be  a scalar or vector of <<Integer,_integer type_>>. +
  +
-The type of 'Operand 1' and 'Operand 2' must be the same as 'Result Type'.
+The type of _Operand 1_ and _Operand 2_ must be the same as _Result Type_.
 
-| 5 | 5595 | '<id>' +
-'Result Type' | 'Result <id>' | '<id> +
-Operand 1' | '<id> +
-Operand 2'
+| 5 | 5595 | _<id>_ +
+_Result Type_ | _Result <id>_ | _<id> +
+Operand 1_ | _<id> +
+Operand 2_
 |======
 
 [cols="2*1,4*2"]
 |======
 6+|[[OpUSubSat]]*OpUSubSat* +
  +
-Returns x - y clamped to the range of 'Result Type' (instead of modulo overflowing). +
+Returns x - y clamped to the range of _Result Type_ (instead of modulo overflowing). +
  +
-'Result Type' must be  a scalar or vector of <<Integer,'integer type'>>, whose 'Signedness' operand is 0. +
+_Result Type_ must be  a scalar or vector of <<Integer,_integer type_>>, whose _Signedness_ operand is 0. +
  +
-The type of 'Operand 1' and 'Operand 2' must be the same as 'Result Type'.
+The type of _Operand 1_ and _Operand 2_ must be the same as _Result Type_.
 
-| 5 | 5596 | '<id>' +
-'Result Type' | 'Result <id>' | '<id> +
-Operand 1' | '<id> +
-Operand 2'
+| 5 | 5596 | _<id>_ +
+_Result Type_ | _Result <id>_ | _<id> +
+Operand 1_ | _<id> +
+Operand 2_
 |======
 
 [cols="2*1,4*2"]
 |======
 6+|[[OpIMul32x16]]*OpIMul32x16* +
  +
-Integer multiplication of 'Operand 1' and 'Operand 2'.  The low 16-bits of 'Operand 2' are sign extended to 32-bits before performing the multiplication. +
+Integer multiplication of _Operand 1_ and _Operand 2_.  The low 16-bits of _Operand 2_ are sign extended to 32-bits before performing the multiplication. +
  +
-'Result Type' must be  a scalar or vector of <<Integer,'integer type'>>, whose 'Width' operand is 32. +
+_Result Type_ must be  a scalar or vector of <<Integer,_integer type_>>, whose _Width_ operand is 32. +
  +
-The type of 'Operand 1' and 'Operand 2' must be the same type as 'Result Type'.
+The type of _Operand 1_ and _Operand 2_ must be the same type as _Result Type_.
 
-| 5 | 5597 | '<id>' +
-'Result Type' | 'Result <id>' | '<id> +
-Operand 1' | '<id> +
-Operand 2'
+| 5 | 5597 | _<id>_ +
+_Result Type_ | _Result <id>_ | _<id> +
+Operand 1_ | _<id> +
+Operand 2_
 |======
 
 [cols="2*1,4*2"]
 |======
 6+|[[OpUMul32x16]]*OpUMul32x16* +
  +
-Integer multiplication of 'Operand 1' and 'Operand 2'.  The high 16-bits of 'Operand 2' are replaced with 0x0000 before performing the multiplication. +
+Integer multiplication of _Operand 1_ and _Operand 2_.  The high 16-bits of _Operand 2_ are replaced with 0x0000 before performing the multiplication. +
  +
-'Result Type' must be  a scalar or vector of <<Integer,'integer type'>>, whose 'Width' operand is 32 and whose 'Signedness' operand is 0. +
+_Result Type_ must be  a scalar or vector of <<Integer,_integer type_>>, whose _Width_ operand is 32 and whose _Signedness_ operand is 0. +
  +
-The type of 'Operand 1' and 'Operand 2' must be the same type as 'Result Type'.
+The type of _Operand 1_ and _Operand 2_ must be the same type as _Result Type_.
 
-| 5 | 5598 | '<id>' +
-'Result Type' | 'Result <id>' | '<id> +
-Operand 1' | '<id> +
-Operand 2'
+| 5 | 5598 | _<id>_ +
+_Result Type_ | _Result <id>_ | _<id> +
+Operand 1_ | _<id> +
+Operand 2_
 |======
 
 

--- a/extensions/INTEL/SPV_INTEL_shader_integer_functions2.html
+++ b/extensions/INTEL/SPV_INTEL_shader_integer_functions2.html
@@ -1,838 +1,116 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta name="generator" content="AsciiDoc 8.6.10">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_shader_integer_functions2</title>
-<style type="text/css">
-/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
-
-/* Default font. */
-body {
-  font-family: Georgia,serif;
-}
-
-/* Title font. */
-h1, h2, h3, h4, h5, h6,
-div.title, caption.title,
-thead, p.table.header,
-#toctitle,
-#author, #revnumber, #revdate, #revremark,
-#footer {
-  font-family: Arial,Helvetica,sans-serif;
-}
-
-body {
-  margin: 1em 5% 1em 5%;
-}
-
-a {
-  color: blue;
-  text-decoration: underline;
-}
-a:visited {
-  color: fuchsia;
-}
-
-em {
-  font-style: italic;
-  color: navy;
-}
-
-strong {
-  font-weight: bold;
-  color: #083194;
-}
-
-h1, h2, h3, h4, h5, h6 {
-  color: #527bbd;
-  margin-top: 1.2em;
-  margin-bottom: 0.5em;
-  line-height: 1.3;
-}
-
-h1, h2, h3 {
-  border-bottom: 2px solid silver;
-}
-h2 {
-  padding-top: 0.5em;
-}
-h3 {
-  float: left;
-}
-h3 + * {
-  clear: left;
-}
-h5 {
-  font-size: 1.0em;
-}
-
-div.sectionbody {
-  margin-left: 0;
-}
-
-hr {
-  border: 1px solid silver;
-}
+<style>
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
 
 p {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
 }
 
-ul, ol, li > p {
-  margin-top: 0;
-}
-ul > li     { color: #aaa; }
-ul > li > * { color: black; }
-
-.monospaced, code, pre {
-  font-family: "Courier New", Courier, monospace;
-  font-size: inherit;
-  color: navy;
-  padding: 0;
-  margin: 0;
-}
-pre {
-  white-space: pre-wrap;
-}
-
-#author {
-  color: #527bbd;
-  font-weight: bold;
-  font-size: 1.1em;
-}
-#email {
-}
-#revnumber, #revdate, #revremark {
-}
-
-#footer {
-  font-size: small;
-  border-top: 2px solid silver;
-  padding-top: 0.5em;
-  margin-top: 4.0em;
-}
-#footer-text {
-  float: left;
-  padding-bottom: 0.5em;
-}
-#footer-badges {
-  float: right;
-  padding-bottom: 0.5em;
-}
-
-#preamble {
-  margin-top: 1.5em;
-  margin-bottom: 1.5em;
-}
-div.imageblock, div.exampleblock, div.verseblock,
-div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
-div.admonitionblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.admonitionblock {
-  margin-top: 2.0em;
-  margin-bottom: 2.0em;
-  margin-right: 10%;
-  color: #606060;
-}
-
-div.content { /* Block element content. */
-  padding: 0;
-}
-
-/* Block element titles. */
-div.title, caption.title {
-  color: #527bbd;
-  font-weight: bold;
-  text-align: left;
-  margin-top: 1.0em;
-  margin-bottom: 0.5em;
-}
-div.title + * {
-  margin-top: 0;
-}
-
-td div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content + div.title {
-  margin-top: 0.0em;
-}
-
-div.sidebarblock > div.content {
-  background: #ffffee;
-  border: 1px solid #dddddd;
-  border-left: 4px solid #f0f0f0;
-  padding: 0.5em;
-}
-
-div.listingblock > div.content {
-  border: 1px solid #dddddd;
-  border-left: 5px solid #f0f0f0;
-  background: #f8f8f8;
-  padding: 0.5em;
-}
-
-div.quoteblock, div.verseblock {
-  padding-left: 1.0em;
-  margin-left: 1.0em;
-  margin-right: 10%;
-  border-left: 5px solid #f0f0f0;
-  color: #888;
-}
-
-div.quoteblock > div.attribution {
-  padding-top: 0.5em;
-  text-align: right;
-}
-
-div.verseblock > pre.content {
-  font-family: inherit;
-  font-size: inherit;
-}
-div.verseblock > div.attribution {
-  padding-top: 0.75em;
-  text-align: left;
-}
-/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
-div.verseblock + div.attribution {
-  text-align: left;
-}
-
-div.admonitionblock .icon {
-  vertical-align: top;
-  font-size: 1.1em;
-  font-weight: bold;
-  text-decoration: underline;
-  color: #527bbd;
-  padding-right: 0.5em;
-}
-div.admonitionblock td.content {
-  padding-left: 0.5em;
-  border-left: 3px solid #dddddd;
-}
-
-div.exampleblock > div.content {
-  border-left: 3px solid #dddddd;
-  padding-left: 0.5em;
-}
-
-div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; vertical-align: text-bottom; }
-a.image:visited { color: white; }
-
-dl {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-dt {
-  margin-top: 0.5em;
-  margin-bottom: 0;
-  font-style: normal;
-  color: navy;
-}
-dd > *:first-child {
-  margin-top: 0.1em;
-}
-
-ul, ol {
-    list-style-position: outside;
-}
-ol.arabic {
-  list-style-type: decimal;
-}
-ol.loweralpha {
-  list-style-type: lower-alpha;
-}
-ol.upperalpha {
-  list-style-type: upper-alpha;
-}
-ol.lowerroman {
-  list-style-type: lower-roman;
-}
-ol.upperroman {
-  list-style-type: upper-roman;
-}
-
-div.compact ul, div.compact ol,
-div.compact p, div.compact p,
-div.compact div, div.compact div {
-  margin-top: 0.1em;
-  margin-bottom: 0.1em;
-}
-
-tfoot {
-  font-weight: bold;
-}
-td > div.verse {
-  white-space: pre;
-}
-
-div.hdlist {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-div.hdlist tr {
-  padding-bottom: 15px;
-}
-dt.hdlist1.strong, td.hdlist1.strong {
-  font-weight: bold;
-}
-td.hdlist1 {
-  vertical-align: top;
-  font-style: normal;
-  padding-right: 0.8em;
-  color: navy;
-}
-td.hdlist2 {
-  vertical-align: top;
-}
-div.hdlist.compact tr {
-  margin: 0;
-  padding-bottom: 0;
-}
-
-.comment {
-  background: yellow;
-}
-
-.footnote, .footnoteref {
-  font-size: 0.8em;
-}
-
-span.footnote, span.footnoteref {
-  vertical-align: super;
-}
-
-#footnotes {
-  margin: 20px 0 20px 0;
-  padding: 7px 0 0 0;
-}
-
-#footnotes div.footnote {
-  margin: 0 0 5px 0;
-}
-
-#footnotes hr {
-  border: none;
-  border-top: 1px solid silver;
-  height: 1px;
-  text-align: left;
-  margin-left: 0;
-  width: 20%;
-  min-width: 100px;
-}
-
-div.colist td {
-  padding-right: 0.5em;
-  padding-bottom: 0.3em;
-  vertical-align: top;
-}
-div.colist td img {
-  margin-top: 0.3em;
-}
-
-@media print {
-  #footer-badges { display: none; }
-}
-
-#toc {
-  margin-bottom: 2.5em;
-}
-
-#toctitle {
-  color: #527bbd;
-  font-size: 1.1em;
-  font-weight: bold;
-  margin-top: 1.0em;
-  margin-bottom: 0.1em;
-}
-
-div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-div.toclevel2 {
-  margin-left: 2em;
-  font-size: 0.9em;
-}
-div.toclevel3 {
-  margin-left: 4em;
-  font-size: 0.9em;
-}
-div.toclevel4 {
-  margin-left: 6em;
-  font-size: 0.9em;
-}
-
-span.aqua { color: aqua; }
-span.black { color: black; }
-span.blue { color: blue; }
-span.fuchsia { color: fuchsia; }
-span.gray { color: gray; }
-span.green { color: green; }
-span.lime { color: lime; }
-span.maroon { color: maroon; }
-span.navy { color: navy; }
-span.olive { color: olive; }
-span.purple { color: purple; }
-span.red { color: red; }
-span.silver { color: silver; }
-span.teal { color: teal; }
-span.white { color: white; }
-span.yellow { color: yellow; }
-
-span.aqua-background { background: aqua; }
-span.black-background { background: black; }
-span.blue-background { background: blue; }
-span.fuchsia-background { background: fuchsia; }
-span.gray-background { background: gray; }
-span.green-background { background: green; }
-span.lime-background { background: lime; }
-span.maroon-background { background: maroon; }
-span.navy-background { background: navy; }
-span.olive-background { background: olive; }
-span.purple-background { background: purple; }
-span.red-background { background: red; }
-span.silver-background { background: silver; }
-span.teal-background { background: teal; }
-span.white-background { background: white; }
-span.yellow-background { background: yellow; }
-
-span.big { font-size: 2em; }
-span.small { font-size: 0.6em; }
-
-span.underline { text-decoration: underline; }
-span.overline { text-decoration: overline; }
-span.line-through { text-decoration: line-through; }
-
-div.unbreakable { page-break-inside: avoid; }
-
-
-/*
- * xhtml11 specific
- *
- * */
-
-div.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.tableblock > table {
-  border: 3px solid #527bbd;
-}
-thead, p.table.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.table {
-  margin-top: 0;
-}
-/* Because the table frame attribute is overriden by CSS in most browsers. */
-div.tableblock > table[frame="void"] {
-  border-style: none;
-}
-div.tableblock > table[frame="hsides"] {
-  border-left-style: none;
-  border-right-style: none;
-}
-div.tableblock > table[frame="vsides"] {
-  border-top-style: none;
-  border-bottom-style: none;
-}
-
-
-/*
- * html5 specific
- *
- * */
-
-table.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-thead, p.tableblock.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.tableblock {
-  margin-top: 0;
-}
-table.tableblock {
-  border-width: 3px;
-  border-spacing: 0px;
-  border-style: solid;
-  border-color: #527bbd;
-  border-collapse: collapse;
-}
-th.tableblock, td.tableblock {
-  border-width: 1px;
-  padding: 4px;
-  border-style: solid;
-  border-color: #527bbd;
-}
-
-table.tableblock.frame-topbot {
-  border-left-style: hidden;
-  border-right-style: hidden;
-}
-table.tableblock.frame-sides {
-  border-top-style: hidden;
-  border-bottom-style: hidden;
-}
-table.tableblock.frame-none {
-  border-style: hidden;
-}
-
-th.tableblock.halign-left, td.tableblock.halign-left {
-  text-align: left;
-}
-th.tableblock.halign-center, td.tableblock.halign-center {
-  text-align: center;
-}
-th.tableblock.halign-right, td.tableblock.halign-right {
-  text-align: right;
-}
-
-th.tableblock.valign-top, td.tableblock.valign-top {
-  vertical-align: top;
-}
-th.tableblock.valign-middle, td.tableblock.valign-middle {
-  vertical-align: middle;
-}
-th.tableblock.valign-bottom, td.tableblock.valign-bottom {
-  vertical-align: bottom;
-}
-
-
-/*
- * manpage specific
- *
- * */
-
-body.manpage h1 {
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
-  border-top: 2px solid silver;
-  border-bottom: 2px solid silver;
-}
-body.manpage h2 {
-  border-style: none;
-}
-body.manpage div.sectionbody {
-  margin-left: 3em;
-}
-
-@media print {
-  body.manpage div#toc { display: none; }
-}
-
-
-@media screen {
-  body {
-    max-width: 50em; /* approximately 80 characters wide */
-    margin-left: 16em;
-  }
-
-  #toc {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 13em;
-    padding: 0.5em;
-    padding-bottom: 1.5em;
-    margin: 0;
-    overflow: auto;
-    border-right: 3px solid #f8f8f8;
-    background-color: white;
-  }
-
-  #toc .toclevel1 {
-    margin-top: 0.5em;
-  }
-
-  #toc .toclevel2 {
-    margin-top: 0.25em;
-    display: list-item;
-    color: #aaaaaa;
-  }
-
-  #toctitle {
-    margin-top: 0.5em;
-  }
-}
 </style>
-<script type="text/javascript">
-/*<![CDATA[*/
-var asciidoc = {  // Namespace.
-
-/////////////////////////////////////////////////////////////////////
-// Table Of Contents generator
-/////////////////////////////////////////////////////////////////////
-
-/* Author: Mihai Bazon, September 2002
- * http://students.infoiasi.ro/~mishoo
- *
- * Table Of Content generator
- * Version: 0.4
- *
- * Feel free to use this script under the terms of the GNU General Public
- * License, as long as you do not remove or alter this notice.
- */
-
- /* modified by Troy D. Hanson, September 2006. License: GPL */
- /* modified by Stuart Rackham, 2006, 2009. License: GPL */
-
-// toclevels = 1..4.
-toc: function (toclevels) {
-
-  function getText(el) {
-    var text = "";
-    for (var i = el.firstChild; i != null; i = i.nextSibling) {
-      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
-        text += i.data;
-      else if (i.firstChild != null)
-        text += getText(i);
-    }
-    return text;
-  }
-
-  function TocEntry(el, text, toclevel) {
-    this.element = el;
-    this.text = text;
-    this.toclevel = toclevel;
-  }
-
-  function tocEntries(el, toclevels) {
-    var result = new Array;
-    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
-    // Function that scans the DOM tree for header elements (the DOM2
-    // nodeIterator API would be a better technique but not supported by all
-    // browsers).
-    var iterate = function (el) {
-      for (var i = el.firstChild; i != null; i = i.nextSibling) {
-        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
-          var mo = re.exec(i.tagName);
-          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
-            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
-          }
-          iterate(i);
-        }
-      }
-    }
-    iterate(el);
-    return result;
-  }
-
-  var toc = document.getElementById("toc");
-  if (!toc) {
-    return;
-  }
-
-  // Delete existing TOC entries in case we're reloading the TOC.
-  var tocEntriesToRemove = [];
-  var i;
-  for (i = 0; i < toc.childNodes.length; i++) {
-    var entry = toc.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div'
-     && entry.getAttribute("class")
-     && entry.getAttribute("class").match(/^toclevel/))
-      tocEntriesToRemove.push(entry);
-  }
-  for (i = 0; i < tocEntriesToRemove.length; i++) {
-    toc.removeChild(tocEntriesToRemove[i]);
-  }
-
-  // Rebuild TOC entries.
-  var entries = tocEntries(document.getElementById("content"), toclevels);
-  for (var i = 0; i < entries.length; ++i) {
-    var entry = entries[i];
-    if (entry.element.id == "")
-      entry.element.id = "_toc_" + i;
-    var a = document.createElement("a");
-    a.href = "#" + entry.element.id;
-    a.appendChild(document.createTextNode(entry.text));
-    var div = document.createElement("div");
-    div.appendChild(a);
-    div.className = "toclevel" + entry.toclevel;
-    toc.appendChild(div);
-  }
-  if (entries.length == 0)
-    toc.parentNode.removeChild(toc);
-},
-
-
-/////////////////////////////////////////////////////////////////////
-// Footnotes generator
-/////////////////////////////////////////////////////////////////////
-
-/* Based on footnote generation code from:
- * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
- */
-
-footnotes: function () {
-  // Delete existing footnote entries in case we're reloading the footnodes.
-  var i;
-  var noteholder = document.getElementById("footnotes");
-  if (!noteholder) {
-    return;
-  }
-  var entriesToRemove = [];
-  for (i = 0; i < noteholder.childNodes.length; i++) {
-    var entry = noteholder.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
-      entriesToRemove.push(entry);
-  }
-  for (i = 0; i < entriesToRemove.length; i++) {
-    noteholder.removeChild(entriesToRemove[i]);
-  }
-
-  // Rebuild footnote entries.
-  var cont = document.getElementById("content");
-  var spans = cont.getElementsByTagName("span");
-  var refs = {};
-  var n = 0;
-  for (i=0; i<spans.length; i++) {
-    if (spans[i].className == "footnote") {
-      n++;
-      var note = spans[i].getAttribute("data-note");
-      if (!note) {
-        // Use [\s\S] in place of . so multi-line matches work.
-        // Because JavaScript has no s (dotall) regex flag.
-        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
-        spans[i].innerHTML =
-          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-        spans[i].setAttribute("data-note", note);
-      }
-      noteholder.innerHTML +=
-        "<div class='footnote' id='_footnote_" + n + "'>" +
-        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
-        n + "</a>. " + note + "</div>";
-      var id =spans[i].getAttribute("id");
-      if (id != null) refs["#"+id] = n;
-    }
-  }
-  if (n == 0)
-    noteholder.parentNode.removeChild(noteholder);
-  else {
-    // Process footnoterefs.
-    for (i=0; i<spans.length; i++) {
-      if (spans[i].className == "footnoteref") {
-        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
-        href = href.match(/#.*/)[0];  // Because IE return full URL.
-        n = refs[href];
-        spans[i].innerHTML =
-          "[<a href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-      }
-    }
-  }
-},
-
-install: function(toclevels) {
-  var timerId;
-
-  function reinstall() {
-    asciidoc.footnotes();
-    if (toclevels) {
-      asciidoc.toc(toclevels);
-    }
-  }
-
-  function reinstallAndRemoveTimer() {
-    clearInterval(timerId);
-    reinstall();
-  }
-
-  timerId = setInterval(reinstall, 500);
-  if (document.addEventListener)
-    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
-  else
-    window.onload = reinstallAndRemoveTimer;
-}
-
-}
-asciidoc.install(1);
-/*]]>*/
-</script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_shader_integer_functions2</h1>
-<div id="toc">
-  <div id="toctitle">Table of Contents</div>
-  <noscript><p><b>JavaScript must be enabled in your browser to display the table of contents.</b></p></noscript>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_new_instructions">New Instructions</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_3">Modifications to the SPIR-V Specification, Version 1.3</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
 </div>
 </div>
 <div id="content">
 <div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>SPV_INTEL_shader_integer_functions2</p></div>
+<div class="paragraph">
+<p>SPV_INTEL_shader_integer_functions2</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>See <strong>Issues</strong> list in the Khronos SPIRV-Registry repository:
-<a href="https://github.com/KhronosGroup/SPIRV-Registry">https://github.com/KhronosGroup/SPIRV-Registry</a></p></div>
+<div class="paragraph">
+<p>See <strong>Issues</strong> list in the Khronos SPIRV-Registry repository:
+<a href="https://github.com/KhronosGroup/SPIRV-Registry" class="bare">https://github.com/KhronosGroup/SPIRV-Registry</a></p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Ian Romanick, Intel<br>
-</p>
+<p>Ian Romanick, Intel<br></p>
 </li>
 <li>
-<p>
-Ben Ashbaugh, Intel
-</p>
+<p>Ben Ashbaugh, Intel</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Copyright (c) 2018 The Khronos Group Inc. Copyright terms at
-<a href="http://www.khronos.org/registry/speccopyright.html">http://www.khronos.org/registry/speccopyright.html</a></p></div>
+<div class="paragraph">
+<p>Copyright (c) 2018 The Khronos Group Inc. Copyright terms at
+<a href="http://www.khronos.org/registry/speccopyright.html" class="bare">http://www.khronos.org/registry/speccopyright.html</a></p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Final Draft</p></div>
+<div class="paragraph">
+<p>Final Draft</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all"
-style="
-width:40%;
-">
-<col style="width:50%;">
-<col style="width:50%;">
+<table class="tableblock frame-all grid-all" style="width: 40%;">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2019-01-22</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2019-01-22</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
 </tr>
 </tbody>
 </table>
@@ -841,45 +119,61 @@ width:40%;
 <div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension is written against the SPIR-V Specification,
-Version 1.3 Revision 1.</p></div>
-<div class="paragraph"><p>This extension requires SPIR-V 1.0.</p></div>
+<div class="paragraph">
+<p>This extension is written against the SPIR-V Specification,
+Version 1.3 Revision 1.</p>
+</div>
+<div class="paragraph">
+<p>This extension requires SPIR-V 1.0.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension is written to provide the functionality of the INTEL_shader_integer_functions2, OpenGL Shading Language Specification extensions, to SPIR-V.</p></div>
-<div class="paragraph"><p>This extension introduces several new integer instructions to SPIR-V for use in graphics shaders.  Many of these instructions have pre-existing counterparts in the Kernel environment.</p></div>
+<div class="paragraph">
+<p>This extension is written to provide the functionality of the INTEL_shader_integer_functions2, OpenGL Shading Language Specification extensions, to SPIR-V.</p>
+</div>
+<div class="paragraph">
+<p>This extension introduces several new integer instructions to SPIR-V for use in graphics shaders.  Many of these instructions have pre-existing counterparts in the Kernel environment.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_extension_name">Extension Name</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>To use this extension within a SPIR-V module, the following
-<strong>OpExtension</strong> must be present in the module:</p></div>
+<div class="paragraph">
+<p>To use this extension within a SPIR-V module, the following
+<strong>OpExtension</strong> must be present in the module:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpExtension "SPV_INTEL_shader_integer_functions2"</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_capabilities">New Capabilities</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension introduces a new capability:</p></div>
+<div class="paragraph">
+<p>This extension introduces a new capability:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>IntegerFunctions2INTEL</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_instructions">New Instructions</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Instructions added under <strong>IntegerFunctions2INTEL</strong> capability.</p></div>
+<div class="paragraph">
+<p>Instructions added under <strong>IntegerFunctions2INTEL</strong> capability.</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpUCountLeadingZeros
 OpUCountTrailingZeros
 OpAbsISub
@@ -894,101 +188,101 @@ OpISubSat
 OpUSubSat
 OpIMul32x16
 OpUMul32x16</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:75%;
-">
-<col style="width:50%;">
-<col style="width:20%;">
-<col style="width:30%;">
+<table class="tableblock frame-all grid-rows" style="width: 75%;">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 20%;">
+<col style="width: 30%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" > Name                          </th>
-<th class="tableblock halign-left valign-top" > Value </th>
-<th class="tableblock halign-left valign-top" > Usage</th>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Value</th>
+<th class="tableblock halign-left valign-top">Usage</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>IntegerFunctions2INTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5584</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>IntegerFunctions2INTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5584</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>OpUCountLeadingZeros</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5585</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Opcode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>OpUCountLeadingZeros</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5585</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Opcode</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>OpUCountTrailingZeros</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5586</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Opcode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>OpUCountTrailingZeros</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5586</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Opcode</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>OpAbsISub</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5587</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Opcode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>OpAbsISub</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5587</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Opcode</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>OpAbsUSub</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5588</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Opcode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>OpAbsUSub</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5588</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Opcode</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>OpIAddSat</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5589</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Opcode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>OpIAddSat</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5589</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Opcode</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>OpUAddSat</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5590</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Opcode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>OpUAddSat</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5590</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Opcode</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>OpIAverage</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5591</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Opcode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>OpIAverage</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5591</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Opcode</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>OpUAverage</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5592</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Opcode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>OpUAverage</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5592</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Opcode</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>OpIAverageRounded</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5593</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Opcode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>OpIAverageRounded</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5593</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Opcode</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>OpUAverageRounded</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5594</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Opcode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>OpUAverageRounded</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5594</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Opcode</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>OpISubSat</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5595</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Opcode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>OpISubSat</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5595</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Opcode</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>OpUSubSat</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5596</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Opcode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>OpUSubSat</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5596</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Opcode</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>OpIMul32x16</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5597</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Opcode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>OpIMul32x16</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5597</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Opcode</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>OpUMul32x16</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5598</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Opcode</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>OpUMul32x16</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5598</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Opcode</p></td>
 </tr>
 </tbody>
 </table>
@@ -999,45 +293,48 @@ width:75%;
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_capabilities">Capabilities</h3>
-<div class="paragraph"><p>Modify Section 3.31, "Capability", adding these rows to the Capability table:</p></div>
+<div class="paragraph">
+<p>Modify Section 3.31, "Capability", adding these rows to the Capability table:</p>
+</div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:33%;">
-<col style="width:33%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-center valign-top" colspan="2" > Capability </th>
-<th class="tableblock halign-center valign-top" > Depends On</th>
+<th class="tableblock halign-center valign-top" colspan="2">Capability</th>
+<th class="tableblock halign-center valign-top">Depends On</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5584</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>IntegerFunctions2INTEL</strong><br>
-Allow this new functionality&#8230;</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5584</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>IntegerFunctions2INTEL</strong><br>
+Allow this new functionality&#8230;&#8203;</p></td>
+<td class="tableblock halign-left valign-top"></td>
 </tr>
 </tbody>
 </table>
-</div></div>
-<div class="paragraph"><p>(Add to the table in 3.32.13, Arithmetic Instructions)</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:25%;">
+</div>
+</div>
+<div class="paragraph">
+<p>(Add to the table in 3.32.13, Arithmetic Instructions)</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><p class="tableblock"><a id="OpUCountLeadingZeros"></a><strong>OpUCountLeadingZeros</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><a id="OpUCountLeadingZeros"></a><strong>OpUCountLeadingZeros</strong><br>
 <br>
 Returns the number of leading 0-bits, starting at the most significant bit, in the binary representation of value.  If value is zero, the size in bits of the type of value or component type of value (if value is a vector) will be returned.<br>
 <br>
@@ -1046,28 +343,27 @@ Returns the number of leading 0-bits, starting at the most significant bit, in t
 The type of <em>Operand</em> must be the same as <em>Result Type</em>.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5585</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5585</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:25%;">
-<col style="width:25%;">
-<col style="width:25%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><p class="tableblock"><a id="OpUCountTrailingZeros"></a><strong>OpUCountTrailingZeros</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><a id="OpUCountTrailingZeros"></a><strong>OpUCountTrailingZeros</strong><br>
 <br>
 Returns the number of trailing 0-bits, starting at the least significant bit, in the binary representation of value.  If value is zero, the size in bits of the type of value or component type of value (if value is a vector) will be returned.<br>
 <br>
@@ -1076,29 +372,28 @@ Returns the number of trailing 0-bits, starting at the least significant bit, in
 The type of <em>Operand</em> must be the same as <em>Result Type</em>.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5586</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5586</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpAbsISub"></a><strong>OpAbsISub</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpAbsISub"></a><strong>OpAbsISub</strong><br>
 <br>
 Returns |x - y| clamped to the range of <em>Result Type</em> (instead of modulo overflowing).<br>
 <br>
@@ -1107,31 +402,30 @@ Returns |x - y| clamped to the range of <em>Result Type</em> (instead of modulo 
 The type of <em>Operand 1</em> and <em>Operand 2</em> must be a scalar or vector of <a href="#Integer"><em>integer type</em></a>. They must have the same number of components as <em>Result Type</em>. They must have the same component width as <em>Result Type</em>.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5587</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5587</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 1</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 2</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpAbsUSub"></a><strong>OpAbsUSub</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpAbsUSub"></a><strong>OpAbsUSub</strong><br>
 <br>
 Returns |x - y| clamped to the range of <em>Result Type</em> (instead of modulo overflowing).<br>
 <br>
@@ -1140,31 +434,30 @@ Returns |x - y| clamped to the range of <em>Result Type</em> (instead of modulo 
 The type of <em>Operand 1</em> and <em>Operand 2</em> must be the same as <em>Result Type</em>.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5588</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5588</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 1</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 2</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpIAddSat"></a><strong>OpIAddSat</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpIAddSat"></a><strong>OpIAddSat</strong><br>
 <br>
 Returns x + y clamped to the range of <em>Result Type</em> (instead of modulo overflowing).<br>
 <br>
@@ -1173,31 +466,30 @@ Returns x + y clamped to the range of <em>Result Type</em> (instead of modulo ov
 The type of <em>Operand 1</em> and <em>Operand 2</em> must be the same as <em>Result Type</em>.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5589</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5589</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 1</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 2</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpUAddSat"></a><strong>OpUAddSat</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpUAddSat"></a><strong>OpUAddSat</strong><br>
 <br>
 Returns x + y clamped to the range of <em>Result Type</em> (instead of modulo overflowing).<br>
 <br>
@@ -1206,31 +498,30 @@ Returns x + y clamped to the range of <em>Result Type</em> (instead of modulo ov
 The type of <em>Operand 1</em> and <em>Operand 2</em> must be the same as <em>Result Type</em>.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5590</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5590</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 1</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 2</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpIAverage"></a><strong>OpIAverage</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpIAverage"></a><strong>OpIAverage</strong><br>
 <br>
 Returns (x+y) &gt;&gt; 1.  The intermediate sum does not modulo overflow.<br>
 <br>
@@ -1239,31 +530,30 @@ Returns (x+y) &gt;&gt; 1.  The intermediate sum does not modulo overflow.<br>
 The type of <em>Operand 1</em> and <em>Operand 2</em> must be the same as <em>Result Type</em>.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5591</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5591</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 1</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 2</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpUAverage"></a><strong>OpUAverage</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpUAverage"></a><strong>OpUAverage</strong><br>
 <br>
 Returns (x+y) &gt;&gt; 1.  The intermediate sum does not modulo overflow.<br>
 <br>
@@ -1272,31 +562,30 @@ Returns (x+y) &gt;&gt; 1.  The intermediate sum does not modulo overflow.<br>
 The type of <em>Operand 1</em> and <em>Operand 2</em> must be the same as <em>Result Type</em>.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5592</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5592</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 1</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 2</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpIAverageRounded"></a><strong>OpIAverageRounded</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpIAverageRounded"></a><strong>OpIAverageRounded</strong><br>
 <br>
 Returns (x+y+1) &gt;&gt; 1.  The intermediate sum does not modulo overflow.<br>
 <br>
@@ -1305,31 +594,30 @@ Returns (x+y+1) &gt;&gt; 1.  The intermediate sum does not modulo overflow.<br>
 The type of <em>Operand 1</em> and <em>Operand 2</em> must be the same as <em>Result Type</em>.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5593</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5593</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 1</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 2</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpUAverageRounded"></a><strong>OpUAverageRounded</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpUAverageRounded"></a><strong>OpUAverageRounded</strong><br>
 <br>
 Returns (x+y+1) &gt;&gt; 1.  The intermediate sum does not modulo overflow.<br>
 <br>
@@ -1338,31 +626,30 @@ Returns (x+y+1) &gt;&gt; 1.  The intermediate sum does not modulo overflow.<br>
 The type of <em>Operand 1</em> and <em>Operand 2</em> must be the same as <em>Result Type</em>.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5594</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5594</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 1</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 2</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpISubSat"></a><strong>OpISubSat</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpISubSat"></a><strong>OpISubSat</strong><br>
 <br>
 Returns x - y clamped to the range of <em>Result Type</em> (instead of modulo overflowing).<br>
 <br>
@@ -1371,31 +658,30 @@ Returns x - y clamped to the range of <em>Result Type</em> (instead of modulo ov
 The type of <em>Operand 1</em> and <em>Operand 2</em> must be the same as <em>Result Type</em>.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5595</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5595</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 1</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 2</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpUSubSat"></a><strong>OpUSubSat</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpUSubSat"></a><strong>OpUSubSat</strong><br>
 <br>
 Returns x - y clamped to the range of <em>Result Type</em> (instead of modulo overflowing).<br>
 <br>
@@ -1404,31 +690,30 @@ Returns x - y clamped to the range of <em>Result Type</em> (instead of modulo ov
 The type of <em>Operand 1</em> and <em>Operand 2</em> must be the same as <em>Result Type</em>.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5596</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5596</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 1</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 2</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpIMul32x16"></a><strong>OpIMul32x16</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpIMul32x16"></a><strong>OpIMul32x16</strong><br>
 <br>
 Integer multiplication of <em>Operand 1</em> and <em>Operand 2</em>.  The low 16-bits of <em>Operand 2</em> are sign extended to 32-bits before performing the multiplication.<br>
 <br>
@@ -1437,31 +722,30 @@ Integer multiplication of <em>Operand 1</em> and <em>Operand 2</em>.  The low 16
 The type of <em>Operand 1</em> and <em>Operand 2</em> must be the same type as <em>Result Type</em>.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5597</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5597</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 1</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 2</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:10%;">
-<col style="width:10%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
-<col style="width:20%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 10%;">
+<col style="width: 10%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpUMul32x16"></a><strong>OpUMul32x16</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpUMul32x16"></a><strong>OpUMul32x16</strong><br>
 <br>
 Integer multiplication of <em>Operand 1</em> and <em>Operand 2</em>.  The high 16-bits of <em>Operand 2</em> are replaced with 0x0000 before performing the multiplication.<br>
 <br>
@@ -1470,14 +754,14 @@ Integer multiplication of <em>Operand 1</em> and <em>Operand 2</em>.  The high 1
 The type of <em>Operand 1</em> and <em>Operand 2</em> must be the same type as <em>Result Type</em>.</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5598</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5598</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em><br>
 <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Result &lt;id&gt;</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 1</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;<br>
 Operand 2</em></p></td>
 </tr>
 </tbody>
@@ -1488,51 +772,45 @@ Operand 2</em></p></td>
 <div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None yet.</p></div>
+<div class="paragraph">
+<p>None yet.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:100%;
-">
-<col style="width:4%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:66%;">
+<table class="tableblock frame-all grid-rows stretch">
+<colgroup>
+<col style="width: 4.7619%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" >Rev</th>
-<th class="tableblock halign-left valign-top" >Date</th>
-<th class="tableblock halign-left valign-top" >Author</th>
-<th class="tableblock halign-left valign-top" >Changes</th>
+<th class="tableblock halign-left valign-top">Rev</th>
+<th class="tableblock halign-left valign-top">Date</th>
+<th class="tableblock halign-left valign-top">Author</th>
+<th class="tableblock halign-left valign-top">Changes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2018-09-10</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">idr</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Initial revision</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2018-09-10</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">idr</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Initial revision</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2019-01-22</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">idr</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Remove all references to Signedness being 1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2019-01-22</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">idr</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Remove all references to Signedness being 1</p></td>
 </tr>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footnotes"><hr></div>
-<div id="footer">
-<div id="footer-text">
-Last updated
- 2019-05-09 22:15:20 PDT
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_split_barrier.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_split_barrier.asciidoc
@@ -95,12 +95,12 @@ This allows atomically specifying both a control barrier and a memory barrier (t
 1+|Capability: +
 *SplitBarrierINTEL*
 1+| 4 | 6142
-| 'Scope <id>' +
-'Execution'
-| 'Scope <id>' +
-'Memory'
-| 'Scope Memory Semantics <id>' +
-'Semantics'
+| _Scope <id>_ +
+_Execution_
+| _Scope <id>_ +
+_Memory_
+| _Memory Semantics <id>_ +
+_Semantics_
 |=====
 
 [cols="1,1,3*3",width="100%"]
@@ -119,12 +119,12 @@ This allows atomically specifying both a control barrier and a memory barrier (t
 1+|Capability: +
 *SplitBarrierINTEL*
 1+| 4 | 6143
-| 'Scope <id>' +
-'Execution'
-| 'Scope <id>' +
-'Memory'
-| 'Scope Memory Semantics <id>' +
-'Semantics'
+| _Scope <id>_ +
+_Execution_
+| _Scope <id>_ +
+_Memory_
+| _Memory Semantics <id>_ +
+_Semantics_
 |=====
 
 == Issues

--- a/extensions/INTEL/SPV_INTEL_split_barrier.html
+++ b/extensions/INTEL/SPV_INTEL_split_barrier.html
@@ -1,838 +1,116 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta name="generator" content="AsciiDoc 9.0.0rc1">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_split_barrier</title>
-<style type="text/css">
-/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
-
-/* Default font. */
-body {
-  font-family: Georgia,serif;
-}
-
-/* Title font. */
-h1, h2, h3, h4, h5, h6,
-div.title, caption.title,
-thead, p.table.header,
-#toctitle,
-#author, #revnumber, #revdate, #revremark,
-#footer {
-  font-family: Arial,Helvetica,sans-serif;
-}
-
-body {
-  margin: 1em 5% 1em 5%;
-}
-
-a {
-  color: blue;
-  text-decoration: underline;
-}
-a:visited {
-  color: fuchsia;
-}
-
-em {
-  font-style: italic;
-  color: navy;
-}
-
-strong {
-  font-weight: bold;
-  color: #083194;
-}
-
-h1, h2, h3, h4, h5, h6 {
-  color: #527bbd;
-  margin-top: 1.2em;
-  margin-bottom: 0.5em;
-  line-height: 1.3;
-}
-
-h1, h2, h3 {
-  border-bottom: 2px solid silver;
-}
-h2 {
-  padding-top: 0.5em;
-}
-h3 {
-  float: left;
-}
-h3 + * {
-  clear: left;
-}
-h5 {
-  font-size: 1.0em;
-}
-
-div.sectionbody {
-  margin-left: 0;
-}
-
-hr {
-  border: 1px solid silver;
-}
+<style>
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
 
 p {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
 }
 
-ul, ol, li > p {
-  margin-top: 0;
-}
-ul > li     { color: #aaa; }
-ul > li > * { color: black; }
-
-.monospaced, code, pre {
-  font-family: "Courier New", Courier, monospace;
-  font-size: inherit;
-  color: navy;
-  padding: 0;
-  margin: 0;
-}
-pre {
-  white-space: pre-wrap;
-}
-
-#author {
-  color: #527bbd;
-  font-weight: bold;
-  font-size: 1.1em;
-}
-#email {
-}
-#revnumber, #revdate, #revremark {
-}
-
-#footer {
-  font-size: small;
-  border-top: 2px solid silver;
-  padding-top: 0.5em;
-  margin-top: 4.0em;
-}
-#footer-text {
-  float: left;
-  padding-bottom: 0.5em;
-}
-#footer-badges {
-  float: right;
-  padding-bottom: 0.5em;
-}
-
-#preamble {
-  margin-top: 1.5em;
-  margin-bottom: 1.5em;
-}
-div.imageblock, div.exampleblock, div.verseblock,
-div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
-div.admonitionblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.admonitionblock {
-  margin-top: 2.0em;
-  margin-bottom: 2.0em;
-  margin-right: 10%;
-  color: #606060;
-}
-
-div.content { /* Block element content. */
-  padding: 0;
-}
-
-/* Block element titles. */
-div.title, caption.title {
-  color: #527bbd;
-  font-weight: bold;
-  text-align: left;
-  margin-top: 1.0em;
-  margin-bottom: 0.5em;
-}
-div.title + * {
-  margin-top: 0;
-}
-
-td div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content + div.title {
-  margin-top: 0.0em;
-}
-
-div.sidebarblock > div.content {
-  background: #ffffee;
-  border: 1px solid #dddddd;
-  border-left: 4px solid #f0f0f0;
-  padding: 0.5em;
-}
-
-div.listingblock > div.content {
-  border: 1px solid #dddddd;
-  border-left: 5px solid #f0f0f0;
-  background: #f8f8f8;
-  padding: 0.5em;
-}
-
-div.quoteblock, div.verseblock {
-  padding-left: 1.0em;
-  margin-left: 1.0em;
-  margin-right: 10%;
-  border-left: 5px solid #f0f0f0;
-  color: #888;
-}
-
-div.quoteblock > div.attribution {
-  padding-top: 0.5em;
-  text-align: right;
-}
-
-div.verseblock > pre.content {
-  font-family: inherit;
-  font-size: inherit;
-}
-div.verseblock > div.attribution {
-  padding-top: 0.75em;
-  text-align: left;
-}
-/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
-div.verseblock + div.attribution {
-  text-align: left;
-}
-
-div.admonitionblock .icon {
-  vertical-align: top;
-  font-size: 1.1em;
-  font-weight: bold;
-  text-decoration: underline;
-  color: #527bbd;
-  padding-right: 0.5em;
-}
-div.admonitionblock td.content {
-  padding-left: 0.5em;
-  border-left: 3px solid #dddddd;
-}
-
-div.exampleblock > div.content {
-  border-left: 3px solid #dddddd;
-  padding-left: 0.5em;
-}
-
-div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; vertical-align: text-bottom; }
-a.image:visited { color: white; }
-
-dl {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-dt {
-  margin-top: 0.5em;
-  margin-bottom: 0;
-  font-style: normal;
-  color: navy;
-}
-dd > *:first-child {
-  margin-top: 0.1em;
-}
-
-ul, ol {
-    list-style-position: outside;
-}
-ol.arabic {
-  list-style-type: decimal;
-}
-ol.loweralpha {
-  list-style-type: lower-alpha;
-}
-ol.upperalpha {
-  list-style-type: upper-alpha;
-}
-ol.lowerroman {
-  list-style-type: lower-roman;
-}
-ol.upperroman {
-  list-style-type: upper-roman;
-}
-
-div.compact ul, div.compact ol,
-div.compact p, div.compact p,
-div.compact div, div.compact div {
-  margin-top: 0.1em;
-  margin-bottom: 0.1em;
-}
-
-tfoot {
-  font-weight: bold;
-}
-td > div.verse {
-  white-space: pre;
-}
-
-div.hdlist {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-div.hdlist tr {
-  padding-bottom: 15px;
-}
-dt.hdlist1.strong, td.hdlist1.strong {
-  font-weight: bold;
-}
-td.hdlist1 {
-  vertical-align: top;
-  font-style: normal;
-  padding-right: 0.8em;
-  color: navy;
-}
-td.hdlist2 {
-  vertical-align: top;
-}
-div.hdlist.compact tr {
-  margin: 0;
-  padding-bottom: 0;
-}
-
-.comment {
-  background: yellow;
-}
-
-.footnote, .footnoteref {
-  font-size: 0.8em;
-}
-
-span.footnote, span.footnoteref {
-  vertical-align: super;
-}
-
-#footnotes {
-  margin: 20px 0 20px 0;
-  padding: 7px 0 0 0;
-}
-
-#footnotes div.footnote {
-  margin: 0 0 5px 0;
-}
-
-#footnotes hr {
-  border: none;
-  border-top: 1px solid silver;
-  height: 1px;
-  text-align: left;
-  margin-left: 0;
-  width: 20%;
-  min-width: 100px;
-}
-
-div.colist td {
-  padding-right: 0.5em;
-  padding-bottom: 0.3em;
-  vertical-align: top;
-}
-div.colist td img {
-  margin-top: 0.3em;
-}
-
-@media print {
-  #footer-badges { display: none; }
-}
-
-#toc {
-  margin-bottom: 2.5em;
-}
-
-#toctitle {
-  color: #527bbd;
-  font-size: 1.1em;
-  font-weight: bold;
-  margin-top: 1.0em;
-  margin-bottom: 0.1em;
-}
-
-div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-div.toclevel2 {
-  margin-left: 2em;
-  font-size: 0.9em;
-}
-div.toclevel3 {
-  margin-left: 4em;
-  font-size: 0.9em;
-}
-div.toclevel4 {
-  margin-left: 6em;
-  font-size: 0.9em;
-}
-
-span.aqua { color: aqua; }
-span.black { color: black; }
-span.blue { color: blue; }
-span.fuchsia { color: fuchsia; }
-span.gray { color: gray; }
-span.green { color: green; }
-span.lime { color: lime; }
-span.maroon { color: maroon; }
-span.navy { color: navy; }
-span.olive { color: olive; }
-span.purple { color: purple; }
-span.red { color: red; }
-span.silver { color: silver; }
-span.teal { color: teal; }
-span.white { color: white; }
-span.yellow { color: yellow; }
-
-span.aqua-background { background: aqua; }
-span.black-background { background: black; }
-span.blue-background { background: blue; }
-span.fuchsia-background { background: fuchsia; }
-span.gray-background { background: gray; }
-span.green-background { background: green; }
-span.lime-background { background: lime; }
-span.maroon-background { background: maroon; }
-span.navy-background { background: navy; }
-span.olive-background { background: olive; }
-span.purple-background { background: purple; }
-span.red-background { background: red; }
-span.silver-background { background: silver; }
-span.teal-background { background: teal; }
-span.white-background { background: white; }
-span.yellow-background { background: yellow; }
-
-span.big { font-size: 2em; }
-span.small { font-size: 0.6em; }
-
-span.underline { text-decoration: underline; }
-span.overline { text-decoration: overline; }
-span.line-through { text-decoration: line-through; }
-
-div.unbreakable { page-break-inside: avoid; }
-
-
-/*
- * xhtml11 specific
- *
- * */
-
-div.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.tableblock > table {
-  border: 3px solid #527bbd;
-}
-thead, p.table.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.table {
-  margin-top: 0;
-}
-/* Because the table frame attribute is overridden by CSS in most browsers. */
-div.tableblock > table[frame="void"] {
-  border-style: none;
-}
-div.tableblock > table[frame="hsides"] {
-  border-left-style: none;
-  border-right-style: none;
-}
-div.tableblock > table[frame="vsides"] {
-  border-top-style: none;
-  border-bottom-style: none;
-}
-
-
-/*
- * html5 specific
- *
- * */
-
-table.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-thead, p.tableblock.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.tableblock {
-  margin-top: 0;
-}
-table.tableblock {
-  border-width: 3px;
-  border-spacing: 0px;
-  border-style: solid;
-  border-color: #527bbd;
-  border-collapse: collapse;
-}
-th.tableblock, td.tableblock {
-  border-width: 1px;
-  padding: 4px;
-  border-style: solid;
-  border-color: #527bbd;
-}
-
-table.tableblock.frame-topbot {
-  border-left-style: hidden;
-  border-right-style: hidden;
-}
-table.tableblock.frame-sides {
-  border-top-style: hidden;
-  border-bottom-style: hidden;
-}
-table.tableblock.frame-none {
-  border-style: hidden;
-}
-
-th.tableblock.halign-left, td.tableblock.halign-left {
-  text-align: left;
-}
-th.tableblock.halign-center, td.tableblock.halign-center {
-  text-align: center;
-}
-th.tableblock.halign-right, td.tableblock.halign-right {
-  text-align: right;
-}
-
-th.tableblock.valign-top, td.tableblock.valign-top {
-  vertical-align: top;
-}
-th.tableblock.valign-middle, td.tableblock.valign-middle {
-  vertical-align: middle;
-}
-th.tableblock.valign-bottom, td.tableblock.valign-bottom {
-  vertical-align: bottom;
-}
-
-
-/*
- * manpage specific
- *
- * */
-
-body.manpage h1 {
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
-  border-top: 2px solid silver;
-  border-bottom: 2px solid silver;
-}
-body.manpage h2 {
-  border-style: none;
-}
-body.manpage div.sectionbody {
-  margin-left: 3em;
-}
-
-@media print {
-  body.manpage div#toc { display: none; }
-}
-
-
-@media screen {
-  body {
-    max-width: 50em; /* approximately 80 characters wide */
-    margin-left: 16em;
-  }
-
-  #toc {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 13em;
-    padding: 0.5em;
-    padding-bottom: 1.5em;
-    margin: 0;
-    overflow: auto;
-    border-right: 3px solid #f8f8f8;
-    background-color: white;
-  }
-
-  #toc .toclevel1 {
-    margin-top: 0.5em;
-  }
-
-  #toc .toclevel2 {
-    margin-top: 0.25em;
-    display: list-item;
-    color: #aaaaaa;
-  }
-
-  #toctitle {
-    margin-top: 0.5em;
-  }
-}
 </style>
-<script type="text/javascript">
-/*<![CDATA[*/
-var asciidoc = {  // Namespace.
-
-/////////////////////////////////////////////////////////////////////
-// Table Of Contents generator
-/////////////////////////////////////////////////////////////////////
-
-/* Author: Mihai Bazon, September 2002
- * http://students.infoiasi.ro/~mishoo
- *
- * Table Of Content generator
- * Version: 0.4
- *
- * Feel free to use this script under the terms of the GNU General Public
- * License, as long as you do not remove or alter this notice.
- */
-
- /* modified by Troy D. Hanson, September 2006. License: GPL */
- /* modified by Stuart Rackham, 2006, 2009. License: GPL */
-
-// toclevels = 1..4.
-toc: function (toclevels) {
-
-  function getText(el) {
-    var text = "";
-    for (var i = el.firstChild; i != null; i = i.nextSibling) {
-      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
-        text += i.data;
-      else if (i.firstChild != null)
-        text += getText(i);
-    }
-    return text;
-  }
-
-  function TocEntry(el, text, toclevel) {
-    this.element = el;
-    this.text = text;
-    this.toclevel = toclevel;
-  }
-
-  function tocEntries(el, toclevels) {
-    var result = new Array;
-    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
-    // Function that scans the DOM tree for header elements (the DOM2
-    // nodeIterator API would be a better technique but not supported by all
-    // browsers).
-    var iterate = function (el) {
-      for (var i = el.firstChild; i != null; i = i.nextSibling) {
-        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
-          var mo = re.exec(i.tagName);
-          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
-            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
-          }
-          iterate(i);
-        }
-      }
-    }
-    iterate(el);
-    return result;
-  }
-
-  var toc = document.getElementById("toc");
-  if (!toc) {
-    return;
-  }
-
-  // Delete existing TOC entries in case we're reloading the TOC.
-  var tocEntriesToRemove = [];
-  var i;
-  for (i = 0; i < toc.childNodes.length; i++) {
-    var entry = toc.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div'
-     && entry.getAttribute("class")
-     && entry.getAttribute("class").match(/^toclevel/))
-      tocEntriesToRemove.push(entry);
-  }
-  for (i = 0; i < tocEntriesToRemove.length; i++) {
-    toc.removeChild(tocEntriesToRemove[i]);
-  }
-
-  // Rebuild TOC entries.
-  var entries = tocEntries(document.getElementById("content"), toclevels);
-  for (var i = 0; i < entries.length; ++i) {
-    var entry = entries[i];
-    if (entry.element.id == "")
-      entry.element.id = "_toc_" + i;
-    var a = document.createElement("a");
-    a.href = "#" + entry.element.id;
-    a.appendChild(document.createTextNode(entry.text));
-    var div = document.createElement("div");
-    div.appendChild(a);
-    div.className = "toclevel" + entry.toclevel;
-    toc.appendChild(div);
-  }
-  if (entries.length == 0)
-    toc.parentNode.removeChild(toc);
-},
-
-
-/////////////////////////////////////////////////////////////////////
-// Footnotes generator
-/////////////////////////////////////////////////////////////////////
-
-/* Based on footnote generation code from:
- * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
- */
-
-footnotes: function () {
-  // Delete existing footnote entries in case we're reloading the footnodes.
-  var i;
-  var noteholder = document.getElementById("footnotes");
-  if (!noteholder) {
-    return;
-  }
-  var entriesToRemove = [];
-  for (i = 0; i < noteholder.childNodes.length; i++) {
-    var entry = noteholder.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
-      entriesToRemove.push(entry);
-  }
-  for (i = 0; i < entriesToRemove.length; i++) {
-    noteholder.removeChild(entriesToRemove[i]);
-  }
-
-  // Rebuild footnote entries.
-  var cont = document.getElementById("content");
-  var spans = cont.getElementsByTagName("span");
-  var refs = {};
-  var n = 0;
-  for (i=0; i<spans.length; i++) {
-    if (spans[i].className == "footnote") {
-      n++;
-      var note = spans[i].getAttribute("data-note");
-      if (!note) {
-        // Use [\s\S] in place of . so multi-line matches work.
-        // Because JavaScript has no s (dotall) regex flag.
-        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
-        spans[i].innerHTML =
-          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-        spans[i].setAttribute("data-note", note);
-      }
-      noteholder.innerHTML +=
-        "<div class='footnote' id='_footnote_" + n + "'>" +
-        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
-        n + "</a>. " + note + "</div>";
-      var id =spans[i].getAttribute("id");
-      if (id != null) refs["#"+id] = n;
-    }
-  }
-  if (n == 0)
-    noteholder.parentNode.removeChild(noteholder);
-  else {
-    // Process footnoterefs.
-    for (i=0; i<spans.length; i++) {
-      if (spans[i].className == "footnoteref") {
-        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
-        href = href.match(/#.*/)[0];  // Because IE return full URL.
-        n = refs[href];
-        spans[i].innerHTML =
-          "[<a href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-      }
-    }
-  }
-},
-
-install: function(toclevels) {
-  var timerId;
-
-  function reinstall() {
-    asciidoc.footnotes();
-    if (toclevels) {
-      asciidoc.toc(toclevels);
-    }
-  }
-
-  function reinstallAndRemoveTimer() {
-    clearInterval(timerId);
-    reinstall();
-  }
-
-  timerId = setInterval(reinstall, 500);
-  if (document.addEventListener)
-    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
-  else
-    window.onload = reinstallAndRemoveTimer;
-}
-
-}
-asciidoc.install(1);
-/*]]>*/
-</script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_split_barrier</h1>
-<div id="toc">
-  <div id="toctitle">Table of Contents</div>
-  <noscript><p><b>JavaScript must be enabled in your browser to display the table of contents.</b></p></noscript>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification, Version 1.6</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
 </div>
 </div>
 <div id="content">
 <div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>SPV_INTEL_split_barrier</p></div>
+<div class="paragraph">
+<p>SPV_INTEL_split_barrier</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>To report problems with this extension, please open a new issue at:</p></div>
-<div class="paragraph"><p><a href="https://github.com/KhronosGroup/SPIRV-Registry">https://github.com/KhronosGroup/SPIRV-Registry</a></p></div>
+<div class="paragraph">
+<p>To report problems with this extension, please open a new issue at:</p>
+</div>
+<div class="paragraph">
+<p><a href="https://github.com/KhronosGroup/SPIRV-Registry" class="bare">https://github.com/KhronosGroup/SPIRV-Registry</a></p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Ben Ashbaugh, Intel
-</p>
+<p>Ben Ashbaugh, Intel</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Copyright (c) 2022 Intel Corporation.  All rights reserved.</p></div>
+<div class="paragraph">
+<p>Copyright (c) 2022 Intel Corporation.  All rights reserved.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Shipping
-</p>
+<p>Shipping</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all"
-style="
-width:40%;
-">
-<col style="width:50%;">
-<col style="width:50%;">
+<table class="tableblock frame-all grid-all" style="width: 40%;">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2022-05-03</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-21</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
 </tr>
 </tbody>
 </table>
@@ -841,82 +119,99 @@ width:40%;
 <div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension is written against the SPIR-V Specification,
-Version 1.6 Revision 1.</p></div>
-<div class="paragraph"><p>This extension requires SPIR-V 1.0.</p></div>
+<div class="paragraph">
+<p>This extension is written against the SPIR-V Specification,
+Version 1.6 Revision 1.</p>
+</div>
+<div class="paragraph">
+<p>This extension requires SPIR-V 1.0.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension adds SPIR-V instructions to split a control barrier (<strong>OpControlBarrier</strong>) into two separate operations:
+<div class="paragraph">
+<p>This extension adds SPIR-V instructions to split a control barrier (<strong>OpControlBarrier</strong>) into two separate operations:
 the first indicates that an invocation has "arrived" at the barrier but should continue executing,
-and the second indicates that an invocation should "wait" for other invocations to arrive at the barrier before executing further.</p></div>
-<div class="paragraph"><p>Splitting a barrier operation may improve performance and may provide a closer match to "latch" or "barrier" operations in other parallel languages such as C++ 20.</p></div>
+and the second indicates that an invocation should "wait" for other invocations to arrive at the barrier before executing further.</p>
+</div>
+<div class="paragraph">
+<p>Splitting a barrier operation may improve performance and may provide a closer match to "latch" or "barrier" operations in other parallel languages such as C++ 20.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_extension_name">Extension Name</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>To use this extension within a SPIR-V module, the appropriate <strong>OpExtension</strong> must
-be present in the module:</p></div>
+<div class="paragraph">
+<p>To use this extension within a SPIR-V module, the appropriate <strong>OpExtension</strong> must
+be present in the module:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpExtension "SPV_INTEL_split_barrier"</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_capabilities">New Capabilities</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension introduces the new capability:</p></div>
+<div class="paragraph">
+<p>This extension introduces the new capability:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>SplitBarrierINTEL</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_modifications_to_the_spir_v_specification_version_1_6">Modifications to the SPIR-V Specification, Version 1.6</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Modify Section 3.31, Capability, adding rows to the Capability table:</p></div>
+<div class="paragraph">
+<p>Modify Section 3.31, Capability, adding rows to the Capability table:</p>
+</div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:33%;">
-<col style="width:33%;">
-<col style="width:33%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-center valign-top" colspan="2" > Capability </th>
-<th class="tableblock halign-center valign-top" > Implicitly Declares</th>
+<th class="tableblock halign-center valign-top" colspan="2">Capability</th>
+<th class="tableblock halign-center valign-top">Implicitly Declares</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6141</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>SplitBarrierINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6141</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>SplitBarrierINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"></td>
 </tr>
 </tbody>
 </table>
-</div></div>
-<div class="paragraph"><p>Add to Section 3.42.20, Barrier Instructions:</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:9%;">
-<col style="width:9%;">
-<col style="width:27%;">
-<col style="width:27%;">
-<col style="width:27%;">
+</div>
+</div>
+<div class="paragraph">
+<p>Add to Section 3.42.20, Barrier Instructions:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 9.0909%;">
+<col style="width: 9.0909%;">
+<col style="width: 27.2727%;">
+<col style="width: 27.2727%;">
+<col style="width: 27.2728%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><a id="OpControlBarrierArriveINTEL"></a><strong>OpControlBarrierArriveINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><a id="OpControlBarrierArriveINTEL"></a><strong>OpControlBarrierArriveINTEL</strong><br>
 <br>
 Indicates that an invocation has arrived at a split control barrier.
 This may allow other invocations waiting on the split control barrier to continue executing.<br>
@@ -926,33 +221,32 @@ When <em>Execution</em> is <strong>Subgroup</strong> or <strong>Invocation</stro
 <br>
 If <em>Semantics</em> is not <strong>None</strong>, this instruction also serves as the start of a memory barrier similar to an <strong>OpMemoryBarrier</strong> instruction with the same <em>Memory</em> and <em>Semantics</em> operands.
 This allows atomically specifying both a control barrier and a memory barrier (that is, without needing two instructions). If <em>Semantics</em> is <strong>None</strong>, <em>Memory</em> is ignored.<br></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SplitBarrierINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6142</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Scope &lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6142</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Scope &lt;id&gt;</em><br>
 <em>Execution</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Scope &lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Scope &lt;id&gt;</em><br>
 <em>Memory</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Scope Memory Semantics &lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Memory Semantics &lt;id&gt;</em><br>
 <em>Semantics</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:9%;">
-<col style="width:9%;">
-<col style="width:27%;">
-<col style="width:27%;">
-<col style="width:27%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 9.0909%;">
+<col style="width: 9.0909%;">
+<col style="width: 27.2727%;">
+<col style="width: 27.2727%;">
+<col style="width: 27.2728%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><a id="OpControlBarrierWaitINTEL"></a><strong>OpControlBarrierWaitINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><a id="OpControlBarrierWaitINTEL"></a><strong>OpControlBarrierWaitINTEL</strong><br>
 <br>
 Waits for other invocations of this module to arrive at a split control barrier.<br>
 <br>
@@ -963,17 +257,17 @@ If <em>Semantics</em> is not <strong>None</strong>, this instruction also serves
 This ensures that memory accesses issued before arriving at the split barrier are observed before memory accesses issued after this instruction.
 This control is ensured only for memory accesses issued by this invocation and observed by another invocation executing within <em>Memory</em> scope.
 This allows atomically specifying both a control barrier and a memory barrier (that is, without needing two instructions). If <em>Semantics</em> is <strong>None</strong>, <em>Memory</em> is ignored.<br></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SplitBarrierINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6143</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Scope &lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6143</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Scope &lt;id&gt;</em><br>
 <em>Execution</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Scope &lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Scope &lt;id&gt;</em><br>
 <em>Memory</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>Scope Memory Semantics &lt;id&gt;</em><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>Memory Semantics &lt;id&gt;</em><br>
 <em>Semantics</em></p></td>
 </tr>
 </tbody>
@@ -983,45 +277,39 @@ This allows atomically specifying both a control barrier and a memory barrier (t
 <div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:100%;
-">
-<col style="width:4%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:66%;">
+<table class="tableblock frame-all grid-rows stretch">
+<colgroup>
+<col style="width: 4.7619%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" >Rev</th>
-<th class="tableblock halign-left valign-top" >Date</th>
-<th class="tableblock halign-left valign-top" >Author</th>
-<th class="tableblock halign-left valign-top" >Changes</th>
+<th class="tableblock halign-left valign-top">Rev</th>
+<th class="tableblock halign-left valign-top">Date</th>
+<th class="tableblock halign-left valign-top">Author</th>
+<th class="tableblock halign-left valign-top">Changes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2022-02-24</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Initial revision</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2022-02-24</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Initial revision</p></td>
 </tr>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footnotes"><hr></div>
-<div id="footer">
-<div id="footer-text">
-Last updated
- 2022-05-03 08:02:53 PDT
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_subgroups.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_subgroups.asciidoc
@@ -50,7 +50,7 @@ This extension builds upon "subgroups" functionality that is already in core SPI
 
 * Intel subgroups adds "block read and write" instructions to take advantage of specialized hardware to read or write blocks of data from or to buffers or images.
 
-This extension has a source language counterpart extension for the OpenCL-C kernel language, +cl_intel_subgroups+, which can be used for online compilation in an OpenCL environment.
+This extension has a source language counterpart extension for the OpenCL-C kernel language, `cl_intel_subgroups`, which can be used for online compilation in an OpenCL environment.
 
 == Extension Name
 
@@ -172,18 +172,18 @@ Modify Section 3.32.21, Group Instructions, adding to the end of the list of ins
 |=====
 5+|[[OpSubgroupShuffleINTEL]]*OpSubgroupShuffleINTEL* +
  +
-Allows data to be arbitrarily transferred between invocations in a subgroup.  The data that is returned for this invocation is the value of 'Data' for the invocation identified by 'InvocationId'.
+Allows data to be arbitrarily transferred between invocations in a subgroup.  The data that is returned for this invocation is the value of _Data_ for the invocation identified by _InvocationId_.
 
-'InvocationId' need not be the same value for all invocations in the subgroup.
+_InvocationId_ need not be the same value for all invocations in the subgroup.
 
-'Result Type' may be a scalar or vector type.
+_Result Type_ may be a scalar or vector type.
 
-The type of 'Data' must be the same as 'Result Type'.
+The type of _Data_ must be the same as _Result Type_.
 
-'InvocationId' must be a 32-bit 'integer type' scalar.
+_InvocationId_ must be a 32-bit _integer type_ scalar.
 1+|Capability: +
 *SubgroupShuffleINTEL*
-| 5 | 5571 | '<id>' 'Result Type' | '<id>' 'Result' |  '<id>' 'Data' | '<id>' 'InvocationId'
+| 5 | 5571 | _<id>_ _Result Type_ | _<id>_ _Result_ |  _<id>_ _Data_ | _<id>_ _InvocationId_
 |=====
 
 [cols="1,1,5*3",width="100%"]
@@ -192,24 +192,24 @@ The type of 'Data' must be the same as 'Result Type'.
  +
 Allows data to be transferred from an invocation in the subgroup with a higher *SubgroupLocalInvocationId* down to a invocation in the subgroup with a lower *SubgroupLocalInvocationId*.
 
-There are two data sources to this built-in function: 'Current' and 'Next'.  To determine the result of this built-in function, first let the unsigned shuffle index be equivalent to the sum of this invocation's *SubgroupLocalInvocationId* plus the specified 'Delta':
+There are two data sources to this built-in function: _Current_ and _Next_.  To determine the result of this built-in function, first let the unsigned shuffle index be equivalent to the sum of this invocation's *SubgroupLocalInvocationId* plus the specified _Delta_:
 
-If the shuffle index is less than the *SubgroupMaxSize*, the result of this built-in function is the value of the 'Current' data source for the invocation with *SubgroupLocalInvocationId* equal to the shuffle index.
+If the shuffle index is less than the *SubgroupMaxSize*, the result of this built-in function is the value of the _Current_ data source for the invocation with *SubgroupLocalInvocationId* equal to the shuffle index.
 
-If the shuffle index is greater than or equal to the *SubgroupMaxSize* but less than twice the *SubgroupMaxSize*, the result of this built-in function is the value of the 'Next' data source for the invocation with *SubgroupLocalInvocationId* equal to the shuffle index minus the *SubgroupMaxSize*.
+If the shuffle index is greater than or equal to the *SubgroupMaxSize* but less than twice the *SubgroupMaxSize*, the result of this built-in function is the value of the _Next_ data source for the invocation with *SubgroupLocalInvocationId* equal to the shuffle index minus the *SubgroupMaxSize*.
 
 All other values of the shuffle index are considered to be out-of-range.
 
-'Delta' need not be the same value for all invocations in the subgroup.
+_Delta_ need not be the same value for all invocations in the subgroup.
 
-'Result Type' may be a scalar or vector type.
+_Result Type_ may be a scalar or vector type.
 
-The type of 'Current' and 'Next' must be the same as 'Result Type'.
+The type of _Current_ and _Next_ must be the same as _Result Type_.
 
-'Delta' must be a 32-bit 'integer type' scalar.
+_Delta_ must be a 32-bit _integer type_ scalar.
 1+|Capability: +
 *SubgroupShuffleINTEL*
-| 6 | 5572 | '<id>' 'Result Type' | '<id>' 'Result' |  '<id>' 'Current' | '<id>' 'Next' | '<id>' 'Delta'
+| 6 | 5572 | _<id>_ _Result Type_ | _<id>_ _Result_ |  _<id>_ _Current_ | _<id>_ _Next_ | _<id>_ _Delta_
 |=====
 
 [cols="1,1,5*3",width="100%"]
@@ -218,126 +218,126 @@ The type of 'Current' and 'Next' must be the same as 'Result Type'.
  +
 Allows data to be transferred from an invocation in the subgroup with a lower *SubgroupLocalInvocationId* up to an invocation in the subgroup with a higher *SubgroupLocalInvocationId*.
 
-There are two data sources to this built-in function: 'Previous' and 'Current'.  To determine the result of this built-in function, first let the signed shuffle index be equivalent to this invocation's *SubgroupLocalInvocationId* minus the specified 'Delta':
+There are two data sources to this built-in function: _Previous_ and _Current_.  To determine the result of this built-in function, first let the signed shuffle index be equivalent to this invocation's *SubgroupLocalInvocationId* minus the specified _Delta_:
 
-If the shuffle index is greater than or equal to zero and less than the *SubgroupMaxSize*, the result of this built-in function is the value of the 'Current' data source for the invocation with *SubgroupLocalInvocationId* equal to the shuffle index.
+If the shuffle index is greater than or equal to zero and less than the *SubgroupMaxSize*, the result of this built-in function is the value of the _Current_ data source for the invocation with *SubgroupLocalInvocationId* equal to the shuffle index.
 
-If the shuffle index is less than zero but greater than or equal to the negative *SubgroupMaxSize*, the result of this built-in function is the value of the 'Previous' data source for the invocation with *SubgroupLocalInvocationId* equal to the shuffle index plus the *SubgroupMaxSize*.
+If the shuffle index is less than zero but greater than or equal to the negative *SubgroupMaxSize*, the result of this built-in function is the value of the _Previous_ data source for the invocation with *SubgroupLocalInvocationId* equal to the shuffle index plus the *SubgroupMaxSize*.
 
 All other values of the shuffle index are considered to be out-of-range.
 
-'Delta' need not be the same value for all invocations in the subgroup.
+_Delta_ need not be the same value for all invocations in the subgroup.
 
-'Result Type' may be a scalar or vector type.
+_Result Type_ may be a scalar or vector type.
 
-The type of 'Previous' and 'Current' must be the same as 'Result Type'.
+The type of _Previous_ and _Current_ must be the same as _Result Type_.
 
-'Delta' must be a 32-bit 'integer type' scalar.
+_Delta_ must be a 32-bit _integer type_ scalar.
 1+|Capability: +
 *SubgroupShuffleINTEL*
-| 6 | 5573 | '<id>' 'Result Type' | '<id>' 'Result' |  '<id>' 'Previous' | '<id>' 'Current' | '<id>' 'Delta'
+| 6 | 5573 | _<id>_ _Result Type_ | _<id>_ _Result_ |  _<id>_ _Previous_ | _<id>_ _Current_ | _<id>_ _Delta_
 |=====
 
 [cols="1,1,4*3",width="100%"]
 |=====
 5+|[[OpSubgroupShuffleXorINTEL]]*OpSubgroupShuffleXorINTEL* +
  +
-Allows data to be transferred between invocations in a subgroup as a function of the invocation's *SubgroupLocalInvocationId*.  The data that is returned for this invocation is the value of 'Data' for the invocation with *SubgroupLocalInvocationId* equal to this invocation's *SubgroupLocalInvocationId* XOR'd with the specified 'Value'.  If the result of the XOR is greater than *SubgroupMaxSize* then it is considered out-of-range.
+Allows data to be transferred between invocations in a subgroup as a function of the invocation_s *SubgroupLocalInvocationId*.  The data that is returned for this invocation is the value of _Data_ for the invocation with *SubgroupLocalInvocationId* equal to this invocation's *SubgroupLocalInvocationId* XOR_d with the specified _Value_.  If the result of the XOR is greater than *SubgroupMaxSize* then it is considered out-of-range.
 
-'Value' need not be the same for all invocations in the subgroup.
+_Value_ need not be the same for all invocations in the subgroup.
 
-'Result Type' may be a scalar or vector type.
+_Result Type_ may be a scalar or vector type.
 
-The type of 'Data' must be the same as 'Result Type'.
+The type of _Data_ must be the same as _Result Type_.
 
-'Value' must be a 32-bit 'integer type' scalar.
+_Value_ must be a 32-bit _integer type_ scalar.
 1+|Capability: +
 *SubgroupShuffleINTEL*
-| 5 | 5574 | '<id>' 'Result Type' | '<id>' 'Result' |  '<id>' 'Data' | '<id>' 'Value'
+| 5 | 5574 | _<id>_ _Result Type_ | _<id>_ _Result_ |  _<id>_ _Data_ | _<id>_ _Value_
 |=====
 
 [cols="1,1,3*3",width="100%"]
 |=====
 4+|[[OpSubgroupBlockReadINTEL]]*OpSubgroupBlockReadINTEL* +
  +
-Reads one or more components of 'Result' data for each invocation in the subgroup from the specified 'Ptr' as a block operation.
+Reads one or more components of _Result_ data for each invocation in the subgroup from the specified _Ptr_ as a block operation.
 
 The data is read strided, so the first value read is:
 
-+Ptr[ *SubgroupLocalInvocationId* ]+
+`Ptr[ *SubgroupLocalInvocationId* ]`
 
 and the second value read is:
 
-+Ptr[ *SubgroupLocalInvocationId* + *SubgroupMaxSize* ]+
+`Ptr[ *SubgroupLocalInvocationId* + *SubgroupMaxSize* ]`
 
 etc.
 
-'Result Type' may be a scalar or vector type, and its component type must be equal to the type pointed to by 'Ptr'.
+_Result Type_ may be a scalar or vector type, and its component type must be equal to the type pointed to by _Ptr_.
 
-The type of 'Ptr' must be a 'pointer type', and must point to a 'scalar type'.
+The type of _Ptr_ must be a _pointer type_, and must point to a _scalar type_.
 1+|Capability: +
 *SubgroupBufferBlockIOINTEL*
-| 4 | 5575 | '<id>' 'Result Type' | '<id>' 'Result' |  '<id>' 'Ptr'
+| 4 | 5575 | _<id>_ _Result Type_ | _<id>_ _Result_ |  _<id>_ _Ptr_
 |=====
 
 [cols="1,1,2*3",width="100%"]
 |=====
 3+|[[OpSubgroupBlockWriteINTEL]]*OpSubgroupBlockWriteINTEL* +
  +
-Writes one or more components of 'Data' for each invocation in the subgroup from the specified 'Ptr' as a block operation.
+Writes one or more components of _Data_ for each invocation in the subgroup from the specified _Ptr_ as a block operation.
 
 The data is written strided, so the first value is written to:
 
-+Ptr[ *SubgroupLocalInvocationId* ]+
+`Ptr[ *SubgroupLocalInvocationId* ]`
 
 and the second value written is:
 
-+Ptr[ *SubgroupLocalInvocationId* + *SubgroupMaxSize* ]+
+`Ptr[ *SubgroupLocalInvocationId* + *SubgroupMaxSize* ]`
 
 etc.
 
-The type of 'Ptr' must be a 'pointer type', and must point to a 'scalar type'.
+The type of _Ptr_ must be a _pointer type_, and must point to a _scalar type_.
 
-The component type of 'Data' must be equal to the type pointed to by 'Ptr'.
+The component type of _Data_ must be equal to the type pointed to by _Ptr_.
 1+|Capability: +
 *SubgroupBufferBlockIOINTEL*
-| 3 | 5576 | '<id>' 'Ptr' | '<id>' 'Data'
+| 3 | 5576 | _<id>_ _Ptr_ | _<id>_ _Data_
 |=====
 
 [cols="1,1,4*3",width="100%"]
 |=====
 5+|[[OpSubgroupImageBlockReadINTEL]]*OpSubgroupImageBlockReadINTEL* +
  +
-Reads one or more components of 'Result' data for each invocation in the subgroup from the specified 'Image' at the specified 'Coordinate' as a block operation.  Note that the 'Coordinate' is a byte coordinate, not a texel coordinate.  Also note that the image data is read without format conversion, so each invocation may read multiple image elements.
+Reads one or more components of _Result_ data for each invocation in the subgroup from the specified _Image_ at the specified _Coordinate_ as a block operation.  Note that the _Coordinate_ is a byte coordinate, not a texel coordinate.  Also note that the image data is read without format conversion, so each invocation may read multiple image elements.
 
-The data is read row-by-row, so the first value read is from the row specified by the y-component of the provided 'Coordinate', the second value is read from the row specified by the y-component of the provided 'Coordinate' plus one, etc.
+The data is read row-by-row, so the first value read is from the row specified by the y-component of the provided _Coordinate_, the second value is read from the row specified by the y-component of the provided _Coordinate_ plus one, etc.
 
-'Result Type' may be a scalar or vector type.
+_Result Type_ may be a scalar or vector type.
 
-'Image' must be an object whose type is *OpTypeImage* with a 'Sampled' operand of 0 or 2.  If the 'Sampled' operand is 2, then some dimensions require a capability.
+_Image_ must be an object whose type is *OpTypeImage* with a _Sampled_ operand of 0 or 2.  If the _Sampled_ operand is 2, then some dimensions require a capability.
 
-'Coordinate' is an integer scalar or vector.  The x-component is a byte coordinate into rows of the image and remaining coordinates are non-normalized texel coordinates.
+_Coordinate_ is an integer scalar or vector.  The x-component is a byte coordinate into rows of the image and remaining coordinates are non-normalized texel coordinates.
 1+|Capability: +
 *SubgroupImageBlockIOINTEL*
-| 5 | 5577 | '<id>' 'Result Type' | '<id>' 'Result' |  '<id>' 'Image' | '<id>' 'Coordinate'
+| 5 | 5577 | _<id>_ _Result Type_ | _<id>_ _Result_ |  _<id>_ _Image_ | _<id>_ _Coordinate_
 |=====
 
 [cols="1,1,3*3",width="100%"]
 |=====
 4+|[[OpSubgroupImageBlockWriteINTEL]]*OpSubgroupImageBlockWriteINTEL* +
  +
-Writes one or more components of 'Data' for each invocation in the subgroup to the specified 'Image' at the specified 'Coordinate' as a block operation.  Note that the 'Coordinate' is a byte coordinate, not a texel coordinate.  Also note that the image data is read without format conversion, so each invocation may write multiple image elements.
+Writes one or more components of _Data_ for each invocation in the subgroup to the specified _Image_ at the specified _Coordinate_ as a block operation.  Note that the _Coordinate_ is a byte coordinate, not a texel coordinate.  Also note that the image data is read without format conversion, so each invocation may write multiple image elements.
 
-The data is written row-by-row, so the first value is written to the row specified by the y-component of the provided 'Coordinate', the second value is written to the row specified by the y-component of the provided 'Coordinate' plus one, etc.
+The data is written row-by-row, so the first value is written to the row specified by the y-component of the provided _Coordinate_, the second value is written to the row specified by the y-component of the provided _Coordinate_ plus one, etc.
 
-'Image' must be an object whose type is *OpTypeImage* with a 'Sampled' operand of 0 or 2.  If the 'Sampled' operand is 2, then some dimensions require a capability.
+_Image_ must be an object whose type is *OpTypeImage* with a _Sampled_ operand of 0 or 2.  If the _Sampled_ operand is 2, then some dimensions require a capability.
 
-'Coordinate' is an integer scalar or vector.  The x-component is a byte coordinate into rows of the image and remaining coordinates are non-normalized texel coordinates.
+_Coordinate_ is an integer scalar or vector.  The x-component is a byte coordinate into rows of the image and remaining coordinates are non-normalized texel coordinates.
 
-'Result Type' may be a scalar or vector type.
+_Result Type_ may be a scalar or vector type.
 1+|Capability: +
 *SubgroupImageBlockIOINTEL*
-| 4 | 5578 |  '<id>' 'Image' | '<id>' 'Coordinate' | '<id>' 'Data'
+| 4 | 5578 |  _<id>_ _Image_ | _<id>_ _Coordinate_ | _<id>_ _Data_
 |=====
 
 == Validation Rules

--- a/extensions/INTEL/SPV_INTEL_subgroups.html
+++ b/extensions/INTEL/SPV_INTEL_subgroups.html
@@ -1,853 +1,128 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta name="generator" content="AsciiDoc 8.6.9">
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_subgroups</title>
-<style type="text/css">
-/* Shared CSS for AsciiDoc xhtml11 and html5 backends */
-
-/* Default font. */
-body {
-  font-family: Georgia,serif;
-}
-
-/* Title font. */
-h1, h2, h3, h4, h5, h6,
-div.title, caption.title,
-thead, p.table.header,
-#toctitle,
-#author, #revnumber, #revdate, #revremark,
-#footer {
-  font-family: Arial,Helvetica,sans-serif;
-}
-
-body {
-  margin: 1em 5% 1em 5%;
-}
-
-a {
-  color: blue;
-  text-decoration: underline;
-}
-a:visited {
-  color: fuchsia;
-}
-
-em {
-  font-style: italic;
-  color: navy;
-}
-
-strong {
-  font-weight: bold;
-  color: #083194;
-}
-
-h1, h2, h3, h4, h5, h6 {
-  color: #527bbd;
-  margin-top: 1.2em;
-  margin-bottom: 0.5em;
-  line-height: 1.3;
-}
-
-h1, h2, h3 {
-  border-bottom: 2px solid silver;
-}
-h2 {
-  padding-top: 0.5em;
-}
-h3 {
-  float: left;
-}
-h3 + * {
-  clear: left;
-}
-h5 {
-  font-size: 1.0em;
-}
-
-div.sectionbody {
-  margin-left: 0;
-}
-
-hr {
-  border: 1px solid silver;
-}
+<style>
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
 
 p {
-  margin-top: 0.5em;
-  margin-bottom: 0.5em;
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
 }
 
-ul, ol, li > p {
-  margin-top: 0;
-}
-ul > li     { color: #aaa; }
-ul > li > * { color: black; }
-
-.monospaced, code, pre {
-  font-family: "Courier New", Courier, monospace;
-  font-size: inherit;
-  color: navy;
-  padding: 0;
-  margin: 0;
-}
-pre {
-  white-space: pre-wrap;
-}
-
-#author {
-  color: #527bbd;
-  font-weight: bold;
-  font-size: 1.1em;
-}
-#email {
-}
-#revnumber, #revdate, #revremark {
-}
-
-#footer {
-  font-size: small;
-  border-top: 2px solid silver;
-  padding-top: 0.5em;
-  margin-top: 4.0em;
-}
-#footer-text {
-  float: left;
-  padding-bottom: 0.5em;
-}
-#footer-badges {
-  float: right;
-  padding-bottom: 0.5em;
-}
-
-#preamble {
-  margin-top: 1.5em;
-  margin-bottom: 1.5em;
-}
-div.imageblock, div.exampleblock, div.verseblock,
-div.quoteblock, div.literalblock, div.listingblock, div.sidebarblock,
-div.admonitionblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.admonitionblock {
-  margin-top: 2.0em;
-  margin-bottom: 2.0em;
-  margin-right: 10%;
-  color: #606060;
-}
-
-div.content { /* Block element content. */
-  padding: 0;
-}
-
-/* Block element titles. */
-div.title, caption.title {
-  color: #527bbd;
-  font-weight: bold;
-  text-align: left;
-  margin-top: 1.0em;
-  margin-bottom: 0.5em;
-}
-div.title + * {
-  margin-top: 0;
-}
-
-td div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content div.title:first-child {
-  margin-top: 0.0em;
-}
-div.content + div.title {
-  margin-top: 0.0em;
-}
-
-div.sidebarblock > div.content {
-  background: #ffffee;
-  border: 1px solid #dddddd;
-  border-left: 4px solid #f0f0f0;
-  padding: 0.5em;
-}
-
-div.listingblock > div.content {
-  border: 1px solid #dddddd;
-  border-left: 5px solid #f0f0f0;
-  background: #f8f8f8;
-  padding: 0.5em;
-}
-
-div.quoteblock, div.verseblock {
-  padding-left: 1.0em;
-  margin-left: 1.0em;
-  margin-right: 10%;
-  border-left: 5px solid #f0f0f0;
-  color: #888;
-}
-
-div.quoteblock > div.attribution {
-  padding-top: 0.5em;
-  text-align: right;
-}
-
-div.verseblock > pre.content {
-  font-family: inherit;
-  font-size: inherit;
-}
-div.verseblock > div.attribution {
-  padding-top: 0.75em;
-  text-align: left;
-}
-/* DEPRECATED: Pre version 8.2.7 verse style literal block. */
-div.verseblock + div.attribution {
-  text-align: left;
-}
-
-div.admonitionblock .icon {
-  vertical-align: top;
-  font-size: 1.1em;
-  font-weight: bold;
-  text-decoration: underline;
-  color: #527bbd;
-  padding-right: 0.5em;
-}
-div.admonitionblock td.content {
-  padding-left: 0.5em;
-  border-left: 3px solid #dddddd;
-}
-
-div.exampleblock > div.content {
-  border-left: 3px solid #dddddd;
-  padding-left: 0.5em;
-}
-
-div.imageblock div.content { padding-left: 0; }
-span.image img { border-style: none; vertical-align: text-bottom; }
-a.image:visited { color: white; }
-
-dl {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-dt {
-  margin-top: 0.5em;
-  margin-bottom: 0;
-  font-style: normal;
-  color: navy;
-}
-dd > *:first-child {
-  margin-top: 0.1em;
-}
-
-ul, ol {
-    list-style-position: outside;
-}
-ol.arabic {
-  list-style-type: decimal;
-}
-ol.loweralpha {
-  list-style-type: lower-alpha;
-}
-ol.upperalpha {
-  list-style-type: upper-alpha;
-}
-ol.lowerroman {
-  list-style-type: lower-roman;
-}
-ol.upperroman {
-  list-style-type: upper-roman;
-}
-
-div.compact ul, div.compact ol,
-div.compact p, div.compact p,
-div.compact div, div.compact div {
-  margin-top: 0.1em;
-  margin-bottom: 0.1em;
-}
-
-tfoot {
-  font-weight: bold;
-}
-td > div.verse {
-  white-space: pre;
-}
-
-div.hdlist {
-  margin-top: 0.8em;
-  margin-bottom: 0.8em;
-}
-div.hdlist tr {
-  padding-bottom: 15px;
-}
-dt.hdlist1.strong, td.hdlist1.strong {
-  font-weight: bold;
-}
-td.hdlist1 {
-  vertical-align: top;
-  font-style: normal;
-  padding-right: 0.8em;
-  color: navy;
-}
-td.hdlist2 {
-  vertical-align: top;
-}
-div.hdlist.compact tr {
-  margin: 0;
-  padding-bottom: 0;
-}
-
-.comment {
-  background: yellow;
-}
-
-.footnote, .footnoteref {
-  font-size: 0.8em;
-}
-
-span.footnote, span.footnoteref {
-  vertical-align: super;
-}
-
-#footnotes {
-  margin: 20px 0 20px 0;
-  padding: 7px 0 0 0;
-}
-
-#footnotes div.footnote {
-  margin: 0 0 5px 0;
-}
-
-#footnotes hr {
-  border: none;
-  border-top: 1px solid silver;
-  height: 1px;
-  text-align: left;
-  margin-left: 0;
-  width: 20%;
-  min-width: 100px;
-}
-
-div.colist td {
-  padding-right: 0.5em;
-  padding-bottom: 0.3em;
-  vertical-align: top;
-}
-div.colist td img {
-  margin-top: 0.3em;
-}
-
-@media print {
-  #footer-badges { display: none; }
-}
-
-#toc {
-  margin-bottom: 2.5em;
-}
-
-#toctitle {
-  color: #527bbd;
-  font-size: 1.1em;
-  font-weight: bold;
-  margin-top: 1.0em;
-  margin-bottom: 0.1em;
-}
-
-div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
-  margin-top: 0;
-  margin-bottom: 0;
-}
-div.toclevel2 {
-  margin-left: 2em;
-  font-size: 0.9em;
-}
-div.toclevel3 {
-  margin-left: 4em;
-  font-size: 0.9em;
-}
-div.toclevel4 {
-  margin-left: 6em;
-  font-size: 0.9em;
-}
-
-span.aqua { color: aqua; }
-span.black { color: black; }
-span.blue { color: blue; }
-span.fuchsia { color: fuchsia; }
-span.gray { color: gray; }
-span.green { color: green; }
-span.lime { color: lime; }
-span.maroon { color: maroon; }
-span.navy { color: navy; }
-span.olive { color: olive; }
-span.purple { color: purple; }
-span.red { color: red; }
-span.silver { color: silver; }
-span.teal { color: teal; }
-span.white { color: white; }
-span.yellow { color: yellow; }
-
-span.aqua-background { background: aqua; }
-span.black-background { background: black; }
-span.blue-background { background: blue; }
-span.fuchsia-background { background: fuchsia; }
-span.gray-background { background: gray; }
-span.green-background { background: green; }
-span.lime-background { background: lime; }
-span.maroon-background { background: maroon; }
-span.navy-background { background: navy; }
-span.olive-background { background: olive; }
-span.purple-background { background: purple; }
-span.red-background { background: red; }
-span.silver-background { background: silver; }
-span.teal-background { background: teal; }
-span.white-background { background: white; }
-span.yellow-background { background: yellow; }
-
-span.big { font-size: 2em; }
-span.small { font-size: 0.6em; }
-
-span.underline { text-decoration: underline; }
-span.overline { text-decoration: overline; }
-span.line-through { text-decoration: line-through; }
-
-div.unbreakable { page-break-inside: avoid; }
-
-
-/*
- * xhtml11 specific
- *
- * */
-
-div.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-div.tableblock > table {
-  border: 3px solid #527bbd;
-}
-thead, p.table.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.table {
-  margin-top: 0;
-}
-/* Because the table frame attribute is overriden by CSS in most browsers. */
-div.tableblock > table[frame="void"] {
-  border-style: none;
-}
-div.tableblock > table[frame="hsides"] {
-  border-left-style: none;
-  border-right-style: none;
-}
-div.tableblock > table[frame="vsides"] {
-  border-top-style: none;
-  border-bottom-style: none;
-}
-
-
-/*
- * html5 specific
- *
- * */
-
-table.tableblock {
-  margin-top: 1.0em;
-  margin-bottom: 1.5em;
-}
-thead, p.tableblock.header {
-  font-weight: bold;
-  color: #527bbd;
-}
-p.tableblock {
-  margin-top: 0;
-}
-table.tableblock {
-  border-width: 3px;
-  border-spacing: 0px;
-  border-style: solid;
-  border-color: #527bbd;
-  border-collapse: collapse;
-}
-th.tableblock, td.tableblock {
-  border-width: 1px;
-  padding: 4px;
-  border-style: solid;
-  border-color: #527bbd;
-}
-
-table.tableblock.frame-topbot {
-  border-left-style: hidden;
-  border-right-style: hidden;
-}
-table.tableblock.frame-sides {
-  border-top-style: hidden;
-  border-bottom-style: hidden;
-}
-table.tableblock.frame-none {
-  border-style: hidden;
-}
-
-th.tableblock.halign-left, td.tableblock.halign-left {
-  text-align: left;
-}
-th.tableblock.halign-center, td.tableblock.halign-center {
-  text-align: center;
-}
-th.tableblock.halign-right, td.tableblock.halign-right {
-  text-align: right;
-}
-
-th.tableblock.valign-top, td.tableblock.valign-top {
-  vertical-align: top;
-}
-th.tableblock.valign-middle, td.tableblock.valign-middle {
-  vertical-align: middle;
-}
-th.tableblock.valign-bottom, td.tableblock.valign-bottom {
-  vertical-align: bottom;
-}
-
-
-/*
- * manpage specific
- *
- * */
-
-body.manpage h1 {
-  padding-top: 0.5em;
-  padding-bottom: 0.5em;
-  border-top: 2px solid silver;
-  border-bottom: 2px solid silver;
-}
-body.manpage h2 {
-  border-style: none;
-}
-body.manpage div.sectionbody {
-  margin-left: 3em;
-}
-
-@media print {
-  body.manpage div#toc { display: none; }
-}
-
-
-@media screen {
-  body {
-    max-width: 50em; /* approximately 80 characters wide */
-    margin-left: 16em;
-  }
-
-  #toc {
-    position: fixed;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    width: 13em;
-    padding: 0.5em;
-    padding-bottom: 1.5em;
-    margin: 0;
-    overflow: auto;
-    border-right: 3px solid #f8f8f8;
-    background-color: white;
-  }
-
-  #toc .toclevel1 {
-    margin-top: 0.5em;
-  }
-
-  #toc .toclevel2 {
-    margin-top: 0.25em;
-    display: list-item;
-    color: #aaaaaa;
-  }
-
-  #toctitle {
-    margin-top: 0.5em;
-  }
-}
 </style>
-<script type="text/javascript">
-/*<![CDATA[*/
-var asciidoc = {  // Namespace.
-
-/////////////////////////////////////////////////////////////////////
-// Table Of Contents generator
-/////////////////////////////////////////////////////////////////////
-
-/* Author: Mihai Bazon, September 2002
- * http://students.infoiasi.ro/~mishoo
- *
- * Table Of Content generator
- * Version: 0.4
- *
- * Feel free to use this script under the terms of the GNU General Public
- * License, as long as you do not remove or alter this notice.
- */
-
- /* modified by Troy D. Hanson, September 2006. License: GPL */
- /* modified by Stuart Rackham, 2006, 2009. License: GPL */
-
-// toclevels = 1..4.
-toc: function (toclevels) {
-
-  function getText(el) {
-    var text = "";
-    for (var i = el.firstChild; i != null; i = i.nextSibling) {
-      if (i.nodeType == 3 /* Node.TEXT_NODE */) // IE doesn't speak constants.
-        text += i.data;
-      else if (i.firstChild != null)
-        text += getText(i);
-    }
-    return text;
-  }
-
-  function TocEntry(el, text, toclevel) {
-    this.element = el;
-    this.text = text;
-    this.toclevel = toclevel;
-  }
-
-  function tocEntries(el, toclevels) {
-    var result = new Array;
-    var re = new RegExp('[hH]([1-'+(toclevels+1)+'])');
-    // Function that scans the DOM tree for header elements (the DOM2
-    // nodeIterator API would be a better technique but not supported by all
-    // browsers).
-    var iterate = function (el) {
-      for (var i = el.firstChild; i != null; i = i.nextSibling) {
-        if (i.nodeType == 1 /* Node.ELEMENT_NODE */) {
-          var mo = re.exec(i.tagName);
-          if (mo && (i.getAttribute("class") || i.getAttribute("className")) != "float") {
-            result[result.length] = new TocEntry(i, getText(i), mo[1]-1);
-          }
-          iterate(i);
-        }
-      }
-    }
-    iterate(el);
-    return result;
-  }
-
-  var toc = document.getElementById("toc");
-  if (!toc) {
-    return;
-  }
-
-  // Delete existing TOC entries in case we're reloading the TOC.
-  var tocEntriesToRemove = [];
-  var i;
-  for (i = 0; i < toc.childNodes.length; i++) {
-    var entry = toc.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div'
-     && entry.getAttribute("class")
-     && entry.getAttribute("class").match(/^toclevel/))
-      tocEntriesToRemove.push(entry);
-  }
-  for (i = 0; i < tocEntriesToRemove.length; i++) {
-    toc.removeChild(tocEntriesToRemove[i]);
-  }
-
-  // Rebuild TOC entries.
-  var entries = tocEntries(document.getElementById("content"), toclevels);
-  for (var i = 0; i < entries.length; ++i) {
-    var entry = entries[i];
-    if (entry.element.id == "")
-      entry.element.id = "_toc_" + i;
-    var a = document.createElement("a");
-    a.href = "#" + entry.element.id;
-    a.appendChild(document.createTextNode(entry.text));
-    var div = document.createElement("div");
-    div.appendChild(a);
-    div.className = "toclevel" + entry.toclevel;
-    toc.appendChild(div);
-  }
-  if (entries.length == 0)
-    toc.parentNode.removeChild(toc);
-},
-
-
-/////////////////////////////////////////////////////////////////////
-// Footnotes generator
-/////////////////////////////////////////////////////////////////////
-
-/* Based on footnote generation code from:
- * http://www.brandspankingnew.net/archive/2005/07/format_footnote.html
- */
-
-footnotes: function () {
-  // Delete existing footnote entries in case we're reloading the footnodes.
-  var i;
-  var noteholder = document.getElementById("footnotes");
-  if (!noteholder) {
-    return;
-  }
-  var entriesToRemove = [];
-  for (i = 0; i < noteholder.childNodes.length; i++) {
-    var entry = noteholder.childNodes[i];
-    if (entry.nodeName.toLowerCase() == 'div' && entry.getAttribute("class") == "footnote")
-      entriesToRemove.push(entry);
-  }
-  for (i = 0; i < entriesToRemove.length; i++) {
-    noteholder.removeChild(entriesToRemove[i]);
-  }
-
-  // Rebuild footnote entries.
-  var cont = document.getElementById("content");
-  var spans = cont.getElementsByTagName("span");
-  var refs = {};
-  var n = 0;
-  for (i=0; i<spans.length; i++) {
-    if (spans[i].className == "footnote") {
-      n++;
-      var note = spans[i].getAttribute("data-note");
-      if (!note) {
-        // Use [\s\S] in place of . so multi-line matches work.
-        // Because JavaScript has no s (dotall) regex flag.
-        note = spans[i].innerHTML.match(/\s*\[([\s\S]*)]\s*/)[1];
-        spans[i].innerHTML =
-          "[<a id='_footnoteref_" + n + "' href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-        spans[i].setAttribute("data-note", note);
-      }
-      noteholder.innerHTML +=
-        "<div class='footnote' id='_footnote_" + n + "'>" +
-        "<a href='#_footnoteref_" + n + "' title='Return to text'>" +
-        n + "</a>. " + note + "</div>";
-      var id =spans[i].getAttribute("id");
-      if (id != null) refs["#"+id] = n;
-    }
-  }
-  if (n == 0)
-    noteholder.parentNode.removeChild(noteholder);
-  else {
-    // Process footnoterefs.
-    for (i=0; i<spans.length; i++) {
-      if (spans[i].className == "footnoteref") {
-        var href = spans[i].getElementsByTagName("a")[0].getAttribute("href");
-        href = href.match(/#.*/)[0];  // Because IE return full URL.
-        n = refs[href];
-        spans[i].innerHTML =
-          "[<a href='#_footnote_" + n +
-          "' title='View footnote' class='footnote'>" + n + "</a>]";
-      }
-    }
-  }
-},
-
-install: function(toclevels) {
-  var timerId;
-
-  function reinstall() {
-    asciidoc.footnotes();
-    if (toclevels) {
-      asciidoc.toc(toclevels);
-    }
-  }
-
-  function reinstallAndRemoveTimer() {
-    clearInterval(timerId);
-    reinstall();
-  }
-
-  timerId = setInterval(reinstall, 500);
-  if (document.addEventListener)
-    document.addEventListener("DOMContentLoaded", reinstallAndRemoveTimer, false);
-  else
-    window.onload = reinstallAndRemoveTimer;
-}
-
-}
-asciidoc.install(1);
-/*]]>*/
-</script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_subgroups</h1>
-<div id="toc">
-  <div id="toctitle">Table of Contents</div>
-  <noscript><p><b>JavaScript must be enabled in your browser to display the table of contents.</b></p></noscript>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_new_instructions">New Instructions</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_2">Modifications to the SPIR-V Specification, Version 1.2</a></li>
+<li><a href="#_validation_rules">Validation Rules</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
 </div>
 </div>
 <div id="content">
 <div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>SPV_INTEL_subgroups</p></div>
+<div class="paragraph">
+<p>SPV_INTEL_subgroups</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>To report problems with this extension, please open a new issue at:</p></div>
-<div class="paragraph"><p><a href="https://github.com/KhronosGroup/SPIRV-Registry">https://github.com/KhronosGroup/SPIRV-Registry</a></p></div>
+<div class="paragraph">
+<p>To report problems with this extension, please open a new issue at:</p>
+</div>
+<div class="paragraph">
+<p><a href="https://github.com/KhronosGroup/SPIRV-Registry" class="bare">https://github.com/KhronosGroup/SPIRV-Registry</a></p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Ben Ashbaugh, Intel<br>
-</p>
+<p>Ben Ashbaugh, Intel<br></p>
 </li>
 <li>
-<p>
-Biju George, Intel<br>
-</p>
+<p>Biju George, Intel<br></p>
 </li>
 <li>
-<p>
-Michael Kinsner, Intel<br>
-</p>
+<p>Michael Kinsner, Intel<br></p>
 </li>
 <li>
-<p>
-Mariusz Merecki, Intel
-</p>
+<p>Mariusz Merecki, Intel</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Copyright (c) 2017-2018 Intel Corporation.  All rights reserved.</p></div>
+<div class="paragraph">
+<p>Copyright (c) 2017-2018 Intel Corporation.  All rights reserved.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="ulist"><ul>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Final Draft
-</p>
+<p>Final Draft</p>
 </li>
-</ul></div>
+</ul>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all"
-style="
-width:40%;
-">
-<col style="width:50%;">
-<col style="width:50%;">
+<table class="tableblock frame-all grid-all" style="width: 40%;">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2018-11-20</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-21</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
 </tr>
 </tbody>
 </table>
@@ -856,131 +131,153 @@ width:40%;
 <div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension is written against the SPIR-V Specification,
-Version 1.2 Revision 1.</p></div>
-<div class="paragraph"><p>This extension requires SPIR-V 1.0.</p></div>
+<div class="paragraph">
+<p>This extension is written against the SPIR-V Specification,
+Version 1.2 Revision 1.</p>
+</div>
+<div class="paragraph">
+<p>This extension requires SPIR-V 1.0.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>The goal of this extension is to allow programmers to improve the performance of their applications by taking advantage of the fact that some work items in a work group execute together as a group (a "subgroup"), and that work items in a subgroup can use hardware features that are not available to all work items in a work group. Specifically, this extension is designed to allow work items in a subgroup to share data without the use of local memory and work group barriers, and to utilize specialized hardware to load and store blocks of data from images or buffers.</p></div>
-<div class="paragraph"><p>This extension builds upon "subgroups" functionality that is already in core SPIR-V, so this extension reuses many of the names, concepts, and instructions already described in SPIR-V.  The key additions in this extension are:</p></div>
-<div class="ulist"><ul>
+<div class="paragraph">
+<p>The goal of this extension is to allow programmers to improve the performance of their applications by taking advantage of the fact that some work items in a work group execute together as a group (a "subgroup"), and that work items in a subgroup can use hardware features that are not available to all work items in a work group. Specifically, this extension is designed to allow work items in a subgroup to share data without the use of local memory and work group barriers, and to utilize specialized hardware to load and store blocks of data from images or buffers.</p>
+</div>
+<div class="paragraph">
+<p>This extension builds upon "subgroups" functionality that is already in core SPIR-V, so this extension reuses many of the names, concepts, and instructions already described in SPIR-V.  The key additions in this extension are:</p>
+</div>
+<div class="ulist">
+<ul>
 <li>
-<p>
-Intel subgroups adds "shuffle" instructions to allow data interchange between work items within a subgroup without the use of local memory or barriers.
-</p>
+<p>Intel subgroups adds "shuffle" instructions to allow data interchange between work items within a subgroup without the use of local memory or barriers.</p>
 </li>
 <li>
-<p>
-Intel subgroups adds "block read and write" instructions to take advantage of specialized hardware to read or write blocks of data from or to buffers or images.
-</p>
+<p>Intel subgroups adds "block read and write" instructions to take advantage of specialized hardware to read or write blocks of data from or to buffers or images.</p>
 </li>
-</ul></div>
-<div class="paragraph"><p>This extension has a source language counterpart extension for the OpenCL-C kernel language, <span class="monospaced">cl_intel_subgroups</span>, which can be used for online compilation in an OpenCL environment.</p></div>
+</ul>
+</div>
+<div class="paragraph">
+<p>This extension has a source language counterpart extension for the OpenCL-C kernel language, <code>cl_intel_subgroups</code>, which can be used for online compilation in an OpenCL environment.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_extension_name">Extension Name</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>To use this extension within a SPIR-V module, the appropriate <strong>OpExtension</strong> must be present in the module:</p></div>
+<div class="paragraph">
+<p>To use this extension within a SPIR-V module, the appropriate <strong>OpExtension</strong> must be present in the module:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpExtension "SPV_INTEL_subgroups"</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_capabilities">New Capabilities</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>This extension introduces new capabilities:</p></div>
+<div class="paragraph">
+<p>This extension introduces new capabilities:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>SubgroupShuffleINTEL
 SubgroupBufferBlockIOINTEL
 SubgroupImageBlockIOINTEL</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_new_instructions">New Instructions</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>Instructions added under the <strong>SubgroupShuffleINTEL</strong> capability:</p></div>
+<div class="paragraph">
+<p>Instructions added under the <strong>SubgroupShuffleINTEL</strong> capability:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpSubgroupShuffleINTEL
 OpSubgroupShuffleDownINTEL
 OpSubgroupShuffleUpINTEL
 OpSubgroupShuffleXorINTEL</pre>
-</div></div>
-<div class="paragraph"><p>Instructions added under the <strong>SubgroupBufferBlockIOINTEL</strong> capability:</p></div>
+</div>
+</div>
+<div class="paragraph">
+<p>Instructions added under the <strong>SubgroupBufferBlockIOINTEL</strong> capability:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpSubgroupBlockReadINTEL
 OpSubgroupBlockWriteINTEL</pre>
-</div></div>
-<div class="paragraph"><p>Instructions added under the <strong>SubgroupImageBlockIOINTEL</strong> capability:</p></div>
+</div>
+</div>
+<div class="paragraph">
+<p>Instructions added under the <strong>SubgroupImageBlockIOINTEL</strong> capability:</p>
+</div>
 <div class="listingblock">
-<div class="content monospaced">
+<div class="content">
 <pre>OpSubgroupImageBlockReadINTEL
 OpSubgroupImageBlockWriteINTEL</pre>
-</div></div>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:40%;
-">
-<col style="width:70%;">
-<col style="width:30%;">
+<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<colgroup>
+<col style="width: 70%;">
+<col style="width: 30%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupShuffleINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5568</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupShuffleINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5568</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupBufferBlockIOINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5569</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupBufferBlockIOINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5569</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">SubgroupImageBlockIOINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5570</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">SubgroupImageBlockIOINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5570</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupShuffleINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5571</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupShuffleINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5571</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupShuffleDownINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5572</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupShuffleDownINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5572</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupShuffleUpINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5573</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupShuffleUpINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5573</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupShuffleXorINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5574</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupShuffleXorINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5574</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupBlockReadINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5575</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupBlockReadINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5575</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupBlockWriteINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5576</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupBlockWriteINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5576</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupImageBlockReadINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5577</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupImageBlockReadINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5577</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">OpSubgroupImageBlockWriteINTEL</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5578</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">OpSubgroupImageBlockWriteINTEL</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5578</p></td>
 </tr>
 </tbody>
 </table>
@@ -991,93 +288,94 @@ width:40%;
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="_capabilities">Capabilities</h3>
-<div class="paragraph"><p>Modify Section 3.31, Capability, adding rows to the Capability table:</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:5%;">
-<col style="width:52%;">
-<col style="width:21%;">
-<col style="width:21%;">
+<div class="paragraph">
+<p>Modify Section 3.31, Capability, adding rows to the Capability table:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 5.2631%;">
+<col style="width: 52.6315%;">
+<col style="width: 21.0526%;">
+<col style="width: 21.0528%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-center valign-top" colspan="2" > Capability </th>
-<th class="tableblock halign-center valign-top" > Implicitly Declares </th>
-<th class="tableblock halign-center valign-top" > Enabled by Extension</th>
+<th class="tableblock halign-center valign-top" colspan="2">Capability</th>
+<th class="tableblock halign-center valign-top">Implicitly Declares</th>
+<th class="tableblock halign-center valign-top">Enabled by Extension</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5568</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>SubgroupShuffleINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>SPV_INTEL_subgroups</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5568</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>SubgroupShuffleINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>SPV_INTEL_subgroups</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5569</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>SubgroupBufferBlockIOINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>SPV_INTEL_subgroups</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5569</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>SubgroupBufferBlockIOINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>SPV_INTEL_subgroups</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5570</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>SubgroupImageBlockIOINTEL</strong></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>SPV_INTEL_subgroups</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5570</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>SubgroupImageBlockIOINTEL</strong></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>SPV_INTEL_subgroups</strong></p></td>
 </tr>
 </tbody>
 </table>
 </div>
 <div class="sect2">
 <h3 id="_instructions">Instructions</h3>
-<div class="paragraph"><p>Modify Section 3.32.21, Group Instructions, adding to the end of the list of instructions:</p></div>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:7%;">
-<col style="width:7%;">
-<col style="width:21%;">
-<col style="width:21%;">
-<col style="width:21%;">
-<col style="width:21%;">
+<div class="paragraph">
+<p>Modify Section 3.32.21, Group Instructions, adding to the end of the list of instructions:</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 7.1428%;">
+<col style="width: 7.1428%;">
+<col style="width: 21.4285%;">
+<col style="width: 21.4285%;">
+<col style="width: 21.4285%;">
+<col style="width: 21.4289%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><p class="tableblock"><a id="OpSubgroupShuffleINTEL"></a><strong>OpSubgroupShuffleINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><a id="OpSubgroupShuffleINTEL"></a><strong>OpSubgroupShuffleINTEL</strong><br>
 <br>
 Allows data to be arbitrarily transferred between invocations in a subgroup.  The data that is returned for this invocation is the value of <em>Data</em> for the invocation identified by <em>InvocationId</em>.</p>
 <p class="tableblock"><em>InvocationId</em> need not be the same value for all invocations in the subgroup.</p>
 <p class="tableblock"><em>Result Type</em> may be a scalar or vector type.</p>
 <p class="tableblock">The type of <em>Data</em> must be the same as <em>Result Type</em>.</p>
 <p class="tableblock"><em>InvocationId</em> must be a 32-bit <em>integer type</em> scalar.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupShuffleINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5571</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Result</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Data</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>InvocationId</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5571</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Result Type</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Result</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Data</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>InvocationId</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:5%;">
-<col style="width:5%;">
-<col style="width:17%;">
-<col style="width:17%;">
-<col style="width:17%;">
-<col style="width:17%;">
-<col style="width:17%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 5.8823%;">
+<col style="width: 5.8823%;">
+<col style="width: 17.647%;">
+<col style="width: 17.647%;">
+<col style="width: 17.647%;">
+<col style="width: 17.647%;">
+<col style="width: 17.6474%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpSubgroupShuffleDownINTEL"></a><strong>OpSubgroupShuffleDownINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpSubgroupShuffleDownINTEL"></a><strong>OpSubgroupShuffleDownINTEL</strong><br>
 <br>
 Allows data to be transferred from an invocation in the subgroup with a higher <strong>SubgroupLocalInvocationId</strong> down to a invocation in the subgroup with a lower <strong>SubgroupLocalInvocationId</strong>.</p>
 <p class="tableblock">There are two data sources to this built-in function: <em>Current</em> and <em>Next</em>.  To determine the result of this built-in function, first let the unsigned shuffle index be equivalent to the sum of this invocation&#8217;s <strong>SubgroupLocalInvocationId</strong> plus the specified <em>Delta</em>:</p>
@@ -1088,34 +386,33 @@ Allows data to be transferred from an invocation in the subgroup with a higher <
 <p class="tableblock"><em>Result Type</em> may be a scalar or vector type.</p>
 <p class="tableblock">The type of <em>Current</em> and <em>Next</em> must be the same as <em>Result Type</em>.</p>
 <p class="tableblock"><em>Delta</em> must be a 32-bit <em>integer type</em> scalar.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupShuffleINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5572</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Result</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Current</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Next</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Delta</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5572</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Result Type</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Result</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Current</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Next</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Delta</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:5%;">
-<col style="width:5%;">
-<col style="width:17%;">
-<col style="width:17%;">
-<col style="width:17%;">
-<col style="width:17%;">
-<col style="width:17%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 5.8823%;">
+<col style="width: 5.8823%;">
+<col style="width: 17.647%;">
+<col style="width: 17.647%;">
+<col style="width: 17.647%;">
+<col style="width: 17.647%;">
+<col style="width: 17.6474%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="6" ><p class="tableblock"><a id="OpSubgroupShuffleUpINTEL"></a><strong>OpSubgroupShuffleUpINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="6"><p class="tableblock"><a id="OpSubgroupShuffleUpINTEL"></a><strong>OpSubgroupShuffleUpINTEL</strong><br>
 <br>
 Allows data to be transferred from an invocation in the subgroup with a lower <strong>SubgroupLocalInvocationId</strong> up to an invocation in the subgroup with a higher <strong>SubgroupLocalInvocationId</strong>.</p>
 <p class="tableblock">There are two data sources to this built-in function: <em>Previous</em> and <em>Current</em>.  To determine the result of this built-in function, first let the signed shuffle index be equivalent to this invocation&#8217;s <strong>SubgroupLocalInvocationId</strong> minus the specified <em>Delta</em>:</p>
@@ -1126,175 +423,170 @@ Allows data to be transferred from an invocation in the subgroup with a lower <s
 <p class="tableblock"><em>Result Type</em> may be a scalar or vector type.</p>
 <p class="tableblock">The type of <em>Previous</em> and <em>Current</em> must be the same as <em>Result Type</em>.</p>
 <p class="tableblock"><em>Delta</em> must be a 32-bit <em>integer type</em> scalar.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupShuffleINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">6</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5573</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Result</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Previous</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Current</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Delta</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">6</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5573</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Result Type</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Result</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Previous</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Current</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Delta</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:7%;">
-<col style="width:7%;">
-<col style="width:21%;">
-<col style="width:21%;">
-<col style="width:21%;">
-<col style="width:21%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 7.1428%;">
+<col style="width: 7.1428%;">
+<col style="width: 21.4285%;">
+<col style="width: 21.4285%;">
+<col style="width: 21.4285%;">
+<col style="width: 21.4289%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><p class="tableblock"><a id="OpSubgroupShuffleXorINTEL"></a><strong>OpSubgroupShuffleXorINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><a id="OpSubgroupShuffleXorINTEL"></a><strong>OpSubgroupShuffleXorINTEL</strong><br>
 <br>
-Allows data to be transferred between invocations in a subgroup as a function of the invocation&#8217;s <strong>SubgroupLocalInvocationId</strong>.  The data that is returned for this invocation is the value of <em>Data</em> for the invocation with <strong>SubgroupLocalInvocationId</strong> equal to this invocation&#8217;s <strong>SubgroupLocalInvocationId</strong> XOR&#8217;d with the specified <em>Value</em>.  If the result of the XOR is greater than <strong>SubgroupMaxSize</strong> then it is considered out-of-range.</p>
+Allows data to be transferred between invocations in a subgroup as a function of the invocation_s <strong>SubgroupLocalInvocationId</strong>.  The data that is returned for this invocation is the value of <em>Data</em> for the invocation with <strong>SubgroupLocalInvocationId</strong> equal to this invocation&#8217;s <strong>SubgroupLocalInvocationId</strong> XOR_d with the specified <em>Value</em>.  If the result of the XOR is greater than <strong>SubgroupMaxSize</strong> then it is considered out-of-range.</p>
 <p class="tableblock"><em>Value</em> need not be the same for all invocations in the subgroup.</p>
 <p class="tableblock"><em>Result Type</em> may be a scalar or vector type.</p>
 <p class="tableblock">The type of <em>Data</em> must be the same as <em>Result Type</em>.</p>
 <p class="tableblock"><em>Value</em> must be a 32-bit <em>integer type</em> scalar.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupShuffleINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5574</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Result</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Data</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Value</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5574</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Result Type</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Result</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Data</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Value</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:9%;">
-<col style="width:9%;">
-<col style="width:27%;">
-<col style="width:27%;">
-<col style="width:27%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 9.0909%;">
+<col style="width: 9.0909%;">
+<col style="width: 27.2727%;">
+<col style="width: 27.2727%;">
+<col style="width: 27.2728%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><a id="OpSubgroupBlockReadINTEL"></a><strong>OpSubgroupBlockReadINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><a id="OpSubgroupBlockReadINTEL"></a><strong>OpSubgroupBlockReadINTEL</strong><br>
 <br>
 Reads one or more components of <em>Result</em> data for each invocation in the subgroup from the specified <em>Ptr</em> as a block operation.</p>
 <p class="tableblock">The data is read strided, so the first value read is:</p>
-<p class="tableblock"><span class="monospaced">Ptr[ <strong>SubgroupLocalInvocationId</strong> ]</span></p>
+<p class="tableblock"><code>Ptr[ <strong>SubgroupLocalInvocationId</strong> ]</code></p>
 <p class="tableblock">and the second value read is:</p>
-<p class="tableblock"><span class="monospaced">Ptr[ <strong>SubgroupLocalInvocationId</strong> + <strong>SubgroupMaxSize</strong> ]</span></p>
+<p class="tableblock"><code>Ptr[ <strong>SubgroupLocalInvocationId</strong> + <strong>SubgroupMaxSize</strong> ]</code></p>
 <p class="tableblock">etc.</p>
 <p class="tableblock"><em>Result Type</em> may be a scalar or vector type, and its component type must be equal to the type pointed to by <em>Ptr</em>.</p>
 <p class="tableblock">The type of <em>Ptr</em> must be a <em>pointer type</em>, and must point to a <em>scalar type</em>.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupBufferBlockIOINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5575</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Result</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Ptr</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5575</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Result Type</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Result</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Ptr</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:12%;">
-<col style="width:12%;">
-<col style="width:37%;">
-<col style="width:37%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 12.5%;">
+<col style="width: 12.5%;">
+<col style="width: 37.5%;">
+<col style="width: 37.5%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="3" ><p class="tableblock"><a id="OpSubgroupBlockWriteINTEL"></a><strong>OpSubgroupBlockWriteINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="3"><p class="tableblock"><a id="OpSubgroupBlockWriteINTEL"></a><strong>OpSubgroupBlockWriteINTEL</strong><br>
 <br>
 Writes one or more components of <em>Data</em> for each invocation in the subgroup from the specified <em>Ptr</em> as a block operation.</p>
 <p class="tableblock">The data is written strided, so the first value is written to:</p>
-<p class="tableblock"><span class="monospaced">Ptr[ <strong>SubgroupLocalInvocationId</strong> ]</span></p>
+<p class="tableblock"><code>Ptr[ <strong>SubgroupLocalInvocationId</strong> ]</code></p>
 <p class="tableblock">and the second value written is:</p>
-<p class="tableblock"><span class="monospaced">Ptr[ <strong>SubgroupLocalInvocationId</strong> + <strong>SubgroupMaxSize</strong> ]</span></p>
+<p class="tableblock"><code>Ptr[ <strong>SubgroupLocalInvocationId</strong> + <strong>SubgroupMaxSize</strong> ]</code></p>
 <p class="tableblock">etc.</p>
 <p class="tableblock">The type of <em>Ptr</em> must be a <em>pointer type</em>, and must point to a <em>scalar type</em>.</p>
 <p class="tableblock">The component type of <em>Data</em> must be equal to the type pointed to by <em>Ptr</em>.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupBufferBlockIOINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">3</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5576</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Ptr</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Data</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5576</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Ptr</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Data</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:7%;">
-<col style="width:7%;">
-<col style="width:21%;">
-<col style="width:21%;">
-<col style="width:21%;">
-<col style="width:21%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 7.1428%;">
+<col style="width: 7.1428%;">
+<col style="width: 21.4285%;">
+<col style="width: 21.4285%;">
+<col style="width: 21.4285%;">
+<col style="width: 21.4289%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="5" ><p class="tableblock"><a id="OpSubgroupImageBlockReadINTEL"></a><strong>OpSubgroupImageBlockReadINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="5"><p class="tableblock"><a id="OpSubgroupImageBlockReadINTEL"></a><strong>OpSubgroupImageBlockReadINTEL</strong><br>
 <br>
 Reads one or more components of <em>Result</em> data for each invocation in the subgroup from the specified <em>Image</em> at the specified <em>Coordinate</em> as a block operation.  Note that the <em>Coordinate</em> is a byte coordinate, not a texel coordinate.  Also note that the image data is read without format conversion, so each invocation may read multiple image elements.</p>
 <p class="tableblock">The data is read row-by-row, so the first value read is from the row specified by the y-component of the provided <em>Coordinate</em>, the second value is read from the row specified by the y-component of the provided <em>Coordinate</em> plus one, etc.</p>
 <p class="tableblock"><em>Result Type</em> may be a scalar or vector type.</p>
 <p class="tableblock"><em>Image</em> must be an object whose type is <strong>OpTypeImage</strong> with a <em>Sampled</em> operand of 0 or 2.  If the <em>Sampled</em> operand is 2, then some dimensions require a capability.</p>
 <p class="tableblock"><em>Coordinate</em> is an integer scalar or vector.  The x-component is a byte coordinate into rows of the image and remaining coordinates are non-normalized texel coordinates.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupImageBlockIOINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5577</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Result Type</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Result</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Image</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Coordinate</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5577</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Result Type</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Result</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Image</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Coordinate</em></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all"
-style="
-width:100%;
-">
-<col style="width:9%;">
-<col style="width:9%;">
-<col style="width:27%;">
-<col style="width:27%;">
-<col style="width:27%;">
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 9.0909%;">
+<col style="width: 9.0909%;">
+<col style="width: 27.2727%;">
+<col style="width: 27.2727%;">
+<col style="width: 27.2728%;">
+</colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" colspan="4" ><p class="tableblock"><a id="OpSubgroupImageBlockWriteINTEL"></a><strong>OpSubgroupImageBlockWriteINTEL</strong><br>
+<td class="tableblock halign-left valign-top" colspan="4"><p class="tableblock"><a id="OpSubgroupImageBlockWriteINTEL"></a><strong>OpSubgroupImageBlockWriteINTEL</strong><br>
 <br>
 Writes one or more components of <em>Data</em> for each invocation in the subgroup to the specified <em>Image</em> at the specified <em>Coordinate</em> as a block operation.  Note that the <em>Coordinate</em> is a byte coordinate, not a texel coordinate.  Also note that the image data is read without format conversion, so each invocation may write multiple image elements.</p>
 <p class="tableblock">The data is written row-by-row, so the first value is written to the row specified by the y-component of the provided <em>Coordinate</em>, the second value is written to the row specified by the y-component of the provided <em>Coordinate</em> plus one, etc.</p>
 <p class="tableblock"><em>Image</em> must be an object whose type is <strong>OpTypeImage</strong> with a <em>Sampled</em> operand of 0 or 2.  If the <em>Sampled</em> operand is 2, then some dimensions require a capability.</p>
 <p class="tableblock"><em>Coordinate</em> is an integer scalar or vector.  The x-component is a byte coordinate into rows of the image and remaining coordinates are non-normalized texel coordinates.</p>
 <p class="tableblock"><em>Result Type</em> may be a scalar or vector type.</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Capability:<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capability:<br>
 <strong>SubgroupImageBlockIOINTEL</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">4</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">5578</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Image</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Coordinate</em></p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><em>&lt;id&gt;</em> <em>Data</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">5578</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Image</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Coordinate</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Data</em></p></td>
 </tr>
 </tbody>
 </table>
@@ -1304,57 +596,53 @@ Writes one or more components of <em>Data</em> for each invocation in the subgro
 <div class="sect1">
 <h2 id="_validation_rules">Validation Rules</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph"><p>None.</p></div>
+<div class="paragraph">
+<p>None.</p>
+</div>
 </div>
 </div>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows"
-style="
-width:100%;
-">
-<col style="width:4%;">
-<col style="width:14%;">
-<col style="width:14%;">
-<col style="width:66%;">
+<table class="tableblock frame-all grid-rows stretch">
+<colgroup>
+<col style="width: 4.7619%;">
+<col style="width: 14.2857%;">
+<col style="width: 14.2857%;">
+<col style="width: 66.6667%;">
+</colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top" >Rev</th>
-<th class="tableblock halign-left valign-top" >Date</th>
-<th class="tableblock halign-left valign-top" >Author</th>
-<th class="tableblock halign-left valign-top" >Changes</th>
+<th class="tableblock halign-left valign-top">Rev</th>
+<th class="tableblock halign-left valign-top">Date</th>
+<th class="tableblock halign-left valign-top">Author</th>
+<th class="tableblock halign-left valign-top">Changes</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2017-09-29</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock"><strong>Initial revision</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2017-09-29</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Initial revision</strong></p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">2018-10-22</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Ben Ashbaugh</p></td>
-<td class="tableblock halign-left valign-top" ><p class="tableblock">Minor formatting updates.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2018-10-22</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Ben Ashbaugh</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Minor formatting updates.</p></td>
 </tr>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footnotes"><hr></div>
-<div id="footer">
-<div id="footer-text">
-Last updated
- 2018-11-20 13:32:28 PST
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_task_sequence.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_task_sequence.asciidoc
@@ -59,7 +59,7 @@ A task sequence object can be created by calling *OpTaskSequenceCreateINTEL*.
 The *OpTaskSequenceAsyncINTEL*, *OpTaskSequenceGetINTEL*, and
 *OpTaskSequenceReleaseINTEL* instructions take a task sequence object as an
 argument. The *OpTaskSequenceAsyncINTEL* instruction creates a invocation which
-will be referred to as a 'task thread' in this document. This task thread is
+will be referred to as a _task thread_ in this document. This task thread is
 said to belong to the task sequence specified to the *OpTaskSequenceAsyncINTEL*
 instruction. The *OpTaskSequenceGetINTEL* instruction returns the result of a
 task thread in the specified task sequence. Results are returned from the task

--- a/extensions/INTEL/SPV_INTEL_task_sequence.html
+++ b/extensions/INTEL/SPV_INTEL_task_sequence.html
@@ -4,441 +4,47 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.17">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_task_sequence</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
-/* Uncomment the following line when using as a custom stylesheet */
-/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
-html{font-family:sans-serif;-webkit-text-size-adjust:100%}
-a{background:none}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-b,strong{font-weight:bold}
-abbr{font-size:.9em}
-abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
-dfn{font-style:italic}
-hr{height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-audio,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type=checkbox],input[type=radio]{padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,::before,::after{box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:0}
-p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-:not(pre).nobreak{word-wrap:normal}
-:not(pre).nowrap{white-space:nowrap}
-:not(pre).pre-wrap{white-space:pre-wrap}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
-pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
-pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
-pre>code{display:block}
-pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #e7e7e9}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details{margin-left:1.25rem}
-details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
-details>summary::-webkit-details-marker{display:none}
-details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
-details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
-details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
-@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
-.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
-.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.prettyprint{background:#f7f7f8}
-pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
-pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
-pre.prettyprint li code[data-lang]::before{opacity:1}
-pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
-table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
-table.linenotable td.code{padding-left:.75em}
-table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
-pre.pygments span.linenos{display:inline-block;margin-right:.75em}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
-.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
-.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
-.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
-td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>*>tr>*{border-width:1px}
-table.grid-cols>*>tr>*{border-width:0 1px}
-table.grid-rows>*>tr>*{border-width:1px 0}
-table.frame-all{border-width:1px}
-table.frame-ends{border-width:1px 0}
-table.frame-sides{border-width:0 1px}
-table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
-table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
-table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
-table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
-table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-li>p:empty:only-child::before{content:"";display:inline-block}
-ul.checklist>li>p:first-child{margin-left:-1em}
-ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
-ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-td.hdlist2{word-wrap:anywhere}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
-.imageblock.left{margin:.25em .625em 1.25em 0}
-.imageblock.right{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background:#00fafa}
-.black{color:#000}
-.black-background{background:#000}
-.blue{color:#0000bf}
-.blue-background{background:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background:#fa00fa}
-.gray{color:#606060}
-.gray-background{background:#7d7d7d}
-.green{color:#006000}
-.green-background{background:#007d00}
-.lime{color:#00bf00}
-.lime-background{background:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background:#7d0000}
-.navy{color:#000060}
-.navy-background{background:#00007d}
-.olive{color:#606000}
-.olive-background{background:#7d7d00}
-.purple{color:#600060}
-.purple-background{background:#7d007d}
-.red{color:#bf0000}
-.red-background{background:#fa0000}
-.silver{color:#909090}
-.silver-background{background:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]{border-bottom:1px dotted}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#header,#content,#footnotes,#footer{max-width:none}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_task_sequence</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_new_instructions">New Instructions</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_6_revision_2">Modifications to the SPIR-V Specification, Version 1.6, Revision 2</a></li>
+<li><a href="#_spir_v_representation_in_llvm_ir">SPIR-V Representation in LLVM IR</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
 <div class="sect1">
@@ -514,7 +120,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-03-21</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-21</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -557,7 +163,7 @@ be queried with the <strong>OpTaskSequenceGetINTEL</strong> instruction.</p>
 The <strong>OpTaskSequenceAsyncINTEL</strong>, <strong>OpTaskSequenceGetINTEL</strong>, and
 <strong>OpTaskSequenceReleaseINTEL</strong> instructions take a task sequence object as an
 argument. The <strong>OpTaskSequenceAsyncINTEL</strong> instruction creates a invocation which
-will be referred to as a 'task thread' in this document. This task thread is
+will be referred to as a <em>task thread</em> in this document. This task thread is
 said to belong to the task sequence specified to the <strong>OpTaskSequenceAsyncINTEL</strong>
 instruction. The <strong>OpTaskSequenceGetINTEL</strong> instruction returns the result of a
 task thread in the specified task sequence. Results are returned from the task
@@ -587,7 +193,7 @@ cannot synchronize with the caller or with other task threads using a barrier.</
 <table>
 <tr>
 <td class="icon">
-<div class="title">Note</div>
+<i class="fa icon-note" title="Note"></i>
 </td>
 <td class="content">
 Calling <strong>OpTaskSequenceAsyncINTEL</strong> is analogous to enqueuing an OpenCL
@@ -1217,11 +823,6 @@ opaque type <code>spirv.TaskSequenceINTEL</code> and mangled as
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2024-03-21 07:44:24 -0700
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_unstructured_loop_controls.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_unstructured_loop_controls.asciidoc
@@ -102,7 +102,7 @@ Modify Section 3.31, Capability, adding a row to the Capability table:
 In section 3.32.17, Control-Flow Instructions, add a new instruction, *OpLoopControlINTEL*, as follows:
 [cols="4", width="100%"]
 |=====
-3+^|*OpLoopControlINTEL* +
+3+|*OpLoopControlINTEL* +
 
 Declare a loop.
 

--- a/extensions/INTEL/SPV_INTEL_unstructured_loop_controls.html
+++ b/extensions/INTEL/SPV_INTEL_unstructured_loop_controls.html
@@ -2,437 +2,48 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 1.5.7">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_unstructured_loop_controls</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
-/* Uncomment @import statement below to use as custom stylesheet */
-/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
-article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
-audio,canvas,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-script{display:none!important}
-html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
-a{background:transparent}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-abbr[title]{border-bottom:1px dotted}
-b,strong{font-weight:bold}
-dfn{font-style:italic}
-hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:none}
-p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #ddddd8;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
-abbr{text-transform:none}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
-blockquote cite::before{content:"\2014 \0020"}
-blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
-*:not(pre)>code.nobreak{word-wrap:normal}
-*:not(pre)>code.nowrap{white-space:nowrap}
-pre,pre>code{line-height:1.45;color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;text-rendering:optimizeSpeed}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #ddddd8}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #ddddd8;padding-bottom:8px}
-#header .details{border-bottom:1px solid #ddddd8;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #ddddd8;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #efefed;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background-color:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #efefed;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #efefed;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:100%;background-color:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #efefed}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p{font-size:inherit}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #ddddd8;color:rgba(0,0,0,.6)}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock pre:not(.highlight),.listingblock pre[class="highlight"],.listingblock pre[class^="highlight "],.listingblock pre.CodeRay,.listingblock pre.prettyprint{background:#f7f7f8}
-.sidebarblock .literalblock pre,.sidebarblock .listingblock pre:not(.highlight),.sidebarblock .listingblock pre[class="highlight"],.sidebarblock .listingblock pre[class^="highlight "],.sidebarblock .listingblock pre.CodeRay,.sidebarblock .listingblock pre.prettyprint{background:#f2f1f1}
-.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;padding:1em;font-size:.8125em}
-.literalblock pre.nowrap,.literalblock pre[class].nowrap,.listingblock pre.nowrap,.listingblock pre[class].nowrap{overflow-x:auto;white-space:pre;word-wrap:normal}
-@media screen and (min-width:768px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:1em}}
-.literalblock.output pre{color:#f7f7f8;background-color:rgba(0,0,0,.9)}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:#999}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:#999}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-table.pyhltable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.pyhltable td{vertical-align:top;padding-top:0;padding-bottom:0;line-height:1.45}
-table.pyhltable td.code{padding-left:.75em;padding-right:0}
-pre.pygments .lineno,table.pyhltable td:not(.code){color:#999;padding-left:0;padding-right:.5em;border-right:1px solid #ddddd8}
-pre.pygments .lineno{display:inline-block;margin-right:.25em}
-table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock blockquote p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.5em;margin-right:.5ex;text-align:right}
-.quoteblock .quoteblock{margin-left:0;margin-right:0;padding:.5em 0;border-left:3px solid rgba(0,0,0,.6)}
-.quoteblock .quoteblock blockquote{padding:0 0 0 .75em}
-.quoteblock .quoteblock blockquote::before{display:none}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.abstract blockquote,.quoteblock.abstract blockquote p{word-spacing:0;line-height:1.6}
-.quoteblock.abstract blockquote::before,.quoteblock.abstract p::before{display:none}
-table.tableblock{max-width:100%;border-collapse:separate}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content{margin-bottom:-1.25em}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
-table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
-table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
-table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
-table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
-table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
-table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
-table.frame-all{border-width:1px}
-table.frame-sides{border-width:0 1px}
-table.frame-topbot,table.frame-ends{border-width:1px 0}
-table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd){background:#f8f8f7}
-table.stripes-none tr,table.stripes-odd tr:nth-of-type(even){background:none}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-td>div.verse{white-space:pre}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-ul.checklist{margin-left:.625em}
-ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
-ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
-.imageblock.left,.imageblock[style*="float: left"]{margin:.25em .625em 1.25em 0}
-.imageblock.right,.imageblock[style*="float: right"]{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
-.gist .file-data>table td.line-data{width:99%}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background-color:#00fafa}
-.black{color:#000}
-.black-background{background-color:#000}
-.blue{color:#0000bf}
-.blue-background{background-color:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background-color:#fa00fa}
-.gray{color:#606060}
-.gray-background{background-color:#7d7d7d}
-.green{color:#006000}
-.green-background{background-color:#007d00}
-.lime{color:#00bf00}
-.lime-background{background-color:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background-color:#7d0000}
-.navy{color:#000060}
-.navy-background{background-color:#00007d}
-.olive{color:#606000}
-.olive-background{background-color:#7d7d00}
-.purple{color:#600060}
-.purple-background{background-color:#7d007d}
-.red{color:#bf0000}
-.red-background{background-color:#fa0000}
-.silver{color:#909090}
-.silver-background{background-color:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background-color:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background-color:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background-color:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background-color:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background-color:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #ddddd8!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_unstructured_loop_controls</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New Capabilities</a></li>
+<li><a href="#_new_instructions">New Instructions</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_4">Modifications to the SPIR-V Specification, Version 1.4</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
 <div class="sect1">
@@ -502,7 +113,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2019-06-12</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-21</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -652,7 +263,7 @@ Version 1.4 Revision 1.</p>
 </colgroup>
 <tbody>
 <tr>
-<td class="tableblock halign-center valign-top" colspan="3"><p class="tableblock"><strong>OpLoopControlINTEL</strong><br></p>
+<td class="tableblock halign-left valign-top" colspan="3"><p class="tableblock"><strong>OpLoopControlINTEL</strong><br></p>
 <p class="tableblock">Declare a loop.</p>
 <p class="tableblock">This instruction must be in a block that is the target of a back edge and that block must dominate the back-edge block from which that edge originated.</p>
 <p class="tableblock">This instruction must immediately precede either an <strong>OpBranch</strong> or <strong>OpBranchConditional</strong> instruction.  That is, it must be the second-to-last instruction in its block.</p>
@@ -708,11 +319,6 @@ Loop Control Parameters</p></td>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2019-06-12 15:27:32 EDT
 </div>
 </div>
 </body>

--- a/extensions/INTEL/SPV_INTEL_usm_storage_classes.html
+++ b/extensions/INTEL/SPV_INTEL_usm_storage_classes.html
@@ -4,494 +4,98 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.17">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_INTEL_usm_storage_classes</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
-/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
-/* Uncomment the following line when using as a custom stylesheet */
-/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
-html{font-family:sans-serif;-webkit-text-size-adjust:100%}
-a{background:none}
-a:focus{outline:thin dotted}
-a:active,a:hover{outline:0}
-h1{font-size:2em;margin:.67em 0}
-b,strong{font-weight:bold}
-abbr{font-size:.9em}
-abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
-dfn{font-style:italic}
-hr{height:0}
-mark{background:#ff0;color:#000}
-code,kbd,pre,samp{font-family:monospace;font-size:1em}
-pre{white-space:pre-wrap}
-q{quotes:"\201C" "\201D" "\2018" "\2019"}
-small{font-size:80%}
-sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
-sup{top:-.5em}
-sub{bottom:-.25em}
-img{border:0}
-svg:not(:root){overflow:hidden}
-figure{margin:0}
-audio,video{display:inline-block}
-audio:not([controls]){display:none;height:0}
-fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
-legend{border:0;padding:0}
-button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
-button,input{line-height:normal}
-button,select{text-transform:none}
-button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
-button[disabled],html input[disabled]{cursor:default}
-input[type=checkbox],input[type=radio]{padding:0}
-button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
-textarea{overflow:auto;vertical-align:top}
-table{border-collapse:collapse;border-spacing:0}
-*,::before,::after{box-sizing:border-box}
-html,body{font-size:100%}
-body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
-a:hover{cursor:pointer}
-img,object,embed{max-width:100%;height:auto}
-object,embed{height:100%}
-img{-ms-interpolation-mode:bicubic}
-.left{float:left!important}
-.right{float:right!important}
-.text-left{text-align:left!important}
-.text-right{text-align:right!important}
-.text-center{text-align:center!important}
-.text-justify{text-align:justify!important}
-.hide{display:none}
-img,object,svg{display:inline-block;vertical-align:middle}
-textarea{height:auto;min-height:50px}
-select{width:100%}
-.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
-div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
-a{color:#2156a5;text-decoration:underline;line-height:inherit}
-a:hover,a:focus{color:#1d4b8f}
-a img{border:0}
-p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
-p aside{font-size:.875em;line-height:1.35;font-style:italic}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
-h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
-h1{font-size:2.125em}
-h2{font-size:1.6875em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
-h4,h5{font-size:1.125em}
-h6{font-size:1em}
-hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
-em,i{font-style:italic;line-height:inherit}
-strong,b{font-weight:bold;line-height:inherit}
-small{font-size:60%;line-height:inherit}
-code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
-ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
-ul,ol{margin-left:1.5em}
-ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
-ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
-ul.square{list-style-type:square}
-ul.circle{list-style-type:circle}
-ul.disc{list-style-type:disc}
-ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
-dl dt{margin-bottom:.3125em;font-weight:bold}
-dl dd{margin-bottom:1.25em}
-blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
-blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
-@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
-h1{font-size:2.75em}
-h2{font-size:2.3125em}
-h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
-h4{font-size:1.4375em}}
-table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
-table thead,table tfoot{background:#f7f8f7}
-table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
-table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
-table tr.even,table tr.alt{background:#f8f8f7}
-table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
-h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
-h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
-.center{margin-left:auto;margin-right:auto}
-.stretch{width:100%}
-.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
-.clearfix::after,.float-group::after{clear:both}
-:not(pre).nobreak{word-wrap:normal}
-:not(pre).nowrap{white-space:nowrap}
-:not(pre).pre-wrap{white-space:pre-wrap}
-:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
-pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
-pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
-pre>code{display:block}
-pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
-em em{font-style:normal}
-strong strong{font-weight:400}
-.keyseq{color:rgba(51,51,51,.8)}
-kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
-.keyseq kbd:first-child{margin-left:0}
-.keyseq kbd:last-child{margin-right:0}
-.menuseq,.menuref{color:#000}
-.menuseq b:not(.caret),.menuref{font-weight:inherit}
-.menuseq{word-spacing:-.02em}
-.menuseq b.caret{font-size:1.25em;line-height:.8}
-.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
-b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
-b.button::before{content:"[";padding:0 3px 0 2px}
-b.button::after{content:"]";padding:0 2px 0 3px}
-p a>code:hover{color:rgba(0,0,0,.9)}
-#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
-#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
-#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
-#content{margin-top:1.25em}
-#content::before{content:none}
-#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
-#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
-#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
-#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
-#header .details span:first-child{margin-left:-.125em}
-#header .details span.email a{color:rgba(0,0,0,.85)}
-#header .details br{display:none}
-#header .details br+span::before{content:"\00a0\2013\00a0"}
-#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
-#header .details br+span#revremark::before{content:"\00a0|\00a0"}
-#header #revnumber{text-transform:capitalize}
-#header #revnumber::after{content:"\00a0"}
-#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
-#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
-#toc>ul{margin-left:.125em}
-#toc ul.sectlevel0>li>a{font-style:italic}
-#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
-#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
-#toc li{line-height:1.3334;margin-top:.3334em}
-#toc a{text-decoration:none}
-#toc a:active{text-decoration:underline}
-#toctitle{color:#7a2518;font-size:1.2em}
-@media screen and (min-width:768px){#toctitle{font-size:1.375em}
-body.toc2{padding-left:15em;padding-right:0}
-#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
-#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
-#toc.toc2>ul{font-size:.9em;margin-bottom:0}
-#toc.toc2 ul ul{margin-left:0;padding-left:1em}
-#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
-body.toc2.toc-right{padding-left:0;padding-right:15em}
-body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
-@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
-#toc.toc2{width:20em}
-#toc.toc2 #toctitle{font-size:1.375em}
-#toc.toc2>ul{font-size:.95em}
-#toc.toc2 ul ul{padding-left:1.25em}
-body.toc2.toc-right{padding-left:0;padding-right:20em}}
-#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
-#content #toc>:first-child{margin-top:0}
-#content #toc>:last-child{margin-bottom:0}
-#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
-#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
-#content{margin-bottom:.625em}
-.sect1{padding-bottom:.625em}
-@media screen and (min-width:768px){#content{margin-bottom:1.25em}
-.sect1{padding-bottom:1.25em}}
-.sect1:last-child{padding-bottom:0}
-.sect1+.sect1{border-top:1px solid #e7e7e9}
-#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
-#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
-#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
-#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
-#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
-details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
-details{margin-left:1.25rem}
-details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
-details>summary::-webkit-details-marker{display:none}
-details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
-details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
-details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
-.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
-table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
-.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
-.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
-.admonitionblock>table td.icon{text-align:center;width:80px}
-.admonitionblock>table td.icon img{max-width:none}
-.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
-.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
-.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
-.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
-.exampleblock>.content>:first-child{margin-top:0}
-.exampleblock>.content>:last-child{margin-bottom:0}
-.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
-.sidebarblock>:first-child{margin-top:0}
-.sidebarblock>:last-child{margin-bottom:0}
-.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
-.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
-.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
-@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
-@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
-.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
-.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
-.listingblock>.content{position:relative}
-.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
-.listingblock:hover code[data-lang]::before{display:block}
-.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
-.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
-.listingblock pre.highlightjs{padding:0}
-.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
-.listingblock pre.prettyprint{border-width:0}
-.prettyprint{background:#f7f7f8}
-pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
-pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
-pre.prettyprint li code[data-lang]::before{opacity:1}
-pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
-table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
-table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
-table.linenotable td.code{padding-left:.75em}
-table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
-pre.pygments span.linenos{display:inline-block;margin-right:.75em}
-.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
-.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
-.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
-.quoteblock blockquote{margin:0;padding:0;border:0}
-.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
-.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
-.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
-.verseblock{margin:0 1em 1.25em}
-.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
-.verseblock pre strong{font-weight:400}
-.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
-.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
-.quoteblock .attribution br,.verseblock .attribution br{display:none}
-.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
-.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
-.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
-.quoteblock.abstract{margin:0 1em 1.25em;display:block}
-.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
-.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
-.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
-.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
-.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
-p.tableblock:last-child{margin-bottom:0}
-td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
-td.tableblock>.content>:last-child{margin-bottom:-1.25em}
-table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
-table.grid-all>*>tr>*{border-width:1px}
-table.grid-cols>*>tr>*{border-width:0 1px}
-table.grid-rows>*>tr>*{border-width:1px 0}
-table.frame-all{border-width:1px}
-table.frame-ends{border-width:1px 0}
-table.frame-sides{border-width:0 1px}
-table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
-table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
-table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
-table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
-table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
-th.halign-left,td.halign-left{text-align:left}
-th.halign-right,td.halign-right{text-align:right}
-th.halign-center,td.halign-center{text-align:center}
-th.valign-top,td.valign-top{vertical-align:top}
-th.valign-bottom,td.valign-bottom{vertical-align:bottom}
-th.valign-middle,td.valign-middle{vertical-align:middle}
-table thead th,table tfoot th{font-weight:bold}
-tbody tr th{background:#f7f8f7}
-tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
-p.tableblock>code:only-child{background:none;padding:0}
-p.tableblock{font-size:1em}
-ol{margin-left:1.75em}
-ul li ol{margin-left:1.5em}
-dl dd{margin-left:1.125em}
-dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
-li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
-ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
-ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
-ul.unstyled,ol.unstyled{margin-left:0}
-li>p:empty:only-child::before{content:"";display:inline-block}
-ul.checklist>li>p:first-child{margin-left:-1em}
-ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
-ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
-ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
-ul.inline>li{margin-left:1.25em}
-.unstyled dl dt{font-weight:400;font-style:normal}
-ol.arabic{list-style-type:decimal}
-ol.decimal{list-style-type:decimal-leading-zero}
-ol.loweralpha{list-style-type:lower-alpha}
-ol.upperalpha{list-style-type:upper-alpha}
-ol.lowerroman{list-style-type:lower-roman}
-ol.upperroman{list-style-type:upper-roman}
-ol.lowergreek{list-style-type:lower-greek}
-.hdlist>table,.colist>table{border:0;background:none}
-.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
-td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
-td.hdlist1{font-weight:bold;padding-bottom:1.25em}
-td.hdlist2{word-wrap:anywhere}
-.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
-.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
-.colist td:not([class]):first-child img{max-width:none}
-.colist td:not([class]):last-child{padding:.25em 0}
-.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
-.imageblock.left{margin:.25em .625em 1.25em 0}
-.imageblock.right{margin:.25em 0 1.25em .625em}
-.imageblock>.title{margin-bottom:0}
-.imageblock.thumb,.imageblock.th{border-width:6px}
-.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
-.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
-.image.left{margin-right:.625em}
-.image.right{margin-left:.625em}
-a.image{text-decoration:none;display:inline-block}
-a.image object{pointer-events:none}
-sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
-sup.footnote a,sup.footnoteref a{text-decoration:none}
-sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
-#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
-#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
-#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
-#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
-#footnotes .footnote:last-of-type{margin-bottom:0}
-#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
-div.unbreakable{page-break-inside:avoid}
-.big{font-size:larger}
-.small{font-size:smaller}
-.underline{text-decoration:underline}
-.overline{text-decoration:overline}
-.line-through{text-decoration:line-through}
-.aqua{color:#00bfbf}
-.aqua-background{background:#00fafa}
-.black{color:#000}
-.black-background{background:#000}
-.blue{color:#0000bf}
-.blue-background{background:#0000fa}
-.fuchsia{color:#bf00bf}
-.fuchsia-background{background:#fa00fa}
-.gray{color:#606060}
-.gray-background{background:#7d7d7d}
-.green{color:#006000}
-.green-background{background:#007d00}
-.lime{color:#00bf00}
-.lime-background{background:#00fa00}
-.maroon{color:#600000}
-.maroon-background{background:#7d0000}
-.navy{color:#000060}
-.navy-background{background:#00007d}
-.olive{color:#606000}
-.olive-background{background:#7d7d00}
-.purple{color:#600060}
-.purple-background{background:#7d007d}
-.red{color:#bf0000}
-.red-background{background:#fa0000}
-.silver{color:#909090}
-.silver-background{background:#bcbcbc}
-.teal{color:#006060}
-.teal-background{background:#007d7d}
-.white{color:#bfbfbf}
-.white-background{background:#fafafa}
-.yellow{color:#bfbf00}
-.yellow-background{background:#fafa00}
-span.icon>.fa{cursor:default}
-a span.icon>.fa{cursor:inherit}
-.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
-.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
-.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
-.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
-.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
-.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
-.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
-.conum[data-value] *{color:#fff!important}
-.conum[data-value]+b{display:none}
-.conum[data-value]::after{content:attr(data-value)}
-pre .conum[data-value]{position:relative;top:-.125em}
-b.conum *{color:inherit!important}
-.conum:not([data-value]):empty{display:none}
-dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
-h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
-p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
-p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
-p{margin-bottom:1.25rem}
-.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
-.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
-.print-only{display:none!important}
-@page{margin:1.25cm .75cm}
-@media print{*{box-shadow:none!important;text-shadow:none!important}
-html{font-size:80%}
-a{color:inherit!important;text-decoration:underline!important}
-a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
-a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
-abbr[title]{border-bottom:1px dotted}
-abbr[title]::after{content:" (" attr(title) ")"}
-pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
-thead{display:table-header-group}
-svg{max-width:100%}
-p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
-h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
-#header,#content,#footnotes,#footer{max-width:none}
-#toc,.sidebarblock,.exampleblock>.content{background:none!important}
-#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
-body.book #header{text-align:center}
-body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
-body.book #header .details{border:0!important;display:block;padding:0!important}
-body.book #header .details span:first-child{margin-left:0!important}
-body.book #header .details br{display:block}
-body.book #header .details br+span::before{content:none!important}
-body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
-body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
-.listingblock code[data-lang]::before{display:block}
-#footer{padding:0 .9375em}
-.hide-on-print{display:none!important}
-.print-only{display:block!important}
-.hide-for-print{display:none!important}
-.show-for-print{display:inherit!important}}
-@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
-.sect1{padding:0!important}
-.sect1+.sect1{border:0}
-#footer{background:none}
-#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
-@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
+@import "https://cdn.jsdelivr.net/gh/asciidoctor/asciidoctor@2.0/data/stylesheets/asciidoctor-default.css";
+
+p {
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: normal;
+}
+em, b, strong {
+    color: darkblue;
+}
+
 </style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 </head>
-<body class="article data-line-1">
+<body class="article toc2 toc-left">
 <div id="header">
 <h1>SPV_INTEL_usm_storage_classes</h1>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_name_strings">Name Strings</a></li>
+<li><a href="#_contact">Contact</a></li>
+<li><a href="#_contributors">Contributors</a></li>
+<li><a href="#_notice">Notice</a></li>
+<li><a href="#_status">Status</a></li>
+<li><a href="#_version">Version</a></li>
+<li><a href="#_dependencies">Dependencies</a></li>
+<li><a href="#_overview">Overview</a></li>
+<li><a href="#_extension_name">Extension Name</a></li>
+<li><a href="#_new_capabilities">New capabilities</a></li>
+<li><a href="#_token_number_assignments">Token Number Assignments</a></li>
+<li><a href="#_modifications_to_the_spir_v_specification_version_1_6_revision_2">Modifications to the SPIR-V Specification, Version 1.6 Revision 2</a></li>
+<li><a href="#_issues">Issues</a></li>
+<li><a href="#_revision_history">Revision History</a></li>
+</ul>
+</div>
 </div>
 <div id="content">
-<div class="sect1 data-line-4">
+<div class="sect1">
 <h2 id="_name_strings">Name Strings</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-6">
+<div class="paragraph">
 <p>SPV_INTEL_usm_storage_classes</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-8">
+<div class="sect1">
 <h2 id="_contact">Contact</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-10">
+<div class="paragraph">
 <p>To report problems with this extension, please open a new issue at:</p>
 </div>
-<div class="paragraph data-line-12">
-<p><a href="https://github.com/KhronosGroup/SPIRV-Headers" class="undefined" data-href="https://github.com/KhronosGroup/SPIRV-Headers">https://github.com/KhronosGroup/SPIRV-Headers</a></p>
+<div class="paragraph">
+<p><a href="https://github.com/KhronosGroup/SPIRV-Headers" class="bare">https://github.com/KhronosGroup/SPIRV-Headers</a></p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-14">
+<div class="sect1">
 <h2 id="_contributors">Contributors</h2>
 <div class="sectionbody">
-<div class="ulist data-line-16">
+<div class="ulist">
 <ul>
-<li class="data-line-16">
+<li>
 <p>Joe Garvey, Intel</p>
 </li>
 </ul>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-18">
+<div class="sect1">
 <h2 id="_notice">Notice</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-20">
+<div class="paragraph">
 <p>Copyright (c) 2022 Intel Corporation.  All rights reserved.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-22">
+<div class="sect1">
 <h2 id="_status">Status</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-24">
+<div class="paragraph">
 <p>Final Draft</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-26">
+<div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all data-line-29" style="width: 40%;">
+<table class="tableblock frame-all grid-all" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -509,58 +113,58 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </table>
 </div>
 </div>
-<div class="sect1 data-line-34">
+<div class="sect1">
 <h2 id="_dependencies">Dependencies</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-36">
+<div class="paragraph">
 <p>This extension is written against the SPIR-V Specification,
 Version 1.6 Revision 2.</p>
 </div>
-<div class="paragraph data-line-39">
+<div class="paragraph">
 <p>This extension requires SPIR-V 1.0.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-41">
+<div class="sect1">
 <h2 id="_overview">Overview</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-43">
+<div class="paragraph">
 <p>This extension introduces two new storage classes that are sub classes of the CrossWorkgroup storage class.
 Using these more specific storage classes provides additional information that can enable optimization.
 The extension also introduces two new conversion instructions to enable converting pointers from and to these storage classes.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-47">
+<div class="sect1">
 <h2 id="_extension_name">Extension Name</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-48">
+<div class="paragraph">
 <p>To use this extension within a SPIR-V module, the following <strong>OpExtension</strong> must be present in the module:</p>
 </div>
-<div class="listingblock data-line-50">
+<div class="listingblock">
 <div class="content">
 <pre>OpExtension "SPV_INTEL_usm_storage_classes"</pre>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-54">
+<div class="sect1">
 <h2 id="_new_capabilities">New capabilities</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-55">
+<div class="paragraph">
 <p>This extension introduces a new capability:</p>
 </div>
-<div class="listingblock data-line-57">
+<div class="listingblock">
 <div class="content">
 <pre>USMStorageClassesINTEL</pre>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-61">
+<div class="sect1">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows data-line-66" style="width: 40%;">
+<table class="tableblock frame-all grid-rows" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -590,17 +194,17 @@ The extension also introduces two new conversion instructions to enable converti
 </table>
 </div>
 </div>
-<div class="sect1 data-line-74">
+<div class="sect1">
 <h2 id="_modifications_to_the_spir_v_specification_version_1_6_revision_2">Modifications to the SPIR-V Specification, Version 1.6 Revision 2</h2>
 <div class="sectionbody">
-<div class="sect2 data-line-76">
+<div class="sect2">
 <h3 id="_storage_class">Storage Class</h3>
-<div class="paragraph data-line-78">
+<div class="paragraph">
 <p>Modify Section 3.7, Storage Class, adding these rows to the table:</p>
 </div>
-<div class="openblock data-line-80">
+<div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch data-line-82">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -630,14 +234,14 @@ A subset of the <strong>CrossWorkgroup</strong> storage class.  Memory that is r
 </div>
 </div>
 </div>
-<div class="sect2 data-line-91">
+<div class="sect2">
 <h3 id="_capability">Capability</h3>
-<div class="paragraph data-line-93">
+<div class="paragraph">
 <p>Modify Section 3.31, Capability, adding a row to the Capability table:</p>
 </div>
-<div class="openblock data-line-94">
+<div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch data-line-96">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -660,18 +264,18 @@ A subset of the <strong>CrossWorkgroup</strong> storage class.  Memory that is r
 </div>
 </div>
 </div>
-<div class="sect2 data-line-102">
+<div class="sect2">
 <h3 id="_instructions">Instructions</h3>
-<div class="paragraph data-line-104">
+<div class="paragraph">
 <p>Modify Section 3.36.11, Conversion Instructions, adding two new instructions as follows:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch data-line-106">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
+<col style="width: 9.0909%;">
+<col style="width: 9.0909%;">
+<col style="width: 27.2727%;">
+<col style="width: 27.2727%;">
+<col style="width: 27.2728%;">
 </colgroup>
 <tbody>
 <tr>
@@ -694,13 +298,13 @@ Pointer</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch data-line-122">
+<table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
+<col style="width: 9.0909%;">
+<col style="width: 9.0909%;">
+<col style="width: 27.2727%;">
+<col style="width: 27.2727%;">
+<col style="width: 27.2728%;">
 </colgroup>
 <tbody>
 <tr>
@@ -724,26 +328,26 @@ Pointer</p></td>
 </tbody>
 </table>
 </div>
-<div class="sect2 data-line-138">
+<div class="sect2">
 <h3 id="_validation_rules">Validation Rules</h3>
-<div class="paragraph data-line-140">
+<div class="paragraph">
 <p>None.</p>
 </div>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-142">
+<div class="sect1">
 <h2 id="_issues">Issues</h2>
 <div class="sectionbody">
-<div class="paragraph data-line-144">
+<div class="paragraph">
 <p>None.</p>
 </div>
 </div>
 </div>
-<div class="sect1 data-line-152">
+<div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch data-line-157">
+<table class="tableblock frame-all grid-rows stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">
@@ -768,11 +372,6 @@ Pointer</p></td>
 </tbody>
 </table>
 </div>
-</div>
-</div>
-<div id="footer">
-<div id="footer-text">
-Last updated 2023-01-04 12:01:18 -0800
 </div>
 </div>
 </body>


### PR DESCRIPTION
Fixes minor errors in the asciidoc source for the Intel SPIR-V extensions.

I haven't re-generated HTML files with these fixes to keep the diff manageable, but I did verify that all of the extensions build cleanly with the latest spec toolchain now (via `make docker-all`).