### PR TITLE
Reduce SPV_KHR_cooperative_matrix version requirement to 1.3

### DIFF
--- a/extensions/KHR/SPV_KHR_cooperative_matrix.asciidoc
+++ b/extensions/KHR/SPV_KHR_cooperative_matrix.asciidoc
@@ -55,8 +55,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2025-04-10
-| Revision           | 9
+| Last Modified Date | 2025-04-24
+| Revision           | 10
 |========================================
 
 Dependencies
@@ -65,7 +65,12 @@ Dependencies
 This extension is written against the SPIR-V Specification,
 Version 1.6, Revision 2, Unified.
 
-This extension requires SPIR-V 1.6.
+This extension requires SPIR-V 1.3.
+
+In modules that declare the *Shader* capability, this extension requires the
+Vulkan memory model
+(https://github.khronos.org/SPIRV-Registry/extensions/KHR/SPV_KHR_vulkan_memory_model.html[SPV_KHR_vulkan_memory_model]
+or SPIR-V version 1.5+).
 
 This extension interacts with SPV_EXT_physical_storage_buffer.
 
@@ -646,6 +651,7 @@ Revision History
 [options="header"]
 |========================================
 |Rev|Date|Author|Changes
+|10|2025-04-24|Alan Baker|Reduce version requirement to 1.3
 |9|2025-04-10|Jeff Bolz|Specify which instructions are tangled
 |8|2025-04-10|Jeff Bolz|Clarify composite creation behavior
 |7|2025-03-05|Kevin Petit|Fix OpCooperativeMatrixLengthKHR instruction section


### PR DESCRIPTION
Should be coordinated with Vulkan issue 4245.