### PR TITLE
Fix typo in QCOM capability

### DIFF
--- a/extensions/QCOM/SPV_QCOM_image_processing.asciidoc
+++ b/extensions/QCOM/SPV_QCOM_image_processing.asciidoc
@@ -71,7 +71,7 @@ New Capabilities
 This extension introduces new capabilities:
 
 ----
-TextureWeightedSampleQCOM
+TextureSampleWeightedQCOM
 TextureBoxFilterQCOM
 TextureBlockMatchQCOM
 ----
@@ -89,7 +89,7 @@ BlockMatchTextureQCOM
 New Instructions
 ----------------
 
-Instruction added under the *TextureWeightedSampleQCOM* capability:
+Instruction added under the *TextureSampleWeightedQCOM* capability:
 
 ----
 OpImageSampleWeightedQCOM
@@ -119,7 +119,7 @@ Modify Section 3.31, "Capability", adding these rows to the Capability table:
 [options="header"]
 |====
 2+^| Capability ^| Implicitly declares
-| 4484 | *TextureWeightedSampleQCOM* +
+| 4484 | *TextureSampleWeightedQCOM* +
 Add weighted sample operation. |
 | 4485 | *TextureBoxFilterQCOM* +
 Add box filter operation. |
@@ -139,7 +139,7 @@ Modify Section 3.20, "Decoration", adding the following rows to the Decoration t
 2+^| Decoration 2+^| Extra Operands	^| Enabling Capabilities
 | 4487 | *WeightTextureQCOM* +
 Apply to a texture used as 'Weight Image' in OpImageSampleWeightedQCOM.  Behavior is defined by the runtime environment.
-2+| | *TextureWeightedSampleQCOM*
+2+| | *TextureSampleWeightedQCOM*
 | 4488 | *BlockMatchTextureQCOM* +
 Apply to textures used as 'Target Sampled Image' and 'Reference Sampled Image' in OpImageBlockMatchSSDQCOM/OpImageBlockMatchSADQCOM. +
 Behavior is defined by the runtime environment.

--- a/extensions/QCOM/SPV_QCOM_image_processing.html
+++ b/extensions/QCOM/SPV_QCOM_image_processing.html
@@ -172,7 +172,7 @@ new capabilities and two new decorations.</p>
 </div>
 <div class="listingblock">
 <div class="content">
-<pre>TextureWeightedSampleQCOM
+<pre>TextureSampleWeightedQCOM
 TextureBoxFilterQCOM
 TextureBlockMatchQCOM</pre>
 </div>
@@ -197,7 +197,7 @@ BlockMatchTextureQCOM</pre>
 <h2 id="_new_instructions">New Instructions</h2>
 <div class="sectionbody">
 <div class="paragraph">
-<p>Instruction added under the <strong>TextureWeightedSampleQCOM</strong> capability:</p>
+<p>Instruction added under the <strong>TextureSampleWeightedQCOM</strong> capability:</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -248,7 +248,7 @@ OpImageBlockMatchSADQCOM</pre>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">4484</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>TextureWeightedSampleQCOM</strong><br>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>TextureSampleWeightedQCOM</strong><br>
 Add weighted sample operation.</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
@@ -297,7 +297,7 @@ Add block matching operations (sum of absolute/square differences).</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><strong>WeightTextureQCOM</strong><br>
 Apply to a texture used as <em>Weight Image</em> in OpImageSampleWeightedQCOM.  Behavior is defined by the runtime environment.</p></td>
 <td class="tableblock halign-left valign-top" colspan="2"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>TextureWeightedSampleQCOM</strong></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><strong>TextureSampleWeightedQCOM</strong></p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">4488</p></td>


### PR DESCRIPTION
Picking the spelling used in the headers: https://github.com/KhronosGroup/SPIRV-Headers/blob/main/include/spirv/unified1/spirv.h#L3813