### PR TITLE
add ratification dates to specifications

### DIFF
--- a/extensions/EXT/SPV_EXT_mesh_shader.asciidoc
+++ b/extensions/EXT/SPV_EXT_mesh_shader.asciidoc
@@ -29,6 +29,8 @@ Status
 ------
 
 - Complete
+- Approved by the SPIR-V Working Group: 2025-03-12
+- Approved by the Khronos Board of Promoters: 2025-04-25
 
 Version
 -------

--- a/extensions/EXT/SPV_EXT_opacity_micromap.asciidoc
+++ b/extensions/EXT/SPV_EXT_opacity_micromap.asciidoc
@@ -22,6 +22,8 @@ Status
 ------
 
 - Complete
+- Approved by the SPIR-V Working Group: 2025-03-12
+- Approved by the Khronos Board of Promoters: 2025-04-25
 
 Version
 -------

--- a/extensions/KHR/SPV_KHR_8bit_storage.asciidoc
+++ b/extensions/KHR/SPV_KHR_8bit_storage.asciidoc
@@ -30,6 +30,7 @@ Status
 
 - Complete
 - Approved by the SPIR Working Group: 2018-03-28
+- Approved by the Khronos Board of Promoters: 2018-05-18
 
 Version
 -------


### PR DESCRIPTION
These two EXT extensions were recently ratified:
* SPV_EXT_mesh_shader
* SPV_EXT_opacity_micromap

This KHR extension was previously ratified, but did not include the ratification date in the specification:
* SPV_KHR_8bit_storage