### PR TITLE
Allow DebugTypePointer BaseType argument substitution by DebugInfoNone

### DIFF
--- a/nonsemantic/NonSemantic.Shader.DebugInfo.100.asciidoc
+++ b/nonsemantic/NonSemantic.Shader.DebugInfo.100.asciidoc
@@ -614,7 +614,8 @@ Describe a pointer or reference data type. +
 {result_type}  +
  +
 'Base Type' is the '<id>' of a debugging instruction that represents the pointee
- type. +
+ type. If the 'Base Type' is not defined or not available in source program,
+ this operand must refer to <<DebugInfoNone,*DebugInfoNone*>>. + 
  +
 'Storage Class' is a 32-bit integer *OpConstant* containing the class of the memory where
  the object pointed to is allocated.  Possible values of this operand are described in the

--- a/nonsemantic/NonSemantic.Shader.DebugInfo.100.html
+++ b/nonsemantic/NonSemantic.Shader.DebugInfo.100.html
@@ -1309,7 +1309,8 @@ Describe a pointer or reference data type.<br>
 <em>Result Type</em> must be <strong>OpTypeVoid</strong>. <br>
 <br>
 <em>Base Type</em> is the <em>&lt;id&gt;</em> of a debugging instruction that represents the pointee
- type.<br>
+type. If the the <em>Base Type</em> is not specified or not available in source program, this operand must refer to
+ <a href="#DebugInfoNone"><strong>DebugInfoNone</strong></a>.<br>
 <br>
 <em>Storage Class</em> is a 32-bit integer <strong>OpConstant</strong> containing the class of the memory where
  the object pointed to is allocated.  Possible values of this operand are described in the


### PR DESCRIPTION
This update addresses the DebugTypePointer instruction, which represents pointer types in the SPIR-V NonSemantic.Shader.DebugInfo.100 standard. Currently, the instruction requires a defined Base Type argument to comply with the standard. This requirement complicates the implementation of pointers to abstract types, such as void * in C, which represents type erasure, since these types do not have an available or defined Base Type.

To accommodate such scenarios, the standard includes the DebugInfoNone instruction. This amendment allows for the substitution of the concrete Base Type argument in DebugTypePointer with DebugInfoNone, thereby simplifying the implementation process for abstract pointer types.