### PR TITLE
Add publishing to pages

### DIFF
--- a/.github/workflows/html-build.yml
+++ b/.github/workflows/html-build.yml
@@ -1,7 +1,10 @@
 name: Rebuild all with asciidoctor
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
+  pages: write
+  id-token: write
 
 on:
   push:
@@ -12,6 +15,11 @@ on:
       - '**/*.md'
     branches:
       - main
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
   # Build job
@@ -28,9 +36,23 @@ jobs:
         run: |
           find . -name "*.asciidoc" -exec touch {} \;
           make all
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4
-        if: always()
+          find . -type d -exec mkdir -p ../_site/{} \;
+          find . -name "*.html" -exec cp {} ../_site/{}  \;
+          find ../_site -type d -empty -delete
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: HTML
-          path: ${{github.workspace}}/**/*.html
+          path: ../_site
+
+  # Deployment job
+  deploy:
+    if: ${{ github.event_name == 'push'}}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This extends the html generation job to also publish the results to pages.

To make this site more usable we should probably add some indices and landing pages, but the page renderings seem to work. You can find them on my local fork by direct URL like:

https://llvm-beanz.github.io/SPIRV-Registry/extensions/AMD/SPV_AMD_gcn_shader.html