### PR TITLE
update the extension HTML toolchain to enable table striping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ ASCIIDOC_HTML_OPTIONS = --trace --failure-level ERROR \
   -a nofooter \
   -a stylesdir=$(SPIRV_DIR)/resources \
   -a stylesheet=spirv.css \
+  -a table-stripes=even \
   -a toc2 \
   -a toclevels=1
 


### PR DESCRIPTION
Fixes #277 

Enables table striping via the extension Makefile. This improves consistency with the main SPIR-V spec and improves readability for long tables.