### PR TITLE
Fix NonSemantic Shader DebugInfo parent name

### DIFF
--- a/nonsemantic/NonSemantic.Shader.DebugInfo.100.asciidoc
+++ b/nonsemantic/NonSemantic.Shader.DebugInfo.100.asciidoc
@@ -34,6 +34,7 @@ Contributors to original *OpenCL.DebugInfo.100* specification.
  - Neil Henning, Codeplay
  - Kerch Holt, Nvidia
  - Jaebaek Seo, Google
+ - Spencer Fricke, LunarG
 
 Notice
 ------
@@ -54,8 +55,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2024-08-07
-| Revision           | 10
+| Last Modified Date | 2024-10-08
+| Revision           | 11
 |========================================
 
 Dependencies
@@ -95,7 +96,7 @@ This is a non-normative list of changes to the OpenCL.DebugInfo.100 specificatio
   instructions).
 * Forward references in any instruction are disallowed.
 * As the result of the above:
-  - <<DebugTypeMember,*DebugTypeMember*>> no longer has a parent `Scope <id>`, this is
+  - <<DebugTypeMember,*DebugTypeMember*>> no longer has a parent `Parent <id>`, this is
     implicit from which <<DebugTypeComposite,*DebugTypeComposite*>> lists it as a member.
   - <<DebugTypeInheritance,*DebugTypeInheritance*>> has no `Child <id>`. This is also
     implicit based on which <<DebugTypeComposite,*DebugTypeComposite*>> lists it as a
@@ -754,7 +755,7 @@ Describe a C/C++ 'typedef declaration'. +
 'Column' is the '<id>' of a 32-bit integer *OpConstant* denoting the column number at
  which the first character of the declaration appears. +
  +
-'Scope' is the '<id>' of a debug instruction that represents the
+'Parent' is the '<id>' of a debug instruction that represents the
  <<LexicalScope,lexical scope>> that contains the typedef declaration. +
 
 | 11 | 12 | '<id>' +
@@ -764,7 +765,7 @@ Describe a C/C++ 'typedef declaration'. +
 | '<id> Source'
 | '<id> Line'
 | '<id> Column'
-| '<id> Scope'
+| '<id> Parent'
 |======
 
 
@@ -817,7 +818,7 @@ Describe an enumeration type. +
 'Column' is the '<id>' of a 32-bit integer *OpConstant* denoting the column number at
  which the first character of the enumeration declaration appears. +
  +
-'Scope' is the '<id>' of a debug instruction that represents the
+'Parent' is the '<id>' of a debug instruction that represents the
  <<LexicalScope,lexical scope>> that contains the enumeration type. +
  +
 'Size' is an *OpConstant* with 32-bit or 64-bit integer type and its value is
@@ -836,7 +837,7 @@ type. 'Name' must be the '<id>' of an *OpString* instruction. +
 | '<id> Source'
 | '<id> Line'
 | '<id> Column'
-| '<id> Scope'
+| '<id> Parent'
 | '<id>' 'Size'
 | '<id>' 'Flags'
 | '<id>' 'Value', +
@@ -869,7 +870,7 @@ Describe a 'structure', 'class', or 'union' data type. The 'Result <id>' of this
 'Column' is the '<id>' of a 32-bit integer *OpConstant* denoting the column number at
  which the first character of the type declaration appears. +
  +
-'Scope' is the '<id>' of a debug instruction that represents the
+'Parent' is the '<id>' of a debug instruction that represents the
  <<LexicalScope,lexical scope>> that contains the composite type. It must be
  one of the following: <<DebugCompilationUnit,*DebugCompilationUnit*>>,
  <<DebugFunction,*DebugFunction*>>,
@@ -907,7 +908,7 @@ Describe a 'structure', 'class', or 'union' data type. The 'Result <id>' of this
 | '<id> Source'
 | '<id> Line'
 | '<id> Column'
-| '<id> Scope'
+| '<id> Parent'
 | '<id> Linkage Name'
 | '<id> Size'
 | '<id> Flags'
@@ -1164,7 +1165,7 @@ Global Variables
 'Column' is the '<id>' of a 32-bit integer *OpConstant* denoting the column number at
  which the first character of the source global variable declaration appears. +
  +
-'Scope' is the '<id>' of a debug instruction that represents the
+'Parent' is the '<id>' of a debug instruction that represents the
  <<LexicalScope,lexical scope>> that contains the source global variable
  declaration. It must be one of the following:
  <<DebugCompilationUnit,*DebugCompilationUnit*>>,
@@ -1195,7 +1196,7 @@ If the source global variable represents a defining declaration
 | '<id> Source'
 | '<id> Line'
 | '<id> Column'
-| '<id> Scope'
+| '<id> Parent'
 | '<id> Linkage Name'
 | '<id> Variable'
 | '<id>' <<DebugFlags,'Flags'>> +
@@ -1227,7 +1228,7 @@ Describe a function or method declaration. +
 'Column' is the '<id>' of a 32-bit integer *OpConstant* denoting the column number at
  which the first character of the function declaration appears. +
  +
-'Scope' is the '<id>' of a debug instruction that represents the
+'Parent' is the '<id>' of a debug instruction that represents the
  <<LexicalScope,lexical scope>> that contains the function declaration. +
  +
 'Linkage Name' is an *OpString*, holding the linkage name of the function. +
@@ -1242,7 +1243,7 @@ Describe a function or method declaration. +
 | '<id> Source'
 | '<id> Line'
 | '<id> Column'
-| '<id> Scope'
+| '<id> Parent'
 | '<id> Linkage Name'
 | '<id>' <<DebugFlags,'Flags'>> +
 |======
@@ -1271,7 +1272,7 @@ Describe a function or method definition. The 'Result <id>' of this instruction
 'Column' is the '<id>' of a 32-bit integer *OpConstant* denoting the column number at
  which the first character of the function declaration appears. +
  +
-'Scope' is the '<id>' of a debug instruction that represents the
+'Parent' is the '<id>' of a debug instruction that represents the
  <<LexicalScope,lexical scope>> that contains the function definition. +
  +
 'Linkage Name' is an *OpString*, holding the linkage name of the function. +
@@ -1291,7 +1292,7 @@ Describe a function or method definition. The 'Result <id>' of this instruction
 | '<id> Source'
 | '<id> Line'
 | '<id> Column'
-| '<id> Scope'
+| '<id> Parent'
 | '<id> Linkage Name'
 | '<id>' <<DebugFlags,'Flags'>> +
 | '<id> Scope Line'
@@ -1342,9 +1343,9 @@ Describe a lexical block in the source program. The 'Result <id>' of this
 'Column' is the '<id>' of a 32-bit integer *OpConstant* denoting the column number at
  which the lexical block begins. +
  +
-'Scope' is the '<id>' of a debug instruction that represents the
+'Parent' is the '<id>' of a debug instruction that represents the
  <<LexicalScope,lexical scope>> containing the lexical block. Entities
- in the global lexical scope should have 'Scope' referring to a
+ in the global lexical scope should have 'Parent' referring to a
  <<DebugCompilationUnit,*DebugCompilationUnit*>>. +
  +
  The presence of the 'Name' operand indicates that this instruction represents a
@@ -1356,7 +1357,7 @@ Describe a lexical block in the source program. The 'Result <id>' of this
 | '<id>' 'Source'
 | '<id> Line'
 | '<id> Column'
-| '<id>' 'Scope'
+| '<id>' 'Parent'
 | Optional '<id>' 'Name'
 |======
 
@@ -1371,7 +1372,7 @@ Distinguish lexical blocks on a single line in the source program. +
  +
 {source} containing the lexical block. +
  +
-'Scope' is the '<id>' of a debug instruction that represents the
+'Parent' is the '<id>' of a debug instruction that represents the
  <<LexicalScope,lexical scope>> containing the lexical block. +
  +
 'Discriminator' is the '<id>' of a 32-bit integer *OpConstant* denoting a DWARF
@@ -1381,7 +1382,7 @@ Distinguish lexical blocks on a single line in the source program. +
 'Result Type' | 'Result <id>' | '<id> Set'| 22
 | '<id>' 'Source'
 | '<id>' 'Discriminator'
-| '<id>' 'Scope'
+| '<id>' 'Parent'
 |======
 
 
@@ -1539,7 +1540,7 @@ Local Variables
 'Column' is the '<id>' of a 32-bit integer *OpConstant* denoting the column number at
  which the first character of the <<LocalVariable,local variable>> declaration appears. +
  +
-'Scope' is the '<id>' of a debug instruction that represents the
+'Parent' is the '<id>' of a debug instruction that represents the
  <<LexicalScope,lexical scope>> that contains the the
  <<LocalVariable,local variable>> declaration. +
  +
@@ -1555,7 +1556,7 @@ If 'ArgNumber' operand is present, this instruction represents a function formal
 | '<id> Source'
 | '<id> Line'
 | '<id> Column'
-| '<id> Scope'
+| '<id> Parent'
 | '<id> Flags'
 | Optional +
   '<id> ArgNumber'
@@ -1764,7 +1765,7 @@ Imported Entities
  'Column' is the '<id>' of a 32-bit integer *OpConstant* denoting the column number at
  which the first character of the 'using' declaration appears. +
  +
- 'Scope' is the '<id>' of a debug instruction that represents the
+ 'Parent' is the '<id>' of a debug instruction that represents the
  <<LexicalScope,lexical scope>> that contains the namespace or declaration. +
 
 | 12 | 12 | '<id>' +
@@ -1775,7 +1776,7 @@ Imported Entities
 | '<id> Entity'
 | '<id> Line'
 | '<id> Column'
-| '<id> Scope'
+| '<id> Parent'
 |======
 
 
@@ -1843,5 +1844,6 @@ Revision History
                                              *DebugFunction*, not an *OpEntryPoint*.
 |1.00 Rev 10 |2024-08-07|Victor Lomüller    |Fix that in *DebugLine* the 'Column end' operand
                                              can be equal to 'Column start' operand.
+|1.00 Rev 11 |2024-10-08|Spencer Fricke     |Fix using 'Scope' instead of 'Parent' operand name.
 |========================================================
 

--- a/nonsemantic/NonSemantic.Shader.DebugInfo.100.html
+++ b/nonsemantic/NonSemantic.Shader.DebugInfo.100.html
@@ -109,6 +109,9 @@ em, b, strong {
 <li>
 <p>Jaebaek Seo, Google</p>
 </li>
+<li>
+<p>Spencer Fricke, LunarG</p>
+</li>
 </ul>
 </div>
 </div>
@@ -152,11 +155,11 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-07</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-10-08</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">10</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">11</p></td>
 </tr>
 </tbody>
 </table>
@@ -228,7 +231,7 @@ instructions).</p>
 <div class="ulist">
 <ul>
 <li>
-<p><a href="#DebugTypeMember"><strong>DebugTypeMember</strong></a> no longer has a parent <code>Scope &lt;id&gt;</code>, this is
+<p><a href="#DebugTypeMember"><strong>DebugTypeMember</strong></a> no longer has a parent <code>Parent &lt;id&gt;</code>, this is
 implicit from which <a href="#DebugTypeComposite"><strong>DebugTypeComposite</strong></a> lists it as a member.</p>
 </li>
 <li>
@@ -1539,7 +1542,7 @@ Describe a C/C++ <em>typedef declaration</em>.<br>
 <em>Column</em> is the <em>&lt;id&gt;</em> of a 32-bit integer <strong>OpConstant</strong> denoting the column number at
  which the first character of the declaration appears.<br>
 <br>
-<em>Scope</em> is the <em>&lt;id&gt;</em> of a debug instruction that represents the
+<em>Parent</em> is the <em>&lt;id&gt;</em> of a debug instruction that represents the
  <a href="#LexicalScope">lexical scope</a> that contains the typedef declaration.<br></p></td>
 </tr>
 <tr>
@@ -1555,7 +1558,7 @@ Describe a C/C++ <em>typedef declaration</em>.<br>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Source</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Line</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Column</em></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Scope</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Parent</em></p></td>
 </tr>
 </tbody>
 </table>
@@ -1644,7 +1647,7 @@ Describe an enumeration type.<br>
 <em>Column</em> is the <em>&lt;id&gt;</em> of a 32-bit integer <strong>OpConstant</strong> denoting the column number at
  which the first character of the enumeration declaration appears.<br>
 <br>
-<em>Scope</em> is the <em>&lt;id&gt;</em> of a debug instruction that represents the
+<em>Parent</em> is the <em>&lt;id&gt;</em> of a debug instruction that represents the
  <a href="#LexicalScope">lexical scope</a> that contains the enumeration type.<br>
 <br>
 <em>Size</em> is an <strong>OpConstant</strong> with 32-bit or 64-bit integer type and its value is
@@ -1669,7 +1672,7 @@ type. <em>Name</em> must be the <em>&lt;id&gt;</em> of an <strong>OpString</stro
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Source</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Line</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Column</em></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Scope</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Parent</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Size</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Flags</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Value</em>,<br>
@@ -1721,7 +1724,7 @@ Describe a <em>structure</em>, <em>class</em>, or <em>union</em> data type. The 
 <em>Column</em> is the <em>&lt;id&gt;</em> of a 32-bit integer <strong>OpConstant</strong> denoting the column number at
  which the first character of the type declaration appears.<br>
 <br>
-<em>Scope</em> is the <em>&lt;id&gt;</em> of a debug instruction that represents the
+<em>Parent</em> is the <em>&lt;id&gt;</em> of a debug instruction that represents the
  <a href="#LexicalScope">lexical scope</a> that contains the composite type. It must be
  one of the following: <a href="#DebugCompilationUnit"><strong>DebugCompilationUnit</strong></a>,
  <a href="#DebugFunction"><strong>DebugFunction</strong></a>,
@@ -1765,7 +1768,7 @@ Describe a <em>structure</em>, <em>class</em>, or <em>union</em> data type. The 
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Source</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Line</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Column</em></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Scope</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Parent</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Linkage Name</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Size</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Flags</em></p></td>
@@ -2180,7 +2183,7 @@ Describe the expanded template parameter pack in a variadic template instantiati
 <em>Column</em> is the <em>&lt;id&gt;</em> of a 32-bit integer <strong>OpConstant</strong> denoting the column number at
  which the first character of the source global variable declaration appears.<br>
 <br>
-<em>Scope</em> is the <em>&lt;id&gt;</em> of a debug instruction that represents the
+<em>Parent</em> is the <em>&lt;id&gt;</em> of a debug instruction that represents the
  <a href="#LexicalScope">lexical scope</a> that contains the source global variable
  declaration. It must be one of the following:
  <a href="#DebugCompilationUnit"><strong>DebugCompilationUnit</strong></a>,
@@ -2217,7 +2220,7 @@ If the source global variable represents a defining declaration
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Source</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Line</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Column</em></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Scope</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Parent</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Linkage Name</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Variable</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <a href="#DebugFlags"><em>Flags</em></a><br></p></td>
@@ -2267,7 +2270,7 @@ Describe a function or method declaration.<br>
 <em>Column</em> is the <em>&lt;id&gt;</em> of a 32-bit integer <strong>OpConstant</strong> denoting the column number at
  which the first character of the function declaration appears.<br>
 <br>
-<em>Scope</em> is the <em>&lt;id&gt;</em> of a debug instruction that represents the
+<em>Parent</em> is the <em>&lt;id&gt;</em> of a debug instruction that represents the
  <a href="#LexicalScope">lexical scope</a> that contains the function declaration.<br>
 <br>
 <em>Linkage Name</em> is an <strong>OpString</strong>, holding the linkage name of the function.<br>
@@ -2288,7 +2291,7 @@ Describe a function or method declaration.<br>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Source</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Line</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Column</em></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Scope</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Parent</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Linkage Name</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <a href="#DebugFlags"><em>Flags</em></a><br></p></td>
 </tr>
@@ -2336,7 +2339,7 @@ Describe a function or method definition. The <em>Result &lt;id&gt;</em> of this
 <em>Column</em> is the <em>&lt;id&gt;</em> of a 32-bit integer <strong>OpConstant</strong> denoting the column number at
  which the first character of the function declaration appears.<br>
 <br>
-<em>Scope</em> is the <em>&lt;id&gt;</em> of a debug instruction that represents the
+<em>Parent</em> is the <em>&lt;id&gt;</em> of a debug instruction that represents the
  <a href="#LexicalScope">lexical scope</a> that contains the function definition.<br>
 <br>
 <em>Linkage Name</em> is an <strong>OpString</strong>, holding the linkage name of the function.<br>
@@ -2362,7 +2365,7 @@ Describe a function or method definition. The <em>Result &lt;id&gt;</em> of this
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Source</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Line</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Column</em></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Scope</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Parent</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Linkage Name</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <a href="#DebugFlags"><em>Flags</em></a><br></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Scope Line</em></p></td>
@@ -2444,7 +2447,7 @@ Describe a lexical block in the source program. The <em>Result &lt;id&gt;</em> o
 <em>Column</em> is the <em>&lt;id&gt;</em> of a 32-bit integer <strong>OpConstant</strong> denoting the column number at
  which the lexical block begins.<br>
 <br>
-<em>Scope</em> is the <em>&lt;id&gt;</em> of a debug instruction that represents the
+<em>Parent</em> is the <em>&lt;id&gt;</em> of a debug instruction that represents the
  <a href="#LexicalScope">lexical scope</a> containing the lexical block. Entities
  in the global lexical scope should have <em>Scope</em> referring to a
  <a href="#DebugCompilationUnit"><strong>DebugCompilationUnit</strong></a>.<br>
@@ -2464,7 +2467,7 @@ Describe a lexical block in the source program. The <em>Result &lt;id&gt;</em> o
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Source</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Line</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Column</em></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Scope</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Parent</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Optional <em>&lt;id&gt;</em> <em>Name</em></p></td>
 </tr>
 </tbody>
@@ -2491,7 +2494,7 @@ Distinguish lexical blocks on a single line in the source program.<br>
 <br>
 <em>Source</em> is a <strong>DebugSource</strong> instruction representing the text of the source program containing the lexical block.<br>
 <br>
-<em>Scope</em> is the <em>&lt;id&gt;</em> of a debug instruction that represents the
+<em>Parent</em> is the <em>&lt;id&gt;</em> of a debug instruction that represents the
  <a href="#LexicalScope">lexical scope</a> containing the lexical block.<br>
 <br>
 <em>Discriminator</em> is the <em>&lt;id&gt;</em> of a 32-bit integer <strong>OpConstant</strong> denoting a DWARF
@@ -2507,7 +2510,7 @@ Distinguish lexical blocks on a single line in the source program.<br>
 <td class="tableblock halign-left valign-top"><p class="tableblock">22</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Source</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Discriminator</em></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Scope</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt;</em> <em>Parent</em></p></td>
 </tr>
 </tbody>
 </table>
@@ -2767,7 +2770,7 @@ Discontinue any source-level line and column information specified by any previo
 <em>Column</em> is the <em>&lt;id&gt;</em> of a 32-bit integer <strong>OpConstant</strong> denoting the column number at
  which the first character of the <a href="#LocalVariable">local variable</a> declaration appears.<br>
 <br>
-<em>Scope</em> is the <em>&lt;id&gt;</em> of a debug instruction that represents the
+<em>Parent</em> is the <em>&lt;id&gt;</em> of a debug instruction that represents the
  <a href="#LexicalScope">lexical scope</a> that contains the the
  <a href="#LocalVariable">local variable</a> declaration.<br>
 <br>
@@ -2789,7 +2792,7 @@ If <em>ArgNumber</em> operand is present, this instruction represents a function
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Source</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Line</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Column</em></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Scope</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Parent</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Flags</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Optional<br>
   <em>&lt;id&gt; ArgNumber</em></p></td>
@@ -3141,7 +3144,7 @@ Represent a DWARF operation that operates on a stack of values.<br>
  <em>Column</em> is the <em>&lt;id&gt;</em> of a 32-bit integer <strong>OpConstant</strong> denoting the column number at
  which the first character of the <em>using</em> declaration appears.<br>
 <br>
- <em>Scope</em> is the <em>&lt;id&gt;</em> of a debug instruction that represents the
+ <em>Parent</em> is the <em>&lt;id&gt;</em> of a debug instruction that represents the
  <a href="#LexicalScope">lexical scope</a> that contains the namespace or declaration.<br></p></td>
 </tr>
 <tr>
@@ -3158,7 +3161,7 @@ Represent a DWARF operation that operates on a stack of values.<br>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Entity</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Line</em></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Column</em></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Scope</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><em>&lt;id&gt; Parent</em></p></td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
The `NonSemantic.Shader.DebugInfo.100` keeps referencing a `Scope <Id>` but the [grammar](https://github.com/KhronosGroup/SPIRV-Headers/blob/main/include/spirv/unified1/extinst.nonsemantic.shader.debuginfo.100.grammar.json) only has `Scope <Id>` at `DebugScope` and `DebugInlinedAt` ... the rest use `Parent <Id>`

This was very confusing for tooling when `"Scope"` was not matching with the auto-generated grammar file

 (this is also wrong in `OpenCL.DebugInfo.100` which I assume where the mistake was copied from)