### PR TITLE
fix word count for OpSubgroupAvcSicSetIntraChromaModeCostFunctionINTEL

### DIFF
--- a/extensions/INTEL/SPV_INTEL_device_side_avc_motion_estimation.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_device_side_avc_motion_estimation.asciidoc
@@ -3198,7 +3198,7 @@ Distortion =
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL, SubgroupAvcMotionEstimationChromaINTEL* +
-| 7 | 5799 | <id> Result Type | Result <id> | <id> Chroma Mode Base Penalty | <id> Payload
+| 5 | 5799 | <id> Result Type | Result <id> | <id> Chroma Mode Base Penalty | <id> Payload
 |=====
 
 ===== Miscellaneous property configuration instructions

--- a/extensions/INTEL/SPV_INTEL_device_side_avc_motion_estimation.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_device_side_avc_motion_estimation.asciidoc
@@ -25,7 +25,7 @@ Copyright (c) 2018 Intel Corporation.  All rights reserved.
 
 == Status
 
-- Final Draft
+- Shipping
 
 == Version
 


### PR DESCRIPTION
fixes #328 

The word count for OpSubgroupAvcSicSetIntraChromaModeCostFunctionINTEL should be 5, not 7.