### PR TITLE
only run deploy job on pushes to the main branch

### DIFF
--- a/.github/workflows/html-build.yml
+++ b/.github/workflows/html-build.yml
@@ -46,7 +46,7 @@ jobs:
 
   # Deployment job
   deploy:
-    if: ${{ github.event_name == 'push'}}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Currently, when I push changes to a branch on my GitHub fork, the "deploy" action runs and fails because I don't have GitHub pages enabled on my fork.  Example:

https://github.com/bashbaug/SPIRV-Registry/actions/runs/13934651192

This change updates our workflow file so the "deploy" action only runs on pushes to the "main" branch.  Because most GitHub workflows that involve pushing to a fork use a different branch name, this means that the "deploy" action doesn't run and the CI builds do not "fail".

I'm open to alternatives if a better solution exists, but this seems to be working for me.

