### PR TITLE
Set actual date rather than using {docdate} and unify version format

### DIFF
--- a/extensions/EXT/SPV_EXT_relaxed_printf_string_address_space.asciidoc
+++ b/extensions/EXT/SPV_EXT_relaxed_printf_string_address_space.asciidoc
@@ -32,7 +32,7 @@ Draft
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2022-06-13
 | Revision           | 3
 |========================================
 

--- a/extensions/EXT/SPV_EXT_relaxed_printf_string_address_space.html
+++ b/extensions/EXT/SPV_EXT_relaxed_printf_string_address_space.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="generator" content="Asciidoctor 2.0.17">
+<meta name="generator" content="Asciidoctor 2.0.23">
 <title>SPV_EXT_relaxed_printf_string_address_space</title>
 <style>
 @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";
@@ -100,7 +100,7 @@ Anastasia Stulova, Arm</p>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2022-08-25</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2022-06-13</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>

--- a/extensions/HUAWEI/SPV_HUAWEI_cluster_culling_shader.asciidoc
+++ b/extensions/HUAWEI/SPV_HUAWEI_cluster_culling_shader.asciidoc
@@ -21,7 +21,8 @@ Complete.
 == Version
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2023-12-04
+| Revision           | 2
 |========================================
 
 Dependencies
@@ -114,7 +115,7 @@ None.
 |========================================================
 |Rev|Date|Author|Changes
 |1|2022-11-16|Yu-Chang Wang|*Initial Public Release*
-|2|{docdate}|Yu-Chang Wang|*add cluster shading rate*
+|2|2023-12-04|Yu-Chang Wang|*add cluster shading rate*
 |========================================================
 
 

--- a/extensions/HUAWEI/SPV_HUAWEI_cluster_culling_shader.html
+++ b/extensions/HUAWEI/SPV_HUAWEI_cluster_culling_shader.html
@@ -96,7 +96,11 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-10-13</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-12-04</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2</p></td>
 </tr>
 </tbody>
 </table>
@@ -313,7 +317,7 @@ ClusterCulingShadingHUAWEI</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-center valign-top"><p class="tableblock">2</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-10-13</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-12-04</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Yu-Chang Wang</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>add cluster shading rate</strong></p></td>
 </tr>

--- a/extensions/INTEL/SPV_INTEL_arbitrary_precision_fixed_point.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_arbitrary_precision_fixed_point.asciidoc
@@ -29,7 +29,7 @@ Final draft
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2023-03-21
 | Revision           | 1
 |========================================
 
@@ -483,5 +483,5 @@ None.
 [cols="^,<,<,<",options="header",]
 |========================================================
 |Rev|Date|Author|Changes
-|1|{docdate}|Ajaykumar Kannan|*Initial Public Release*
+|1|2023-03-21|Ajaykumar Kannan|*Initial Public Release*
 |========================================================

--- a/extensions/INTEL/SPV_INTEL_arbitrary_precision_fixed_point.html
+++ b/extensions/INTEL/SPV_INTEL_arbitrary_precision_fixed_point.html
@@ -102,7 +102,7 @@ em, b, strong {
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -110,7 +110,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-09</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-03-21</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -235,7 +235,7 @@ OpFixedExpINTEL</pre>
 <div class="sect1">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<table class="tableblock frame-all grid-rows stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -301,7 +301,7 @@ OpFixedExpINTEL</pre>
 </div>
 <div class="sect2">
 <h3 id="_quantization_modes">Quantization Modes</h3>
-<table class="tableblock frame-all grid-all" style="width: 80%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 80%;">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 20%;">
@@ -373,7 +373,7 @@ OpFixedExpINTEL</pre>
 </div>
 <div class="sect2">
 <h3 id="_overflow_modes">Overflow Modes</h3>
-<table class="tableblock frame-all grid-all" style="width: 80%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 80%;">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 20%;">
@@ -422,7 +422,7 @@ OpFixedExpINTEL</pre>
 </div>
 <div class="sect2">
 <h3 id="_signedness_modes">Signedness Modes</h3>
-<table class="tableblock frame-all grid-all" style="width: 80%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 80%;">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 20%;">
@@ -458,7 +458,7 @@ OpFixedExpINTEL</pre>
 <div class="paragraph">
 <p>Modify Section 3.31, <strong>Capability</strong>, adding a row to the Capability table:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -485,7 +485,7 @@ OpFixedExpINTEL</pre>
 <div class="paragraph">
 <p>In Section 3.32.13, <strong>Arithmetic Instructions</strong>, add the following instructions:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -527,7 +527,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -568,7 +568,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -610,7 +610,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -651,7 +651,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -692,7 +692,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -732,7 +732,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -773,7 +773,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -814,7 +814,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -854,7 +854,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -895,7 +895,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -956,7 +956,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -974,7 +974,7 @@ The behavior of this function is undefined for input values &lt; 0.</p>
 <tbody>
 <tr>
 <td class="tableblock halign-center valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-09</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-03-21</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Ajaykumar Kannan</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Initial Public Release</strong></p></td>
 </tr>

--- a/extensions/INTEL/SPV_INTEL_arbitrary_precision_floating_point.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_arbitrary_precision_floating_point.asciidoc
@@ -29,7 +29,7 @@ Supported
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2023-03-29
 | Revision           | 1
 |========================================
 
@@ -1239,5 +1239,5 @@ None.
 [cols="^,<,<,<",options="header",]
 |===================================================================
 |Rev|Date|Author|Changes
-|1|{docdate}|Ajaykumar Kannan|*Initial Public Release*
+|1|2023-03-29|Ajaykumar Kannan|*Initial Public Release*
 |===================================================================

--- a/extensions/INTEL/SPV_INTEL_arbitrary_precision_floating_point.html
+++ b/extensions/INTEL/SPV_INTEL_arbitrary_precision_floating_point.html
@@ -102,7 +102,7 @@ em, b, strong {
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -110,7 +110,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-27</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-03-29</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -256,7 +256,7 @@ OpArbitraryFloatConvertToSIntINTEL</pre>
 <div class="sect1">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<table class="tableblock frame-all grid-rows stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -453,7 +453,7 @@ OpArbitraryFloatConvertToSIntINTEL</pre>
 <div class="paragraph">
 <p>Control whether subnormal support is enabled or not.</p>
 </div>
-<table class="tableblock frame-all grid-all" style="width: 60%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 60%;">
 <colgroup>
 <col style="width: 15%;">
 <col style="width: 85%;">
@@ -484,7 +484,7 @@ OpArbitraryFloatConvertToSIntINTEL</pre>
 <div class="paragraph">
 <p>Controls whether rounding operations can be relaxed to trade correctness for improved resource utilization.</p>
 </div>
-<table class="tableblock frame-all grid-all" style="width: 80%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 80%;">
 <colgroup>
 <col style="width: 15%;">
 <col style="width: 20%;">
@@ -518,7 +518,7 @@ The returned result is one of the two floating point values closest to the mathe
 <div class="paragraph">
 <p>Modify Section 3.31, <strong>Capability</strong>, adding a row to the Capability table:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -545,7 +545,7 @@ The returned result is one of the two floating point values closest to the mathe
 <div class="paragraph">
 <p>In Section 3.32.13, <strong>Arithmetic Instructions</strong>, add the following instructions:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 8.3333%;">
 <col style="width: 8.3333%;">
@@ -590,7 +590,7 @@ Note that the exponent values (Ea, Eb, Eresult) are inferred from the width of t
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 8.3333%;">
 <col style="width: 8.3333%;">
@@ -635,7 +635,7 @@ Note that the exponent values (Ea, Eb, Eresult) are inferred from the width of t
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 8.3333%;">
 <col style="width: 8.3333%;">
@@ -680,7 +680,7 @@ Note that the exponent values (Ea, Eb, Eresult) are inferred from the width of t
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 8.3333%;">
 <col style="width: 8.3333%;">
@@ -725,7 +725,7 @@ Note that the exponent values (Ea, Eb, Eresult) are inferred from the width of t
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -761,7 +761,7 @@ Note that the exponent values (Ea, Eb) are inferred from the width of the <stron
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -797,7 +797,7 @@ Note that the exponent values (Ea, Eb) are inferred from the width of the <stron
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -833,7 +833,7 @@ Note that the exponent values (Ea, Eb) are inferred from the width of the <stron
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -869,7 +869,7 @@ Note that the exponent values (Ea, Eb) are inferred from the width of the <stron
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -905,7 +905,7 @@ Note that the exponent values (Ea, Eb) are inferred from the width of the <stron
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -946,7 +946,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -987,7 +987,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1028,7 +1028,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 8.3333%;">
 <col style="width: 8.3333%;">
@@ -1073,7 +1073,7 @@ Note that the exponent values (Ea, Eb, Eresult) are inferred from the width of t
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1114,7 +1114,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1155,7 +1155,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1196,7 +1196,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1237,7 +1237,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1278,7 +1278,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1319,7 +1319,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1360,7 +1360,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1401,7 +1401,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1442,7 +1442,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1483,7 +1483,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1524,7 +1524,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1564,7 +1564,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1605,7 +1605,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1646,7 +1646,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1686,7 +1686,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1727,7 +1727,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1768,7 +1768,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1809,7 +1809,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1850,7 +1850,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1891,7 +1891,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -1932,7 +1932,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 8.3333%;">
 <col style="width: 8.3333%;">
@@ -1977,7 +1977,7 @@ Note that the exponent values (Ea, Eb, Eresult) are inferred from the width of t
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 8.3333%;">
 <col style="width: 8.3333%;">
@@ -2022,7 +2022,7 @@ Note that the exponent values (Ea, Eb, Eresult) are inferred from the width of t
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 8.3333%;">
 <col style="width: 8.3333%;">
@@ -2068,7 +2068,7 @@ Note that the exponent values (Ea, Eb, Eresult) are inferred from the width of t
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 8.3333%;">
 <col style="width: 8.3333%;">
@@ -2115,7 +2115,7 @@ Note that the exponent values (Ea, Eresult) are inferred from the width of the <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 11.1111%;">
 <col style="width: 11.1111%;">
@@ -2153,7 +2153,7 @@ It is type converted into an arbitrary precision floating point number with the 
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -2186,7 +2186,7 @@ It is type converted into an arbitrary precision floating point number with the 
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -2219,7 +2219,7 @@ It is type converted into an arbitrary precision floating point number with the 
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -2252,7 +2252,7 @@ It is type converted into an unsigned integer and returned as <em>Result</em>.</
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -2309,7 +2309,7 @@ It is type converted into a signed integer and returned as <em>Result</em>.</p>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -2327,7 +2327,7 @@ It is type converted into a signed integer and returned as <em>Result</em>.</p>
 <tbody>
 <tr>
 <td class="tableblock halign-center valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-27</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-03-29</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Ajaykumar Kannan</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Initial Public Release</strong></p></td>
 </tr>

--- a/extensions/INTEL/SPV_INTEL_arbitrary_precision_integers.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_arbitrary_precision_integers.asciidoc
@@ -27,7 +27,7 @@ Final draft
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2020-03-27
 | Revision           | 1
 |========================================
 

--- a/extensions/INTEL/SPV_INTEL_arbitrary_precision_integers.html
+++ b/extensions/INTEL/SPV_INTEL_arbitrary_precision_integers.html
@@ -94,7 +94,7 @@ em, b, strong {
 </div>
 <div class="sect2">
 <h3 id="_version">Version</h3>
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -102,7 +102,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2023-02-02</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2020-03-27</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -159,7 +159,7 @@ Ints of arbitrary bit widths can be beneficial on targets that can exploit narro
 <div class="sect1">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<table class="tableblock frame-all grid-rows stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -181,7 +181,7 @@ Ints of arbitrary bit widths can be beneficial on targets that can exploit narro
 <div class="paragraph">
 <p>Modify Section 3.31, <strong>Capability</strong>, adding a row to the Capability table:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -223,7 +223,7 @@ The minimum requirement is that all bitwidths up to 32-bits must be supported, b
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">

--- a/extensions/INTEL/SPV_INTEL_bfloat16_conversion.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_bfloat16_conversion.asciidoc
@@ -40,7 +40,7 @@ Copyright (c) 2023 Intel Corporation.  All rights reserved.
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2023-03-06
 | Revision           | 1
 |========================================
 

--- a/extensions/INTEL/SPV_INTEL_bfloat16_conversion.html
+++ b/extensions/INTEL/SPV_INTEL_bfloat16_conversion.html
@@ -106,7 +106,7 @@ em, b, strong {
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -114,7 +114,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-21</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-03-06</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -179,7 +179,7 @@ be present in the module:</p>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -207,7 +207,7 @@ be present in the module:</p>
 <div class="paragraph">
 <p>Add to Section 3.42.11, Conversion Instructions:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 9.0909%;">
 <col style="width: 9.0909%;">
@@ -245,7 +245,7 @@ Results are computed per component.<br></p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 9.0909%;">
 <col style="width: 9.0909%;">
@@ -297,7 +297,7 @@ Results are computed per component.<br></p></td>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stripes-even stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">

--- a/extensions/INTEL/SPV_INTEL_blocking_pipes.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_blocking_pipes.asciidoc
@@ -28,7 +28,7 @@ Final draft
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2019-07-17
 | Revision           | 1
 |========================================
 

--- a/extensions/INTEL/SPV_INTEL_blocking_pipes.html
+++ b/extensions/INTEL/SPV_INTEL_blocking_pipes.html
@@ -99,7 +99,7 @@ em, b, strong {
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -107,7 +107,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-21</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2019-07-17</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -182,7 +182,7 @@ OpWritePipeBlockingINTEL</pre>
 <div class="sectionbody">
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<table class="tableblock frame-all grid-rows stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -216,7 +216,7 @@ OpWritePipeBlockingINTEL</pre>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -244,7 +244,7 @@ OpWritePipeBlockingINTEL</pre>
 <div class="paragraph">
 <p>In section 3.32.23, Pipe Instructions, add two new instructions: <strong>OpReadPipeBlockingINTEL</strong> and <strong>OpWritePipeBlockingINTEL</strong>, as follows:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -282,7 +282,7 @@ OpWritePipeBlockingINTEL</pre>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -334,7 +334,7 @@ OpWritePipeBlockingINTEL</pre>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stripes-even stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">

--- a/extensions/INTEL/SPV_INTEL_device_side_avc_motion_estimation.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_device_side_avc_motion_estimation.asciidoc
@@ -31,7 +31,7 @@ Copyright (c) 2018 Intel Corporation.  All rights reserved.
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2018-10-29
 | Revision           | 1
 |========================================
 

--- a/extensions/INTEL/SPV_INTEL_device_side_avc_motion_estimation.html
+++ b/extensions/INTEL/SPV_INTEL_device_side_avc_motion_estimation.html
@@ -117,7 +117,7 @@ em, b, strong {
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -125,7 +125,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-21</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2018-10-29</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -387,7 +387,7 @@ OpTypeAvcSicResultINTEL</pre>
 <div class="sect1">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<table class="tableblock frame-all grid-rows stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -1030,7 +1030,7 @@ The configuration of a search window which is a combination of the search path a
 <div class="paragraph">
 <p>The predefined search window configurations are:</p>
 </div>
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 75%;">
@@ -1113,7 +1113,7 @@ An 8x8 or 4x4 integer transform used to transform the residual to the frequency 
 <div class="paragraph">
 <p>Modify Section 3.31, Capability, adding rows to the Capability table:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -1212,7 +1212,7 @@ An 8x8 or 4x4 integer transform used to transform the residual to the frequency 
 <div class="paragraph">
 <p>Modify Section <strong>3.32.6</strong>, <strong>Type Declaration Instructions</strong>, amending the description of OpTypeSampler as follows:</p>
 </div>
-<table id="bookmark-OpTypeSampler" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpTypeSampler" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 100%;">
 </colgroup>
@@ -1223,7 +1223,7 @@ An 8x8 or 4x4 integer transform used to transform the residual to the frequency 
 <br>
 Declare the sampler type. Consumed by OpSampledImage or <span class="blue"><a href="#bookmark-OpVmeImageINTEL">OpVmeImageINTEL</a></span>. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -1243,7 +1243,7 @@ Declare the sampler type. Consumed by OpSampledImage or <span class="blue"><a hr
 <div class="paragraph">
 <p>Modify Section <strong>3.32.6</strong>, <strong>Type Declaration Instructions</strong>, adding the description of OpTypeSampledImage as follows:</p>
 </div>
-<table id="bookmark-OpTypeVmeImageINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpTypeVmeImageINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 100%;">
 </colgroup>
@@ -1257,7 +1257,7 @@ Declare a VME image type, the <em>Result Type</em> of <span class="blue"><a href
 <div class="paragraph">
 <p>Image Type must be an OpTypeImage. It is the type of the image in the combined sampler and image type.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -1279,7 +1279,7 @@ Declare a VME image type, the <em>Result Type</em> of <span class="blue"><a href
 <div class="paragraph">
 <p>Modify Section <strong>3.32.6</strong>, <strong>Type Declaration Instructions</strong>, adding to the end of the list of type declarations:<br></p>
 </div>
-<table id="bookmark-OpTypeAvcMcePayloadINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpTypeAvcMcePayloadINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 100%;">
 </colgroup>
@@ -1290,7 +1290,7 @@ Declare a VME image type, the <em>Result Type</em> of <span class="blue"><a href
 <br>
 Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupMCEInstructions">AVC MCE Group Instruction</a></span>. Consumed by AVC MCE Group Instruction and represents the payload for a basic IME/REF/SIC operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -1307,7 +1307,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpTypeAvcImePayloadINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpTypeAvcImePayloadINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 100%;">
 </colgroup>
@@ -1318,7 +1318,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <br>
 Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupIMEInstructions">AVC IME Group Instruction</a></span>. Consumed by AVC MCE Group Instruction and represents the payload for a basic IME operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -1335,7 +1335,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpTypeAvcRefPayloadINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpTypeAvcRefPayloadINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 100%;">
 </colgroup>
@@ -1346,7 +1346,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <br>
 Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupREFInstructions">AVC REF Group Instruction</a></span>. Consumed by AVC REF Group Instruction and represents the payload for a basic REF operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -1363,7 +1363,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpTypeAvcSicPayloadINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpTypeAvcSicPayloadINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 100%;">
 </colgroup>
@@ -1374,7 +1374,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <br>
 Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupSICGroupInstructions">AVC SIC Group Instruction</a></span>. Consumed by AVC SIC Group Instruction and represents the payload for a basic SIC operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -1391,7 +1391,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpTypeAvcMceResultINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpTypeAvcMceResultINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 100%;">
 </colgroup>
@@ -1402,7 +1402,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <br>
 Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupMCEInstructions">AVC MCE Group Instruction</a></span>. Consumed by AVC MCE Group Instruction and represents the evluation results of a basic IME/REF/SIC operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -1419,7 +1419,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpTypeAvcImeResultINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpTypeAvcImeResultINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 100%;">
 </colgroup>
@@ -1430,7 +1430,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <br>
 Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupIMEInstructions">AVC IME Group Instruction</a></span>. Consumed by AVC IME Group Instruction and represents the evaluation of a basic IME operation not using the stream-in/streamout functionality. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -1447,7 +1447,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpTypeAvcImeResultSingleReferenceStreamoutINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 100%;">
 </colgroup>
@@ -1458,7 +1458,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <br>
 Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupIMEInstructions">AVC IME Group Instruction</a></span>. Consumed by AVC IME Group Instruction and represents the additional results from the result of an IME evaluation using the streamout functionality that may be streamed-in in a subsequent IME streamin call. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -1475,7 +1475,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpTypeAvcImeResultDualReferenceStreamoutINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 100%;">
 </colgroup>
@@ -1486,7 +1486,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <br>
 Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupIMEInstructions">AVC IME Group Instruction</a></span>. Consumed by AVC IME Group Instruction and represents the additional results from the result of an IME evaluation using the streamout functionality that may be streamed-in in a subsequent IME streamin call. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -1503,7 +1503,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpTypeAvcImeSingleReferenceStreaminINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpTypeAvcImeSingleReferenceStreaminINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 100%;">
 </colgroup>
@@ -1514,7 +1514,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <br>
 Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupIMEInstructions">AVC IME Group Instruction</a></span>. Consumed by AVC IME Group Instruction and represents the additional results from the result of an IME evaluation using the streamout functionality that may be streamed-in in a subsequent IME streamin call. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -1531,7 +1531,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpTypeAvcImeDualReferenceStreaminINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpTypeAvcImeDualReferenceStreaminINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 100%;">
 </colgroup>
@@ -1542,7 +1542,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <br>
 Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupIMEInstructions">AVC IME Group Instruction</a></span>. Consumed by AVC IME Group Instruction and represents the additional results from the result of an IME evaluation using the streamout functionality that may be streamed-in in a subsequent IME streamin call. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -1559,7 +1559,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpTypeAvcRefResultINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpTypeAvcRefResultINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 100%;">
 </colgroup>
@@ -1570,7 +1570,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <br>
 Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupREFInstructions">AVC REF Group Instruction</a></span>. Consumed by AVC REF Group Instruction and represents the evaluation of a basic REF operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -1587,7 +1587,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpTypeAvcSicResultINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpTypeAvcSicResultINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 100%;">
 </colgroup>
@@ -1598,7 +1598,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <br>
 Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"><a href="#bookmark-GroupSICGroupInstructions">AVC SIC Group Instruction</a></span>. Consumed by AVC SIC Group Instruction and represents the evaluation of a basic SIC operation. This type is opaque: values of this type have no defined physical size or bit pattern.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -1625,7 +1625,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>Interlaced image field polarity values:</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -1654,7 +1654,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>Inter macro-block major shape values:</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -1693,7 +1693,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>Inter macro-block minor shape values:</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -1732,7 +1732,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>Inter macro-block major direction values:</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -1766,7 +1766,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>Inter (IME) partition mask values:</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -1825,7 +1825,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>Slice type values:</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -1859,7 +1859,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>Search window configuration:</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -1918,7 +1918,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>SAD adjustment mode:</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -1948,7 +1948,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>Pixel resolution values:</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -1982,7 +1982,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>Cost precision values:</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -2021,7 +2021,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>Inter bidirectional weights:</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -2065,7 +2065,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>Inter border reached values</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -2104,7 +2104,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>Intra macro-block shape values</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -2138,7 +2138,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>Inter skip block partition type:</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -2167,7 +2167,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>Inter skip motion vector mask:</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -2256,7 +2256,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>Block based skip type values:</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -2285,7 +2285,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>Luma intra partition mask values:</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -2324,7 +2324,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>Intra neighbor availability mask values:</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -2363,7 +2363,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>Luma intra modes:</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -2432,7 +2432,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>Chroma intra modes:</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -2471,7 +2471,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p><strong>Reference image select values:</strong><br></p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 55%;">
@@ -2509,7 +2509,7 @@ Declare the <em>Operand</em> and/or <em>Result Type</em> of a <span class="blue"
 <div class="paragraph">
 <p>Modify Section <strong>3.32.7</strong>, <strong>Constant-Creation Instructions</strong>, amending the desciption of OpConstantNull as follow:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 100%;">
 </colgroup>
@@ -2582,7 +2582,7 @@ Declare a new null constant value.</p>
 </li>
 </ul>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -2604,7 +2604,7 @@ Declare a new null constant value.</p>
 <div class="paragraph">
 <p>Modify Section <strong>3.32.10</strong>, <strong>Image Instructions</strong>, amending the description of OpImage as follows:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 100%;">
 </colgroup>
@@ -2621,7 +2621,7 @@ Extract the image from a sampled or VME image.</p>
 <div class="paragraph">
 <p>Sampled Image must have type OpTypeSampledImage or <span class="blue"><a href="#bookmark-OpTypeVmeImageINTEL"><em>OpTypeVmeImageINTEL</em></a></span> whose Image Type is the same as Result Type.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 11.1111%;">
 <col style="width: 11.1111%;">
@@ -2645,7 +2645,7 @@ Extract the image from a sampled or VME image.</p>
 <div class="paragraph">
 <p>Modify Section <strong>3.32.10</strong>, <strong>Image Instructions</strong>, adding the description of OpVmeImageINTEL as follows:</p>
 </div>
-<table id="bookmark-OpVmeImageINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpVmeImageINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 100%;">
 </colgroup>
@@ -2665,7 +2665,7 @@ Create a VME image, containing both a (media) sampler and an image.</p>
 <div class="paragraph">
 <p>Sampler must be an object whose type is <span class="blue"><a href="#bookmark-OpTypeSampler"><em>OpTypeSampler</em></a></span>.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -2705,7 +2705,7 @@ Create a VME image, containing both a (media) sampler and an image.</p>
 <div class="paragraph">
 <p>These instructions enable multi-reference image costing. They allow for the configuration of the payloads to favorably bias the major partitions coming from reference images that are closer to the source image, than the ones coming from reference images that are further away. The distance of the reference images, in the timing order, from the source image is implied based on the order in which the reference images are declared in the kernel parameter operand list.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -2735,7 +2735,7 @@ Get the default base multi-reference cost penalty in U4U4 format when HW assiste
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -2755,7 +2755,7 @@ Set the multi-reference base penalty when HW assisted multi-reference search is 
 <p>Reference major partitions get associated with a penalty based on its distance from the source image. The <em>Reference Base Penalty</em> is scaled using a scaling factor based on the implied distance of the reference image from
 the source image as shown below.</p>
 </div>
-<table class="tableblock frame-all grid-all" style="width: 50%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 50%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -2809,7 +2809,7 @@ the source image as shown below.</p>
 <div class="paragraph">
 <p>These instructions enable shape costing for inter estimation. They allow for the configuration of payloads for the biasing of certain shapes over others based on the configured parameters.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -2839,7 +2839,7 @@ Get the default packed shape cost for inter estimation in U4U4 format.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -2861,7 +2861,7 @@ Set the shape penalty for inter motion estimation.</p>
 <div class="paragraph">
 <p><em>Packed Shape Penalty</em> must be 64-bit scalar integer type. It is treated as an unsigned value. The following bits specify the shape penalty in U4U4 format:</p>
 </div>
-<table class="tableblock frame-all grid-all" style="width: 55%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 55%;">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 75%;">
@@ -2914,7 +2914,7 @@ Set the shape penalty for inter motion estimation.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -2944,7 +2944,7 @@ Get the default direction penalty for inter estimation in U4U4 format.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -2981,7 +2981,7 @@ the decoded integer value must fit within 12 bits. It is treated as an unsigned 
 <div class="paragraph">
 <p>These instructions enable shape costing for intra estimation. They allow for the configuration of payloads for biasing of certain shapes over others based on the configured parameters. Only the instruction providing the default shape penalty is specified as an MCE instruction. The instruction which actually configures the payload for the intra estimation operation is specified as a SIC instruction.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -3017,7 +3017,7 @@ Get the default packed luma intra penalty estimation in U4U4 format.</p>
 <div class="paragraph">
 <p>These instructions enable motion vector costing for inter estimation. The distortion measure is augmented to favor motion vectors closer to the cost-center considered in conjunction with the primary objective of minimizing the SAD between the source and reference blocks.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -3047,7 +3047,7 @@ Get the default inter motion vector cost table for the pre-defined control point
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -3071,7 +3071,7 @@ Get the default predefined packed U4U4 format high cost table for high Qp. This 
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -3095,7 +3095,7 @@ Get the default predefined packed U4U4 format high cost table for medium Qp. Thi
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -3119,7 +3119,7 @@ Get the default predefined packed U4U4 format low cost table for high Qp. This m
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -3149,7 +3149,7 @@ Update the input payload to set the cost precision along with the cost center an
 <div class="paragraph">
 <p><em>Cost Precision</em> must be an OpTypeInt with 8-bit Width and 0 Signedness that must evaluate to a valid cost precision value as per <span class="blue"><a href="#bookmark-BF">Section 3, Binary Form</a></span>, and specifies the precision of the delta units from the cost center, dx. This effectively can be used to control the range of the cost function as follows:</p>
 </div>
-<table class="tableblock frame-all grid-all" style="width: 55%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 55%;">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 37.5%;">
@@ -3222,7 +3222,7 @@ Update the input payload to set the cost precision along with the cost center an
 <div class="paragraph">
 <p>These instructions enable mode costing for intra estimation. They allow for the configuration of payloads to bias the computed intra modes to be closer to their configured neighbor modes. This form of costing is similar to the inter motion vector costing. Only the instructions providing the defaults mode costs are specified as MCE instructions. The remaining instructions which actually configure the payload for the intra estimation operation is specified as SIC instruction.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -3252,7 +3252,7 @@ Get the default inter motion vector cost table for the pre-defined control point
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -3276,7 +3276,7 @@ Get the default intra non-dc cost penalty for intra luma estimation in packed 32
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -3306,7 +3306,7 @@ Get the default chroma mode base penalty in U4U4 format.</p>
 <div class="paragraph">
 <p>These instructions enable miscellaneous MCE properties settings.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -3333,7 +3333,7 @@ Update the input payload to enable an AC only HAAR SAD mode and return it. It ov
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -3363,7 +3363,7 @@ Update the input payload to specify the field polarities for interlaced source i
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -3393,7 +3393,7 @@ Update the input payload to specify the field polarities for interlaced referenc
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -3432,7 +3432,7 @@ Update the input payload to specify the field polarities for interlaced referenc
 <div class="paragraph">
 <p>These instructions facilitate the extraction of components of the result from VME unit.</p>
 </div>
-<table id="bookmark-OpSubgroupAvcMceGetMotionVectorsINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcMceGetMotionVectorsINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -3526,7 +3526,7 @@ overlapping with the bottom MBs.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -3555,7 +3555,7 @@ returned by <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterDirect
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -3582,7 +3582,7 @@ Get the best inter distortion for the whole MB.</p>
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpSubgroupAvcMceGetInterMajorShapeINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcMceGetInterMajorShapeINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -3611,7 +3611,7 @@ Get the MCE inter MB major partition shape.</p>
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpSubgroupAvcMceGetInterMinorShapeINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcMceGetInterMinorShapeINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -3641,7 +3641,7 @@ Get the MCE inter MB minor partition shapes.</p>
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpSubgroupAvcMceGetInterDirectionsINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcMceGetInterDirectionsINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -3702,7 +3702,7 @@ directions</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -3730,7 +3730,7 @@ Get the count of motion vectors (based on the partitioning decision) returned by
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpSubgroupAvcMceGetInterReferenceIdsINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcMceGetInterReferenceIdsINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -3745,7 +3745,7 @@ Get the count of motion vectors (based on the partitioning decision) returned by
 <br>
 Get the MCE inter MB reference identifiers in a packed integer format, with the following bits specifying the reference identifiers for the major partitions.</p>
 </div>
-<table class="tableblock frame-all grid-all" style="width: 55%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 55%;">
 <colgroup>
 <col style="width: 27.2727%;">
 <col style="width: 72.7273%;">
@@ -3832,7 +3832,7 @@ images).</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -3850,7 +3850,7 @@ images).</p>
 Get the MCE inter MB reference field polarities for the corresponding reference identifiers returned by <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetInterReferenceIdsINTEL">OpSubgroupAvcMceGetInterReferenceIdsINTEL</a></span> in a packed integer format, with the following bits specifying the reference field polarities
 for the major partitions.</p>
 </div>
-<table class="tableblock frame-all grid-all" style="width: 55%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 55%;">
 <colgroup>
 <col style="width: 27.2727%;">
 <col style="width: 72.7273%;">
@@ -3958,7 +3958,7 @@ operation.</p>
 <div class="paragraph">
 <p>These instructions create a properly initialized payload that can be used for further configured for evaluating IME operations. This is a required initial phase.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -4026,7 +4026,7 @@ Return an initialized payload for a VME integer search (IME) operation.</p>
 <div class="paragraph">
 <p>These instructions allow for configuration of the search window. A call to either <span class="blue"><a href="#bookmark-OpSubgroupAvcImeSetSingleReferenceINTEL">OpSubgroupAvcImeSetSingleReferenceINTEL</a></span> or <span class="blue"><a href="#bookmark-OpSubgroupAvcImeSetDualReferenceINTEL">OpSubgroupAvcImeSetDualReferenceINTEL</a></span> is required. This is a required phase immediately following the initialization phase.</p>
 </div>
-<table id="bookmark-OpSubgroupAvcImeSetSingleReferenceINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcImeSetSingleReferenceINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -4086,7 +4086,7 @@ specifying the <em>Ref Offset</em> value.</p>
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpSubgroupAvcImeSetDualReferenceINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcImeSetDualReferenceINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -4148,7 +4148,7 @@ reference window search regions, and return it.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -4178,7 +4178,7 @@ Get the 2D size of the reference window in pixel units.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -4266,7 +4266,7 @@ size of the progressive scan, or top or bottom fields, of the interlaced scan im
 <div class="paragraph">
 <p>These are optional instructions that may be called following the search configuration phase to convert IME payload to MCE payloads and vice-versa.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -4293,7 +4293,7 @@ Convert the IME payload to a generic MCE payload.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -4326,7 +4326,7 @@ Convert the generic MCE payload to a IME payload.</p>
 <div class="paragraph">
 <p>These are optional instructions that may be called following the search configuration phase to enable miscellaneous properties setting in the payload.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -4381,7 +4381,7 @@ will compute the best allowed partitioning such that the number of sub-block mot
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -4409,7 +4409,7 @@ Update the input payload to disable a mix of forward and backward MVs in the res
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -4441,7 +4441,7 @@ single-reference search, below which no more searching is performed for the MB.<
 </tr>
 </tbody>
 </table>
-<table id="bookmark-weightedsad" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-weightedsad" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -4517,7 +4517,7 @@ A B E F</pre>
 <div class="paragraph">
 <p>These instructions perform the evaluation of the IME operation configured in the payload with a VME media sampler and return the results.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -4550,7 +4550,7 @@ Evaluate the basic IME operation with a single reference and return its results.
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -4586,7 +4586,7 @@ Evaluate the basic IME operation with dual references and return its results. Th
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -4619,7 +4619,7 @@ Evaluate the single reference IME operation with streamout and return its result
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -4655,7 +4655,7 @@ Evaluate the basic IME operation with dual references with streamout and return 
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -4691,7 +4691,7 @@ Evaluate the single reference IME operation with streamin and return its results
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 11.1111%;">
 <col style="width: 11.1111%;">
@@ -4730,7 +4730,7 @@ Evaluate the dual reference IME operation with streamin and return its results. 
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -4766,7 +4766,7 @@ Evaluate the single reference IME operation with streamin/streamout and return i
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 11.1111%;">
 <col style="width: 11.1111%;">
@@ -4811,7 +4811,7 @@ Evaluate the dual reference IME operation with streamin/streamout and return its
 <div class="paragraph">
 <p>These are optional instructions that may be called following the evaluation phase to convert IME results to MCE results and vice-versa.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -4838,7 +4838,7 @@ Convert the IME result to a generic MCE result.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -4871,7 +4871,7 @@ Convert the generic MCE result to a IME result.</p>
 <div class="paragraph">
 <p>These instructions are called following the evaluation phase to extract the various result components from an IME evaluation result.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -4898,7 +4898,7 @@ Return the streamed out BMVs and distortions from the input result from a single
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -4925,7 +4925,7 @@ Return the streamed out BMVs and distortions from the input result from a dual r
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -4952,7 +4952,7 @@ Strip out the single reference streamout BMVs and distortions from the streamout
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -4979,7 +4979,7 @@ Strip out the dual reference streamout BMVs and distortions from the streamout r
 </tr>
 </tbody>
 </table>
-<table id="bookmark-singlerefmv" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-singlerefmv" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -5036,7 +5036,7 @@ streamout results.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -5086,7 +5086,7 @@ vectors for single reference streamout as described in <span class="blue"><a hre
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -5130,7 +5130,7 @@ vectors as described in <span class="blue"><a href="#bookmark-singlerefmv">OpSub
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -5179,7 +5179,7 @@ vectors for single reference streamout as described in <span class="blue"><a hre
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -5223,7 +5223,7 @@ vectors as described in <span class="blue"><a href="#bookmark-singlerefmv">OpSub
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -5271,7 +5271,7 @@ Get the reference identifiers for the input major shape from the IME dual refere
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -5315,7 +5315,7 @@ set as <span class="blue"><a href="#bookmark-forward">AVC_ME_FRAME_FORWARD_INTEL
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -5352,7 +5352,7 @@ vectors configured for the search operation.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -5387,7 +5387,7 @@ Get the indication that unidirectional search operation terminated early because
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -5438,7 +5438,7 @@ the traditional Z-order SAD weighting pattern.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -5486,7 +5486,7 @@ Get the minimum 16x16 distortion when applying the traditional Z-order SAD weigh
 <div class="paragraph">
 <p>These instructions create a properly initialized payload that can be used for further configured for evaluating REF operations. This is a required initial phase. A call to either <span class="blue"><a href="#bookmark-OpSubgroupAvcFmeInitializeINTEL">OpSubgroupAvcFmeInitializeINTEL</a></span> or <span class="blue"><a href="#bookmark-OpSubgroupAvcBmeInitializeINTEL">OpSubgroupAvcBmeInitializeINTEL</a></span> is required.</p>
 </div>
-<table id="bookmark-OpSubgroupAvcFmeInitializeINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcFmeInitializeINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 9.0909%;">
 <col style="width: 9.0909%;">
@@ -5586,7 +5586,7 @@ returned by <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetMotionVecto
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpSubgroupAvcBmeInitializeINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcBmeInitializeINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 8.3333%;">
 <col style="width: 8.3333%;">
@@ -5697,7 +5697,7 @@ returned by <span class="blue"><a href="#bookmark-OpSubgroupAvcMceGetMotionVecto
 <div class="paragraph">
 <p>These are optional instructions that may be called following the initialization phase to convert REF payload to MCE payloads and vice-versa.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -5724,7 +5724,7 @@ Convert the REF payload to a generic MCE payload.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -5757,7 +5757,7 @@ Convert the generic MCE payload to a REF payload.</p>
 <div class="paragraph">
 <p>These are optional instructions that may be called following the initialization phase to enable miscellaneous properties setting in the payload.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -5785,7 +5785,7 @@ Update the input payload to disable a mix of bidirectional and unidirectional MV
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -5844,7 +5844,7 @@ filter interpolation. Default is 4-tap filter interpolation.</p>
 <div class="paragraph">
 <p>These instructions perform the evaluation of the REF operation configured in the payload with a VME media sampler and return the results.</p>
 </div>
-<table id="bookmark-OpSubgroupAvcRefEvaluateWithSingleReferenceINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcRefEvaluateWithSingleReferenceINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -5877,7 +5877,7 @@ Evaluate the basic REF operation with a single reference and return its results.
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpSubgroupAvcRefEvaluateWithDualReferenceINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcRefEvaluateWithDualReferenceINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -5913,7 +5913,7 @@ Evaluate the basic REF operation with dual references and return its results.</p
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpSubgroupAvcRefEvaluateWithMultiReferenceINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcRefEvaluateWithMultiReferenceINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -5939,7 +5939,7 @@ Evaluate the basic REF operation with multi references and return its results.</
 <div class="paragraph">
 <p><em>Packed Reference Ids</em> must be an OpTypeInt with 32-bit Width and 0 Signedness, with the following bits specifying the values for the pair of reference images for each major partition.</p>
 </div>
-<table class="tableblock frame-all grid-all" style="width: 55%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 55%;">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 66.6667%;">
@@ -6026,7 +6026,7 @@ for block 0.</p>
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpSubgroupAvcRefEvaluateWithMultiReferenceInterlacedINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcRefEvaluateWithMultiReferenceInterlacedINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -6054,7 +6054,7 @@ is used for interlaced source and reference images.</p>
 <div class="paragraph">
 <p><em>Packed Reference Ids</em> must be an OpTypeInt with 32-bit Width and 0 Signedness, with the following bits specifying the values for the pair of reference images for each major partition.</p>
 </div>
-<table class="tableblock frame-all grid-all" style="width: 55%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 55%;">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 66.6667%;">
@@ -6125,7 +6125,7 @@ for block 0.</p>
 <div class="paragraph">
 <p><em>Packed Reference Field Polarities</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Reference field polarities for forward and backward reference images are specified for each of the allowed major partitions using it, with the following bits specifying the reference field polarities for the major partitions.</p>
 </div>
-<table class="tableblock frame-all grid-all" style="width: 50%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 50%;">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 66.6667%;">
@@ -6200,7 +6200,7 @@ four pairs of reference field polarities are replicated to the value of the firs
 <div class="paragraph">
 <p>These are optional instructions that may be called following the evaluation phase to convert REF results to MCE results and vice-versa.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -6227,7 +6227,7 @@ Convert the REF result to a generic MCE result.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -6267,7 +6267,7 @@ Convert the generic MCE result to a REF result.</p>
 <div class="paragraph">
 <p>These instructions create a properly initialized payload that can be used for further configured for evaluating SIC operations. This is a required initial phase.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -6328,7 +6328,7 @@ are considered as logically overlapping with the bottom MBs) for the purposes fo
 </div>
 <div class="sect4">
 <h5 id="_configuration_instructions_2">Configuration instructions</h5>
-<table id="bookmark-OpSubgroupAvcSicConfigureSkcINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcSicConfigureSkcINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 10%;">
 <col style="width: 10%;">
@@ -6399,7 +6399,7 @@ Configure the SIC payload for (uni or bi-directional) skip checks.</p>
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpSubgroupAvcSicConfigureIpeLumaINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcSicConfigureIpeLumaINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 8.3333%;">
 <col style="width: 8.3333%;">
@@ -6464,7 +6464,7 @@ corner pixel is a uniform pixel value with each work-item providing the same cor
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpSubgroupAvcSicConfigureIpeLumaChromaINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcSicConfigureIpeLumaChromaINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 6.6666%;">
 <col style="width: 6.6666%;">
@@ -6537,7 +6537,7 @@ corner pixel is a uniform pixel value with each work-item providing the same cor
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -6574,7 +6574,7 @@ input <em>Skip Block Partition Type</em> and direction.</p>
 <div class="paragraph">
 <p>These are optional instructions that may be called following the search configuration phase to convert SIC payload to MCE payloads and vice-versa.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -6601,7 +6601,7 @@ Convert the SIC payload to a generic MCE payload.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -6631,7 +6631,7 @@ Convert the generic MCE payload to a SIC payload.</p>
 </div>
 <div class="sect4">
 <h5 id="_intra_shape_cost_configuration_instructions">Intra shape cost configuration instructions</h5>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -6653,7 +6653,7 @@ Set the shape penalty for inter motion estimation.</p>
 <div class="paragraph">
 <p><em>Packed Shape Penalty</em> must be a 32-bit scalar integer type. It is treated as an unsigned value. The following bits specify the shape penalty in U4U4 format:</p>
 </div>
-<table class="tableblock frame-all grid-all" style="width: 55%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 55%;">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 75%;">
@@ -6701,7 +6701,7 @@ Set the shape penalty for inter motion estimation.</p>
 </div>
 <div class="sect4">
 <h5 id="_intra_mode_cost_configuration_instructions">Intra mode cost configuration instructions</h5>
-<table id="bookmark-OpSubgroupAvcSicSetIntraLumaModeCostFunctionINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcSicSetIntraLumaModeCostFunctionINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -6740,7 +6740,7 @@ A B E F</pre>
 <div class="paragraph">
 <p>The following bits specify the neighbor modes.</p>
 </div>
-<table class="tableblock frame-all grid-all" style="width: 55%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 55%;">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 75%;">
@@ -6783,7 +6783,7 @@ A B E F</pre>
 <div class="paragraph">
 <p><em>Luma Packed Non Dc Penalty</em> specifies the penalty to be applied for any computed non-DC luma mode for each of the 16x16, 8x8, and 4x4 shapes, with the following bits specifying the penalties.</p>
 </div>
-<table class="tableblock frame-all grid-all" style="width: 55%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 55%;">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 66.6667%;">
@@ -6853,7 +6853,7 @@ Luma_Non_Dc_16x16_Penalty(if not DC)</pre>
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpSubgroupAvcSicSetIntraChromaModeCostFunctionINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcSicSetIntraChromaModeCostFunctionINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -6881,7 +6881,7 @@ Update the payload to configure the intra chroma mode cost function by specifyin
 <div class="paragraph">
 <p>The base penalty is scaled based on the computed mode as defined below.</p>
 </div>
-<table class="tableblock frame-all grid-all" style="width: 55%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 55%;">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 66.6667%;">
@@ -6944,7 +6944,7 @@ formula:</p>
 <div class="paragraph">
 <p>These are optional instructions that may be called following the configuration phase to enable miscellaneous properties setting in the payload.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -6997,7 +6997,7 @@ filter interpolation. Default is 4-tap filter interpolation.<br></p>
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcSicSetSkcForwardTransformEnableINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -7030,7 +7030,7 @@ emulate quantization&#8217;s zeroing effect. The user is returned the count of c
 <div class="paragraph">
 <p><em>Packed Sad Coefficients</em> must be an OpTypeInt with 64-bit Width and 0 Signedness, and spoecifies the SAD coefficient threshold matrix. The SAD coefficient threshold matrix for a 4x4 transform as shown in the table below is packed into a 64-bit integer. The low 16 bits contains the larger DC threshold. The coefficient thresholds for the remaining 6 AC thresholds in the order of increasing frequency are provided by the successive 8-bit bit ranges.</p>
 </div>
-<table class="tableblock frame-all grid-all" style="width: 70%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 70%;">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -7082,7 +7082,7 @@ emulate quantization&#8217;s zeroing effect. The user is returned the count of c
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -7133,7 +7133,7 @@ operation by a prior call to [blue]#<a href="#bookmark-OpSubgroupAvcSicConfigure
 <div class="paragraph">
 <p>These instructions perform the evaluation of the SIC operation configured in the payload with a VME media sampler and return the results.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -7163,7 +7163,7 @@ Evaluate the SIC IPE operation and return its results.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -7196,7 +7196,7 @@ Evaluate the SIC operation with single reference and return its results.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -7232,7 +7232,7 @@ Evaluate the SIC operation with dual references and return its results.</p>
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpSubgroupAvcSicEvaluateWithMultiReferenceINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcSicEvaluateWithMultiReferenceINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 14.2857%;">
 <col style="width: 14.2857%;">
@@ -7258,7 +7258,7 @@ Evaluate the SIC operation with multi references and return its results.</p>
 <div class="paragraph">
 <p><em>Packed Reference Ids</em> must be an OpTypeInt with 32-bit Width and 0 Signedness, with the following bits specifying the values for the pair of reference images for each major partition.</p>
 </div>
-<table class="tableblock frame-all grid-all" style="width: 55%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 55%;">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 66.6667%;">
@@ -7331,7 +7331,7 @@ for block 0.</p>
 </tr>
 </tbody>
 </table>
-<table id="bookmark-OpSubgroupAvcSicEvaluateWithMultiReferenceInterlacedINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcSicEvaluateWithMultiReferenceInterlacedINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -7358,7 +7358,7 @@ Evaluate the SIC operation with multi references and return its results. This is
 <div class="paragraph">
 <p><em>Packed Reference Ids</em> must be an OpTypeInt with 32-bit Width and 0 Signedness, with the following bits specifying the values for the pair of reference images for each major partition.</p>
 </div>
-<table class="tableblock frame-all grid-all" style="width: 55%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 55%;">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 66.6667%;">
@@ -7429,7 +7429,7 @@ for block 0.</p>
 <div class="paragraph">
 <p><em>Packed Reference Field Polarities</em> must be an OpTypeInt with 8-bit Width and 0 Signedness. Reference field polarities for forward and backward reference images are specified for each of the allowed major partitions using it, with the following bits specifying the reference field polarities for the major partitions.</p>
 </div>
-<table class="tableblock frame-all grid-all" style="width: 50%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 50%;">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 66.6667%;">
@@ -7504,7 +7504,7 @@ four pairs of reference field polarities are replicated to the value of the firs
 <div class="paragraph">
 <p>These are optional instructions that may be called following the evaluation phase to convert SIC results to MCE results and vice-versa.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -7531,7 +7531,7 @@ Convert the SIC result to a generic MCE result.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -7564,7 +7564,7 @@ Convert the generic MCE result to a SIC result.</p>
 <div class="paragraph">
 <p>These instructions are called following the evaluation phase to extract the various result components from an SIC evaluation result.</p>
 </div>
-<table id="bookmark-OpSubgroupAvcSicGetIpeLumaShapeINTEL" class="tableblock frame-all grid-all stretch">
+<table id="bookmark-OpSubgroupAvcSicGetIpeLumaShapeINTEL" class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -7592,7 +7592,7 @@ Return the best intra shape from the SIC result.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -7619,7 +7619,7 @@ Return the best intra luma distortion for the shape return by <span class="blue"
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -7646,7 +7646,7 @@ Return the best intra chroma distortion for the 8x8 shape from the SIC result.</
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -7714,7 +7714,7 @@ A B E F</pre>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -7742,7 +7742,7 @@ Return the intra chroma mode for the 8x8 block from the SIC result.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -7799,7 +7799,7 @@ Return the packed count of luma coefficient components that exceeded their trans
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -7856,7 +7856,7 @@ Return the packed sum of luma coefficient components that exceeded their transfo
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -7911,7 +7911,7 @@ Return the skip check raw SAD (i.e. without any mode or shape costs included) fo
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stripes-even stretch">
 <colgroup>
 <col style="width: 4.3478%;">
 <col style="width: 13.0434%;">

--- a/extensions/INTEL/SPV_INTEL_fp_max_error.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_fp_max_error.asciidoc
@@ -28,7 +28,7 @@ Final draft
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2023-03-29
 | Revision           | 1
 |========================================
 
@@ -131,5 +131,5 @@ None.
 [options="header"]
 |========================================
 |Rev|Date|Author|Changes
-|1|{docdate}|Shuo Niu|*Initial public release*
+|1|2023-03-29|Shuo Niu|*Initial public release*
 |========================================

--- a/extensions/INTEL/SPV_INTEL_fp_max_error.html
+++ b/extensions/INTEL/SPV_INTEL_fp_max_error.html
@@ -99,7 +99,7 @@ em, b, strong {
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -107,7 +107,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-09</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-03-29</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -184,7 +184,7 @@ Version 1.6 Revision 2.</p>
 <div class="sectionbody">
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<table class="tableblock frame-all grid-rows stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -214,7 +214,7 @@ Version 1.6 Revision 2.</p>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -253,7 +253,7 @@ To give attribution, this description referenced Jean-Michel Muller&#8217;s defi
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -295,7 +295,7 @@ To give attribution, this description referenced Jean-Michel Muller&#8217;s defi
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stripes-even stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">
@@ -313,7 +313,7 @@ To give attribution, this description referenced Jean-Michel Muller&#8217;s defi
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-09</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-03-29</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Shuo Niu</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>Initial public release</strong></p></td>
 </tr>

--- a/extensions/INTEL/SPV_INTEL_fpga_argument_interfaces.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_fpga_argument_interfaces.asciidoc
@@ -45,8 +45,10 @@ Final draft
 
 == Version
 
-Built On: {docdate} +
-Revision: 1
+|========================================
+| Last Modified Date | 2022-12-04
+| Revision           | 1
+|========================================
 
 == Dependencies
 

--- a/extensions/INTEL/SPV_INTEL_fpga_argument_interfaces.html
+++ b/extensions/INTEL/SPV_INTEL_fpga_argument_interfaces.html
@@ -92,10 +92,22 @@ Joe Garvey, Intel</p>
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<div class="paragraph">
-<p>Built On: 2023-02-08<br>
-Revision: 1</p>
-</div>
+<table class="tableblock frame-all grid-all stripes-even stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2022-12-04</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 </div>
 <div class="sect1">
@@ -149,7 +161,7 @@ Version 1.6 Revision 2.</p>
 <div class="sectionbody">
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<table class="tableblock frame-all grid-rows stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -211,7 +223,7 @@ Version 1.6 Revision 2.</p>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -309,7 +321,7 @@ Must be applied only to an <strong>OpFunctionParameter</strong> of a function th
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -351,7 +363,7 @@ Must be applied only to an <strong>OpFunctionParameter</strong> of a function th
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stripes-even stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">

--- a/extensions/INTEL/SPV_INTEL_fpga_latency_control.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_fpga_latency_control.asciidoc
@@ -27,7 +27,7 @@ Final Draft
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2022-11-28
 | Revision           | 1
 |========================================
 

--- a/extensions/INTEL/SPV_INTEL_fpga_latency_control.html
+++ b/extensions/INTEL/SPV_INTEL_fpga_latency_control.html
@@ -92,7 +92,7 @@ em, b, strong {
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -100,7 +100,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2023-02-08</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2022-11-28</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -181,7 +181,7 @@ LatencyControlConstraintINTEL</pre>
 <div class="sectionbody">
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<table class="tableblock frame-all grid-rows stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -215,7 +215,7 @@ LatencyControlConstraintINTEL</pre>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 16.6666%;">
@@ -275,7 +275,7 @@ Apply to an object of type OpTypePointer or OpTypePipe. If that object is used a
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -311,7 +311,7 @@ Apply to an object of type OpTypePointer or OpTypePipe. If that object is used a
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stripes-even stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">

--- a/extensions/INTEL/SPV_INTEL_fpga_memory_accesses.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_fpga_memory_accesses.asciidoc
@@ -30,7 +30,7 @@ First draft
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2020-02-20
 | Revision           | 1
 |========================================
 

--- a/extensions/INTEL/SPV_INTEL_fpga_memory_accesses.html
+++ b/extensions/INTEL/SPV_INTEL_fpga_memory_accesses.html
@@ -105,7 +105,7 @@ em, b, strong {
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -113,7 +113,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2023-02-02</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2020-02-20</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -190,7 +190,7 @@ PrefetchINTEL</pre>
 <div class="sectionbody">
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<table class="tableblock frame-all grid-rows stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -232,7 +232,7 @@ PrefetchINTEL</pre>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -290,7 +290,7 @@ Apply to a pointer. Request, to the extent possible, that a prefetcher of the sp
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -332,7 +332,7 @@ Apply to a pointer. Request, to the extent possible, that a prefetcher of the sp
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stripes-even stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">

--- a/extensions/INTEL/SPV_INTEL_fpga_memory_attributes.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_fpga_memory_attributes.asciidoc
@@ -32,7 +32,7 @@ Final draft
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2023-10-03
 | Revision           | I
 |========================================
 

--- a/extensions/INTEL/SPV_INTEL_fpga_memory_attributes.html
+++ b/extensions/INTEL/SPV_INTEL_fpga_memory_attributes.html
@@ -111,7 +111,7 @@ em, b, strong {
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -119,7 +119,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-09</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-10-03</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -207,7 +207,7 @@ TrueDualPortINTEL</pre>
 <div class="sectionbody">
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<table class="tableblock frame-all grid-rows stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -293,7 +293,7 @@ TrueDualPortINTEL</pre>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -454,7 +454,7 @@ Apply to a variable or a structure-type member. Request, to the extent possible,
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -496,7 +496,7 @@ Apply to a variable or a structure-type member. Request, to the extent possible,
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stripes-even stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">

--- a/extensions/INTEL/SPV_INTEL_fpga_reg.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_fpga_reg.asciidoc
@@ -28,7 +28,7 @@ Final draft
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2019-07-12
 | Revision           | 1
 |========================================
 

--- a/extensions/INTEL/SPV_INTEL_fpga_reg.html
+++ b/extensions/INTEL/SPV_INTEL_fpga_reg.html
@@ -99,7 +99,7 @@ em, b, strong {
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -107,7 +107,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-21</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2019-07-12</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -181,7 +181,7 @@ Version 1.4 Revision 1.</p>
 <div class="sectionbody">
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<table class="tableblock frame-all grid-rows stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -211,7 +211,7 @@ Version 1.4 Revision 1.</p>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -239,7 +239,7 @@ Version 1.4 Revision 1.</p>
 <div class="paragraph">
 <p>In section 3.32.1, Miscellaneous Instructions, add a new instruction, <strong>OpFPGARegINTEL</strong>, as follows:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -285,7 +285,7 @@ Result Type</p></td>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stripes-even stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">

--- a/extensions/INTEL/SPV_INTEL_global_variable_fpga_decorations.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_global_variable_fpga_decorations.asciidoc
@@ -39,8 +39,8 @@ Copyright (c) 2021-2023 Intel Corporation. All rights reserved.
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
-| Revision      | 1
+| Last Modified Date | 2023-10-27
+| Revision      | 3
 |========================================
 
 == Dependencies

--- a/extensions/INTEL/SPV_INTEL_global_variable_fpga_decorations.html
+++ b/extensions/INTEL/SPV_INTEL_global_variable_fpga_decorations.html
@@ -111,7 +111,7 @@ em, b, strong {
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -119,11 +119,11 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-09</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-10-27</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">3</p></td>
 </tr>
 </tbody>
 </table>
@@ -183,7 +183,7 @@ be present in the module:</p>
 <div class="sectionbody">
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<table class="tableblock frame-all grid-rows stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -223,7 +223,7 @@ be present in the module:</p>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -264,7 +264,7 @@ be present in the module:</p>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 7.1428%;">
 <col style="width: 35.7142%;">
@@ -345,7 +345,7 @@ interface for the variable is implementation defined.</p>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -381,7 +381,7 @@ interface for the variable is implementation defined.</p>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stripes-even stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">

--- a/extensions/INTEL/SPV_INTEL_global_variable_host_access.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_global_variable_host_access.asciidoc
@@ -39,8 +39,8 @@ Copyright (c) 2021-2023 Intel Corporation. All rights reserved.
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
-| Revision      | 1
+| Last Modified Date | 2023-10-27
+| Revision      | 4
 |========================================
 
 == Dependencies

--- a/extensions/INTEL/SPV_INTEL_global_variable_host_access.html
+++ b/extensions/INTEL/SPV_INTEL_global_variable_host_access.html
@@ -111,7 +111,7 @@ em, b, strong {
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -119,11 +119,11 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-09</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-10-27</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">4</p></td>
 </tr>
 </tbody>
 </table>
@@ -182,7 +182,7 @@ be present in the module:</p>
 <div class="sectionbody">
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<table class="tableblock frame-all grid-rows stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -218,7 +218,7 @@ be present in the module:</p>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -272,7 +272,7 @@ will never write it. On an FPGA device, only a read memory port is exposed.</p><
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 7.1428%;">
 <col style="width: 35.7142%;">
@@ -323,7 +323,7 @@ API&#8217;s execution environment may use to identify this variable.</p>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -370,7 +370,7 @@ have the same <em>Name</em> operand.</p>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stripes-even stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">

--- a/extensions/INTEL/SPV_INTEL_io_pipes.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_io_pipes.asciidoc
@@ -28,7 +28,7 @@ Draft
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2020-02-25
 | Revision           | 1
 |========================================
 

--- a/extensions/INTEL/SPV_INTEL_io_pipes.html
+++ b/extensions/INTEL/SPV_INTEL_io_pipes.html
@@ -99,7 +99,7 @@ em, b, strong {
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -107,7 +107,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2023-02-02</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2020-02-25</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -181,7 +181,7 @@ Version 1.5 Revision 2.</p>
 <div class="sectionbody">
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<table class="tableblock frame-all grid-rows stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -211,7 +211,7 @@ Version 1.5 Revision 2.</p>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -247,7 +247,7 @@ Apply to a pipe-storage object created from <strong>OpConstantPipeStorage</stron
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -289,7 +289,7 @@ Apply to a pipe-storage object created from <strong>OpConstantPipeStorage</stron
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stripes-even stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">

--- a/extensions/INTEL/SPV_INTEL_maximum_registers.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_maximum_registers.asciidoc
@@ -34,7 +34,7 @@ Copyright (c) 2024 Intel Corporation.  All rights reserved.
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2024-02-05
 | Revision           | 1
 |========================================
 

--- a/extensions/INTEL/SPV_INTEL_maximum_registers.html
+++ b/extensions/INTEL/SPV_INTEL_maximum_registers.html
@@ -100,7 +100,7 @@ em, b, strong {
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -108,7 +108,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-21</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-02-05</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -180,7 +180,7 @@ be present in the module:</p>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 11.1111%;">
 <col style="width: 55.5555%;">
@@ -209,7 +209,7 @@ Specifies the maximum number of registers that may be used by an entry point.</p
 <div class="paragraph">
 <p>Modify Section 3.6, Execution Mode, adding rows to the Execution Mode table:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 6.5573%;">
 <col style="width: 32.7868%;">
@@ -276,7 +276,7 @@ to a single invocation.</p>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 11.4285%;">
 <col style="width: 45.7142%;">
@@ -370,7 +370,7 @@ although it is a <strong>different</strong> implementation, at least for current
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stripes-even stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">

--- a/extensions/INTEL/SPV_INTEL_media_block_io.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_media_block_io.asciidoc
@@ -27,7 +27,7 @@ Copyright (c) 2018 Intel Corporation.  All rights reserved.
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2018-10-29
 | Revision           | 1
 |========================================
 

--- a/extensions/INTEL/SPV_INTEL_media_block_io.html
+++ b/extensions/INTEL/SPV_INTEL_media_block_io.html
@@ -104,7 +104,7 @@ em, b, strong {
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -112,7 +112,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-21</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2018-10-29</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -185,7 +185,7 @@ OpSubgroupImageMediaBlockWriteINTEL</pre>
 <div class="sect1">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<table class="tableblock frame-all grid-rows stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -215,7 +215,7 @@ OpSubgroupImageMediaBlockWriteINTEL</pre>
 <div class="paragraph">
 <p>Modify Section 3.31, Capability, adding rows to the Capability table:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 5.2631%;">
 <col style="width: 52.6315%;">
@@ -244,7 +244,7 @@ OpSubgroupImageMediaBlockWriteINTEL</pre>
 <div class="paragraph">
 <p>Modify Section 3.32.21, Group Instructions, adding to the end of the list of instructions:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 5%;">
 <col style="width: 5%;">
@@ -281,7 +281,7 @@ Reads a block of data from a 2D region of the specified <em>Image</em>.</p>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 5.8823%;">
 <col style="width: 5.8823%;">
@@ -338,7 +338,7 @@ Writes a block of data into a 2D region of the specified <em>Image</em>.</p>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stripes-even stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">

--- a/extensions/INTEL/SPV_INTEL_split_barrier.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_split_barrier.asciidoc
@@ -27,7 +27,7 @@ Copyright (c) 2022 Intel Corporation.  All rights reserved.
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2022-02-24
 | Revision           | 1
 |========================================
 

--- a/extensions/INTEL/SPV_INTEL_split_barrier.html
+++ b/extensions/INTEL/SPV_INTEL_split_barrier.html
@@ -98,7 +98,7 @@ em, b, strong {
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -106,7 +106,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-21</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2022-02-24</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -176,7 +176,7 @@ be present in the module:</p>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -201,7 +201,7 @@ be present in the module:</p>
 <div class="paragraph">
 <p>Add to Section 3.42.20, Barrier Instructions:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 9.0909%;">
 <col style="width: 9.0909%;">
@@ -236,7 +236,7 @@ This allows atomically specifying both a control barrier and a memory barrier (t
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 9.0909%;">
 <col style="width: 9.0909%;">
@@ -285,7 +285,7 @@ This allows atomically specifying both a control barrier and a memory barrier (t
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stripes-even stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">

--- a/extensions/INTEL/SPV_INTEL_subgroup_buffer_prefetch.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_subgroup_buffer_prefetch.asciidoc
@@ -31,7 +31,7 @@ Copyright (c) 2024 Intel Corporation.  All rights reserved.
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2024-05-30
 | Revision           | 1
 |========================================
 

--- a/extensions/INTEL/SPV_INTEL_subgroup_buffer_prefetch.html
+++ b/extensions/INTEL/SPV_INTEL_subgroup_buffer_prefetch.html
@@ -108,7 +108,7 @@ em, b, strong {
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -116,7 +116,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-26</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2024-05-30</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -172,7 +172,7 @@ The functionality added by this extension can improve the performance of some ke
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -200,7 +200,7 @@ The functionality added by this extension can improve the performance of some ke
 <div class="paragraph">
 <p>Modify Section 3.49.21, Group and Subgroup Instructions, adding to the end of the list of instructions:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 16.6666%;">
 <col style="width: 8.3333%;">
@@ -363,7 +363,7 @@ Passing a pointer to a concrete type provides alignment information that would n
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stripes-even stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">

--- a/extensions/INTEL/SPV_INTEL_subgroups.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_subgroups.asciidoc
@@ -29,7 +29,7 @@ Copyright (c) 2017-2018 Intel Corporation.  All rights reserved.
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2018-10-22
 | Revision           | 2
 |========================================
 

--- a/extensions/INTEL/SPV_INTEL_subgroups.html
+++ b/extensions/INTEL/SPV_INTEL_subgroups.html
@@ -110,7 +110,7 @@ em, b, strong {
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -118,7 +118,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-21</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2018-10-22</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -229,7 +229,7 @@ OpSubgroupImageBlockWriteINTEL</pre>
 <div class="sect1">
 <h2 id="_token_number_assignments">Token Number Assignments</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<table class="tableblock frame-all grid-rows stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -291,7 +291,7 @@ OpSubgroupImageBlockWriteINTEL</pre>
 <div class="paragraph">
 <p>Modify Section 3.31, Capability, adding rows to the Capability table:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 5.2631%;">
 <col style="width: 52.6315%;">
@@ -332,7 +332,7 @@ OpSubgroupImageBlockWriteINTEL</pre>
 <div class="paragraph">
 <p>Modify Section 3.32.21, Group Instructions, adding to the end of the list of instructions:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 7.1428%;">
 <col style="width: 7.1428%;">
@@ -363,7 +363,7 @@ Allows data to be arbitrarily transferred between invocations in a subgroup.  Th
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 5.8823%;">
 <col style="width: 5.8823%;">
@@ -400,7 +400,7 @@ Allows data to be transferred from an invocation in the subgroup with a higher <
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 5.8823%;">
 <col style="width: 5.8823%;">
@@ -437,7 +437,7 @@ Allows data to be transferred from an invocation in the subgroup with a lower <s
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 7.1428%;">
 <col style="width: 7.1428%;">
@@ -468,7 +468,7 @@ Allows data to be transferred between invocations in a subgroup as a function of
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 9.0909%;">
 <col style="width: 9.0909%;">
@@ -500,7 +500,7 @@ Reads one or more components of <em>Result</em> data for each invocation in the 
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 12.5%;">
 <col style="width: 12.5%;">
@@ -530,7 +530,7 @@ Writes one or more components of <em>Data</em> for each invocation in the subgro
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 7.1428%;">
 <col style="width: 7.1428%;">
@@ -561,7 +561,7 @@ Reads one or more components of <em>Result</em> data for each invocation in the 
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 9.0909%;">
 <col style="width: 9.0909%;">
@@ -612,7 +612,7 @@ Writes one or more components of <em>Data</em> for each invocation in the subgro
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stripes-even stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">

--- a/extensions/INTEL/SPV_INTEL_task_sequence.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_task_sequence.asciidoc
@@ -31,7 +31,7 @@ Complete
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2023-03-06
 | Revision           | 1
 |========================================
 

--- a/extensions/INTEL/SPV_INTEL_task_sequence.html
+++ b/extensions/INTEL/SPV_INTEL_task_sequence.html
@@ -112,7 +112,7 @@ em, b, strong {
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -120,7 +120,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-21</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2023-03-06</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -328,7 +328,7 @@ Similarly the next two calls create <em>Task_2_1</em> and <em>Task_2_2</em>.</p>
 <p>The table below provides a view of the hierarchy of task threads that will be
 generated.</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <caption class="title">Table 1. Hierarchy of task threads.</caption>
 <colgroup>
 <col style="width: 20%;">
@@ -364,7 +364,7 @@ example one task thread for each task sequence is also strengthened. This is
 depicted in the table below (progress guarantee for each thread is in
 parenthesis):</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <caption class="title">Table 2. Possible Progress Guarantees at some time after <em>WI</em> is strengthened.</caption>
 <colgroup>
 <col style="width: 20%;">
@@ -513,7 +513,7 @@ OpTaskSequenceReleaseINTEL</pre>
 <div class="sectionbody">
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<table class="tableblock frame-all grid-rows stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -559,7 +559,7 @@ OpTaskSequenceReleaseINTEL</pre>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -588,7 +588,7 @@ OpTaskSequenceReleaseINTEL</pre>
 <p>Add a new subsection, 3.42.26, Task Sequence Type Declaration Instruction, and
 add one new instruction in this subsection as follows:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -616,7 +616,7 @@ add one new instruction in this subsection as follows:</p>
 <p>Add a new subsection, 3.42.27, Task Sequence Instructions, and add four new
 instructions in this subsection as follows:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 11.1111%;">
 <col style="width: 11.1111%;">
@@ -684,7 +684,7 @@ threads in <em>Result</em> are strictly less than this limit.</p></td>
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -718,7 +718,7 @@ If <code>f</code> cannot be called with <em>N</em> arguments the behavior is und
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 20%;">
 <col style="width: 20%;">
@@ -751,7 +751,7 @@ This instruction will block if there are no results to return.
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -798,7 +798,7 @@ opaque type <code>spirv.TaskSequenceINTEL</code> and mangled as
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stripes-even stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">

--- a/extensions/INTEL/SPV_INTEL_unstructured_loop_controls.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_unstructured_loop_controls.asciidoc
@@ -30,7 +30,7 @@ Final draft
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2019-06-12
 | Revision           | 1
 |========================================
 

--- a/extensions/INTEL/SPV_INTEL_unstructured_loop_controls.html
+++ b/extensions/INTEL/SPV_INTEL_unstructured_loop_controls.html
@@ -105,7 +105,7 @@ em, b, strong {
 <div class="sect1">
 <h2 id="_version">Version</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-all" style="width: 40%;">
+<table class="tableblock frame-all grid-all stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -113,7 +113,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-08-21</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2019-06-12</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>
@@ -187,7 +187,7 @@ Version 1.4 Revision 1.</p>
 <div class="sectionbody">
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-rows" style="width: 40%;">
+<table class="tableblock frame-all grid-rows stripes-even" style="width: 40%;">
 <colgroup>
 <col style="width: 70%;">
 <col style="width: 30%;">
@@ -226,7 +226,7 @@ Version 1.4 Revision 1.</p>
 </div>
 <div class="openblock">
 <div class="content">
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 33.3333%;">
 <col style="width: 33.3333%;">
@@ -254,7 +254,7 @@ Version 1.4 Revision 1.</p>
 <div class="paragraph">
 <p>In section 3.32.17, Control-Flow Instructions, add a new instruction, <strong>OpLoopControlINTEL</strong>, as follows:</p>
 </div>
-<table class="tableblock frame-all grid-all stretch">
+<table class="tableblock frame-all grid-all stripes-even stretch">
 <colgroup>
 <col style="width: 25%;">
 <col style="width: 25%;">
@@ -294,7 +294,7 @@ Loop Control Parameters</p></td>
 <div class="sect1">
 <h2 id="_revision_history">Revision History</h2>
 <div class="sectionbody">
-<table class="tableblock frame-all grid-rows stretch">
+<table class="tableblock frame-all grid-rows stripes-even stretch">
 <colgroup>
 <col style="width: 4.7619%;">
 <col style="width: 14.2857%;">

--- a/extensions/KHR/SPV_KHR_uniform_group_instructions.asciidoc
+++ b/extensions/KHR/SPV_KHR_uniform_group_instructions.asciidoc
@@ -44,7 +44,7 @@ http://www.khronos.org/registry/speccopyright.html
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
+| Last Modified Date | 2021-11-08
 | Revision           | 1
 |========================================
 

--- a/extensions/KHR/SPV_KHR_uniform_group_instructions.html
+++ b/extensions/KHR/SPV_KHR_uniform_group_instructions.html
@@ -120,7 +120,7 @@ em, b, strong {
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Last Modified Date</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2024-09-05</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">2021-11-08</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Revision</p></td>


### PR DESCRIPTION
{docdate} will print the generation date, which will change with every PR merged. Change to actual dates.

Some documents used docdate for the Revision History, in which case date set is the PR date.

Address point 1 of https://github.com/KhronosGroup/SPIRV-Registry/issues/270#issuecomment-2471674678