### PR TITLE
Align SPV_KHR_cooperative_matrix instruction categories to the grammar

### DIFF
--- a/extensions/KHR/SPV_KHR_cooperative_matrix.asciidoc
+++ b/extensions/KHR/SPV_KHR_cooperative_matrix.asciidoc
@@ -55,8 +55,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2024-08-07
-| Revision           | 6
+| Last Modified Date | 2025-03-05
+| Revision           | 7
 |========================================
 
 Dependencies
@@ -247,6 +247,26 @@ New section in 3 "Binary Form".
 |====
 --
 
+3.42.1 Miscellaneous Instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+[cols="1,1,3*3",width="100%"]
+|=====
+4+|[[OpCooperativeMatrixLengthKHR]]*OpCooperativeMatrixLengthKHR* +
+ +
+Number of components of a cooperative matrix type accessible to the current
+invocation when treated as a composite. +
+ +
+'Result Type' must be an *OpTypeInt* with 32-bit 'Width' and 0 'Signedness'. +
+ +
+'Type' is a cooperative matrix type. +
+1+|Capability: +
+*CooperativeMatrixKHR*
+1+| 4 | 4460 | '<id>' +
+'Result Type' |'Result <id>' | '<id>' +
+'Type'
+|=====
+
 3.42.6 Type-Declaration Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -364,23 +384,6 @@ instance of the 'Scope' of the cooperative matrix.
 'MemoryLayout' | Optional '<id>' +
 'Stride' | Optional +
 'Memory Operand'
-|=====
-
-[cols="1,1,3*3",width="100%"]
-|=====
-4+|[[OpCooperativeMatrixLengthKHR]]*OpCooperativeMatrixLengthKHR* +
- +
-Number of components of a cooperative matrix type accessible to the current
-invocation when treated as a composite. +
- +
-'Result Type' must be an *OpTypeInt* with 32-bit 'Width' and 0 'Signedness'. +
- +
-'Type' is a cooperative matrix type. +
-1+|Capability: +
-*CooperativeMatrixKHR*
-1+| 4 | 4460 | '<id>' +
-'Result Type' |'Result <id>' | '<id>' +
-'Type'
 |=====
 
 3.42.11 Conversion Instructions
@@ -630,6 +633,7 @@ Revision History
 [options="header"]
 |========================================
 |Rev|Date|Author|Changes
+|7|2025-03-05|Kevin Petit|Fix OpCooperativeMatrixLengthKHR instruction section
 |6|2024-08-07|Jeff Bolz|Clarify sign/zero-extension behavior
 |5|2023-12-06|Kevin Petit|Clarifications, mostly of uniformity rules
 |4|2023-07-26|Kevin Petit|Add KHR suffixes to Cooperative Matrix Operands


### PR DESCRIPTION
OpCooperativeMatrixLengthKHR is classified as Miscellaneous in the grammar, not a memory instruction.


Change-Id: Ic83106efbdd1dbbf4b76c7da0721f50d5f8e4160