### PR TITLE
Replace "Depends On" with "Implicitly Declares" in all extensions

### DIFF
--- a/extensions/AMD/SPV_AMD_gpu_shader_half_float_fetch.asciidoc
+++ b/extensions/AMD/SPV_AMD_gpu_shader_half_float_fetch.asciidoc
@@ -135,7 +135,7 @@ Append the following Capability to the table:
 
 [options="header"]
 |========================================
-|Capability|Depends On|Enabled by Extension
+|Capability|Implicitly Declares|Enabled by Extension
 |*Float16ImageAMD*
 
 Expands image type declaration instruction and image instructions to allow them to use 16-bit type in image declaration/sampling/read/write/sparse read operations.|*Shader*|SPV_AMD_gpu_shader_half_float_fetch

--- a/extensions/AMD/SPV_AMD_shader_image_load_store_lod.asciidoc
+++ b/extensions/AMD/SPV_AMD_shader_image_load_store_lod.asciidoc
@@ -90,7 +90,7 @@ Append the following Capability to the table:
 
 [options="header"]
 |========================================
-|Capability|Depends On|Enabled by Extension
+|Capability|Implicitly Declares|Enabled by Extension
 |*CapabilityImageReadWriteLodAMD*
  
 Expands *Lod* image operand definition to support image read/write/sparse read operations.|*CapabilityShader*|SPV_AMD_shader_image_load_store_lod

--- a/extensions/AMD/SPV_AMD_texture_gather_bias_lod.asciidoc
+++ b/extensions/AMD/SPV_AMD_texture_gather_bias_lod.asciidoc
@@ -112,7 +112,7 @@ Append the following Capability to the table:
 
 [options="header"]
 |========================================
-|Capability|Depends On|Enabled by Extension
+|Capability|Implicitly Declares|Enabled by Extension
 |*ImageGatherBiasLodAMD* 
  
 Uses texture gather with either bias added to the implicit level-of-detail or explicit level-of-detail.|Shader|SPV_AMD_texture_gather_bias_lod

--- a/extensions/ARM/SPV_ARM_cooperative_matrix_layouts.asciidoc
+++ b/extensions/ARM/SPV_ARM_cooperative_matrix_layouts.asciidoc
@@ -98,7 +98,7 @@ Modify Section 3.31, "Capability", adding these rows to the Capability table:
 --
 [options="header"]
 |====
-2+^| Capability ^| Depends On
+2+^| Capability ^| Implicitly Declares
 | 4201 | *CooperativeMatrixLayoutsARM* +
 Uses ARM cooperative matrix layouts | *CooperativeMatrixKHR*
 |====

--- a/extensions/ARM/SPV_ARM_core_builtins.asciidoc
+++ b/extensions/ARM/SPV_ARM_core_builtins.asciidoc
@@ -96,7 +96,7 @@ Modify Section 3.31, "Capability", adding these rows to the Capability table:
 --
 [options="header"]
 |====
-2+^| Capability ^| Depends On
+2+^| Capability ^| Implicitly Declares
 | 4165 | *CoreBuiltinsARM* +
 Uses the *CoreIDARM*, *CoreCountARM*, *CoreMaxIDARM*, *WarpIDARM*, *WarpMaxIDARM* builtin decorations. |
 |====

--- a/extensions/ARM/SPV_ARM_tensors.asciidoc
+++ b/extensions/ARM/SPV_ARM_tensors.asciidoc
@@ -94,7 +94,7 @@ Modify Section 3.31, "Capability", adding these rows to the Capability table:
 --
 [options="header"]
 |====
-2+^| Capability ^| Depends On
+2+^| Capability ^| Implicitly Declares
 | 4174 | *TensorsARM* +
 Uses **OpTypeTensorARM** |
 | 4175 | *StorageTensorArrayDynamicIndexingARM* +

--- a/extensions/EXT/SPV_EXT_arithmetic_fence.asciidoc
+++ b/extensions/EXT/SPV_EXT_arithmetic_fence.asciidoc
@@ -131,7 +131,7 @@ Modify Section 3.31, "Capability", adding these rows to the Capability table:
 --
 [options="header"]
 |====
-2+^| Capability ^| Depends On
+2+^| Capability ^| Implicitly Declares
 | 6144 | *ArithmeticFenceEXT* +
 Allow to use *OpArithmeticFenceEXT* instruction |
 |====

--- a/extensions/EXT/SPV_EXT_descriptor_indexing.asciidoc
+++ b/extensions/EXT/SPV_EXT_descriptor_indexing.asciidoc
@@ -207,7 +207,7 @@ See the API specification for more information.
 --
 [cols="1,15,8,30",options="header",width = "100%"]
 |====
-2+^.^| Capability | Depends On | Enabled by Extension
+2+^.^| Capability | Implicitly Declares | Enabled by Extension
 | 5301 | *ShaderNonUniformEXT* +
 Uses the *NonUniformEXT* decoration on a variable or instruction.
 | *Shader* | *SPV_EXT_descriptor_indexing*

--- a/extensions/EXT/SPV_EXT_float8.asciidoc
+++ b/extensions/EXT/SPV_EXT_float8.asciidoc
@@ -153,7 +153,7 @@ Modify Section 3.31, "Capability", adding these rows to the Capability table:
 --
 [options="header"]
 |====
-2+^| Capability ^| Depends On
+2+^| Capability ^| Implicitly Declares
 | 4212 | *Float8EXT* +
 Uses *OpTypeFloat* to specify types with the *Float8E4M3EXT* or *Float8E5M2EXT* FP Encoding and values of this type with a few instructions.
 |

--- a/extensions/EXT/SPV_EXT_fragment_fully_covered.asciidoc
+++ b/extensions/EXT/SPV_EXT_fragment_fully_covered.asciidoc
@@ -116,7 +116,7 @@ See Vulkan EXT_conservative_rasterization extension for more detail.
 --
 [cols="1,10,12,8",options="header",width = "80%"]
 |====
-2+^.^| Capability | Depends On | Enabled by Extension
+2+^.^| Capability | Implicitly Declares | Enabled by Extension
 | 5265 | *FragmentFullyCoveredEXT* |  *Shader*  | SPV_EXT_fragment_fully_covered
 |====
 

--- a/extensions/EXT/SPV_EXT_fragment_invocation_density.asciidoc
+++ b/extensions/EXT/SPV_EXT_fragment_invocation_density.asciidoc
@@ -112,7 +112,7 @@ See the API specification for more detail.
 --
 [options="header"]
 |====
-2+| Capability | Depends On | Enabled by Extension
+2+| Capability | Implicitly Declares | Enabled by Extension
 | 5291 | *FragmentDensityEXT* +
 Uses the *FragSizeEXT* or *FragInvocationCountEXT* Builtins. | *Shader*
 | *SPV_EXT_fragment_invocation_density*

--- a/extensions/EXT/SPV_EXT_replicated_composites.asciidoc
+++ b/extensions/EXT/SPV_EXT_replicated_composites.asciidoc
@@ -78,7 +78,7 @@ Modify Section 3.31, "Capability", adding these rows to the Capability table:
 --
 [options="header"]
 |====
-2+^| Capability ^| Depends On
+2+^| Capability ^| Implicitly Declares
 | 6024 | *ReplicatedCompositesEXT* +
 Uses **OpConstantCompositeReplicateEXT**, **OpSpecConstantCompositeReplicateEXT**, or **OpCompositeConstructReplicateEXT** |
 |====

--- a/extensions/EXT/SPV_EXT_shader_viewport_index_layer.asciidoc
+++ b/extensions/EXT/SPV_EXT_shader_viewport_index_layer.asciidoc
@@ -142,7 +142,7 @@ input to a *Fragment* Execution Model.
 --
 [cols="1,10,8,15",options="header",width = "80%"]
 |====
-2+^.^| Capability | Depends On | Enabled by Extension
+2+^.^| Capability | Implicitly Declares | Enabled by Extension
 | 5254 | *ShaderViewportIndexLayerEXT* | *MultiViewport*
 | *SPV_EXT_shader_viewport_index_layer*
 |====

--- a/extensions/INTEL/SPV_INTEL_shader_integer_functions2.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_shader_integer_functions2.asciidoc
@@ -115,7 +115,7 @@ Modify Section 3.31, "Capability", adding these rows to the Capability table:
 --
 [options="header"]
 |====
-2+^| Capability ^| Depends On
+2+^| Capability ^| Implicitly Declares
 | 5584 | *IntegerFunctions2INTEL* +
 Allow this new functionality... |
 |====

--- a/extensions/KHR/SPV_KHR_16bit_storage.asciidoc
+++ b/extensions/KHR/SPV_KHR_16bit_storage.asciidoc
@@ -148,7 +148,7 @@ Modify Section 3.31, Capability, adding the following rows to the Capability tab
 --
 [cols="^.^2,16,15", options="header"]
 |====
-2+^| Capability ^| Depends On
+2+^| Capability ^| Implicitly Declares
 | 4433 | *StorageUniformBufferBlock16* +
 Allows 16-bit <<OpTypeFloat, *OpTypeFloat*>> and <<OpTypeInt, *OpTypeInt*>>
 instructions for creating scalar, vector, and composite types that become members of a block
@@ -229,7 +229,7 @@ Modify Section 3.31, Capability, adding the following rows to the Capability tab
 
 [cols="^.^2,16,15", options="header"]
 |====
-2+^| Capability ^| Depends On
+2+^| Capability ^| Implicitly Declares
 | 4433 | *StorageBuffer16BitAccess* +
 Same as *StorageUniformBufferBlock16* |
 | 4434 | *UniformAndStorageBuffer16BitAccess* +

--- a/extensions/KHR/SPV_KHR_8bit_storage.asciidoc
+++ b/extensions/KHR/SPV_KHR_8bit_storage.asciidoc
@@ -77,7 +77,7 @@ Modify Section 3.31, Capability, adding the following rows to the Capability tab
 --
 [cols="^.^2,16,15", options="header"]
 |====
-2+^| Capability ^| Depends On
+2+^| Capability ^| Implicitly Declares
 | 4448 | *StorageBuffer8BitAccess* +
 Allows an <<OpTypePointer, *OpTypePointer*>> to an 8-bit <<OpTypeInt, *OpTypeInt*>>
 type used as a member of a structure in the *StorageBuffer* <<Storage_Class, storage class>>.

--- a/extensions/KHR/SPV_KHR_device_group.asciidoc
+++ b/extensions/KHR/SPV_KHR_device_group.asciidoc
@@ -122,7 +122,7 @@ Input device index of the logical device. See VK_KHX_device_group for more detai
 --
 [cols="^.^1,10,^8,15",options="header",width = "80%"]
 |====
-2+^.^| Capability | Depends On | Enabled by Extension
+2+^.^| Capability | Implicitly Declares | Enabled by Extension
 | 4437    | *DeviceGroup* |
 | *SPV_KHR_device_group*
 |====

--- a/extensions/KHR/SPV_KHR_fragment_shader_barycentric.asciidoc
+++ b/extensions/KHR/SPV_KHR_fragment_shader_barycentric.asciidoc
@@ -114,7 +114,7 @@ See the Vulkan API specification for more detail.
 --
 [cols="^.^1,10,^8,15",options="header",width = "80%"]
 |====
-2+^.^| Capability | Depends On | Enabled by Extension
+2+^.^| Capability | Implicitly Declares | Enabled by Extension
 | 5284 | *FragmentBarycentricKHR* | *Shader*
 | *SPV_KHR_fragment_shader_barycentric*
 |====

--- a/extensions/KHR/SPV_KHR_multiview.asciidoc
+++ b/extensions/KHR/SPV_KHR_multiview.asciidoc
@@ -119,7 +119,7 @@ Input view index of the view currently being rendered to. See VK_KHX_multiview f
 --
 [cols="^.^1,10,^8,15",options="header",width = "80%"]
 |====
-2+^.^| Capability | Depends On | Enabled by Extension
+2+^.^| Capability | Implicitly Declares | Enabled by Extension
 | 4439    | *MultiView* | Shader
 | *SPV_KHR_multiview*
 |====

--- a/extensions/KHR/SPV_KHR_post_depth_coverage.asciidoc
+++ b/extensions/KHR/SPV_KHR_post_depth_coverage.asciidoc
@@ -132,7 +132,7 @@ the *EarlyFragmentTests*.  Only valid with the *Fragment* Execution Model.
 --
 [cols="^.^1,15,10,^8",options="header",width = "100%"]
 |====
-  2+^.^| Capability         | Depends On      | Enabled by Extension
+  2+^.^| Capability         | Implicitly Declares      | Enabled by Extension
 | 4447 | *SampleMaskPostDepthCoverage* | 
 | *SPV_KHR_post_depth_coverage*
 |====

--- a/extensions/KHR/SPV_KHR_ray_cull_mask.asciidoc
+++ b/extensions/KHR/SPV_KHR_ray_cull_mask.asciidoc
@@ -103,7 +103,7 @@ Refer to the Vulkan API specification for more details.
 --
 [cols="^.^1,25,^8,15",options="header",width = "100%"]
 |====
-2+^.^| Capability | Depends On | Enabled by Extension
+2+^.^| Capability | Implicitly Declares | Enabled by Extension
 | 6020 | *RayCullMaskKHR* +
 Allows the use of *CullMaskKHR* builtin.
 |  | *SPV_KHR_ray_cull_mask*

--- a/extensions/KHR/SPV_KHR_shader_atomic_counter_ops.asciidoc
+++ b/extensions/KHR/SPV_KHR_shader_atomic_counter_ops.asciidoc
@@ -105,7 +105,7 @@ Modifications to the SPIR-V Specification, Version 1.1
 --
 [cols="^.^1,15,10,^8",options="header",width = "100%"]
 |====
-  2+^.^| Capability         | Depends On      | Enabled by Extension
+  2+^.^| Capability         | Implicitly Declares      | Enabled by Extension
 | 4445 | *AtomicStorageOps* +
 Uses atomic instructions: *OpAtomicIAdd*, *OpAtomicISub*, *OpAtomicUMin,*
 *OpAtomicUMax*, *OpAtomicAnd*, *OpAtomicOr*, *OpAtomicXor*,

--- a/extensions/KHR/SPV_KHR_shader_ballot.asciidoc
+++ b/extensions/KHR/SPV_KHR_shader_ballot.asciidoc
@@ -189,7 +189,7 @@ component where the bit index is *less than SubgroupLocalInvocationId*.
 --
 [cols="^.^1,10,^8",options="header",width = "80%"]
 |====
-2+^.^| Capability| Depends On
+2+^.^| Capability| Implicitly Declares
 | 4423 | *SubgroupBallotKHR* |
 |====
 

--- a/extensions/KHR/SPV_KHR_shader_draw_parameters.asciidoc
+++ b/extensions/KHR/SPV_KHR_shader_draw_parameters.asciidoc
@@ -138,7 +138,7 @@ See OpenGL GL_ARB_shader_draw_parameters for more detail.
 --
 [cols="^.^1,10,^8",options="header",width = "80%"]
 |====
-2+^.^| Capability| Depends On
+2+^.^| Capability| Implicitly Declares
 | 4427 | *DrawParameters* |  *Shader*
 |====
 

--- a/extensions/KHR/SPV_KHR_storage_buffer_storage_class.asciidoc
+++ b/extensions/KHR/SPV_KHR_storage_buffer_storage_class.asciidoc
@@ -203,7 +203,7 @@ Modify Section 3.31, Capability, adding the following rows to the Capability tab
 
 [options="header"]
 |====
-2+^| Capability ^| Depends On
+2+^| Capability ^| Implicitly Declares
 | 4433 | *StorageBuffer16BitAccess* +
 Same as *StorageUniformBufferBlock16* |
 | 4434 | *UniformAndStorageBuffer16BitAccess* +

--- a/extensions/KHR/SPV_KHR_subgroup_vote.asciidoc
+++ b/extensions/KHR/SPV_KHR_subgroup_vote.asciidoc
@@ -160,7 +160,7 @@ value returned by *OpSubgroupAllKHR*, *OpSubgroupAnyKHR*, and
 --
 [cols="^.^1,10,^8",options="header",width = "80%"]
 |====
-2+^.^| Capability | Depends On
+2+^.^| Capability | Implicitly Declares
 | 4431 | *SubgroupVoteKHR* |
 |====
 --

--- a/extensions/KHR/SPV_KHR_variable_pointers.asciidoc
+++ b/extensions/KHR/SPV_KHR_variable_pointers.asciidoc
@@ -209,7 +209,7 @@ Modify Section 3.31, Capability, adding these rows to the Capability table:
 --
 [options="header"]
 |====
-2+^| Capability ^| Depends On
+2+^| Capability ^| Implicitly Declares
 | 4441 | *VariablePointersStorageBuffer* +
 Allow <<VariablePointer, 'variable pointers'>>, each confined to a single *Block*-decorated struct in the *StorageBuffer* storage class. | *Shader*
 | 4442 | *VariablePointers* +

--- a/extensions/NV/SPV_NVX_multiview_per_view_attributes.asciidoc
+++ b/extensions/NV/SPV_NVX_multiview_per_view_attributes.asciidoc
@@ -144,7 +144,7 @@ Execution Model. See Vulkan API specification for more detail.
 --
 [cols="^.^1,10,^8,15",options="header",width = "80%"]
 |====
-2+^.^| Capability | Depends On | Enabled by Extension
+2+^.^| Capability | Implicitly Declares | Enabled by Extension
 | 5260 | *PerViewAttributesNV* | *MultiView*
 | *SPV_NVX_multiview_per_view_attributes*
 |====

--- a/extensions/NV/SPV_NV_compute_shader_derivatives.asciidoc
+++ b/extensions/NV/SPV_NV_compute_shader_derivatives.asciidoc
@@ -123,7 +123,7 @@ Only valid with the *Compute* Execution Model.
 --
 [cols="^.^1,10,^8,15",options="header",width = "80%"]
 |====
-2+^.^| Capability | Depends On | Enabled by Extension
+2+^.^| Capability | Implicitly Declares | Enabled by Extension
 | 5288 | *ComputeDerivativeGroupQuadsNV*  +
 Uses the *DerivativeGroupQuadsNV* execution mode. | *Shader*
 | *SPV_NV_compute_shader_derivatives*

--- a/extensions/NV/SPV_NV_fragment_shader_barycentric.asciidoc
+++ b/extensions/NV/SPV_NV_fragment_shader_barycentric.asciidoc
@@ -114,7 +114,7 @@ See the Vulkan API specification for more detail.
 --
 [cols="^.^1,10,^8,15",options="header",width = "80%"]
 |====
-2+^.^| Capability | Depends On | Enabled by Extension
+2+^.^| Capability | Implicitly Declares | Enabled by Extension
 | 5284 | *FragmentBarycentricNV* | *Shader*
 | *SPV_NV_fragment_shader_barycentric*
 |====

--- a/extensions/NV/SPV_NV_geometry_shader_passthrough.asciidoc
+++ b/extensions/NV/SPV_NV_geometry_shader_passthrough.asciidoc
@@ -123,7 +123,7 @@ Storage Class.
 --
 [cols="^.^1,10,^8,15",options="header",width = "80%"]
 |====
-2+^.^| Capability | Depends On | Enabled by Extension
+2+^.^| Capability | Implicitly Declares | Enabled by Extension
 | 5251 | *GeometryShaderPassthroughNV* | *Geometry* | *SPV_NV_geometry_shader_passthrough*
 |====
 --

--- a/extensions/NV/SPV_NV_mesh_shader.asciidoc
+++ b/extensions/NV/SPV_NV_mesh_shader.asciidoc
@@ -407,7 +407,7 @@ See Vulkan API specification for more detail. | *PerViewAttributesNV* *MeshShadi
 --
 [cols="^.^1,20,^8,15",options="header",width = "80%"]
 |====
-2+^.^| Capability | Depends On | Enabled by Extension
+2+^.^| Capability | Implicitly Declares | Enabled by Extension
 | 5266 | *MeshShadingNV* +
 Uses the *TaskNV* or *MeshNV* Execution Models. | *Shader*
 | *SPV_NV_mesh_shader*

--- a/extensions/NV/SPV_NV_raw_access_chains.asciidoc
+++ b/extensions/NV/SPV_NV_raw_access_chains.asciidoc
@@ -124,7 +124,7 @@ Modify Section 3.31, "Capability", adding these rows to the Capability table:
 --
 [options="header"]
 |====
-2+^| Capability ^| Depends On
+2+^| Capability ^| Implicitly Declares
 | 5414 | *RawAccessChainNV* +
 Allow the instruction <<OpRawAccessChainNV,*OpRawAccessChainNV*>>, and raw access chain operands *RawAccessChainRobustnessPerComponentNV* and *RawAccessChainRobustnessPerElementNV*. | *Shader*
 |====

--- a/extensions/NV/SPV_NV_ray_tracing.asciidoc
+++ b/extensions/NV/SPV_NV_ray_tracing.asciidoc
@@ -354,7 +354,7 @@ Primitive identifier. See the client API specifications for more detail. | |
 --
 [cols="^.^1,25,^8,15",options="header",width = "100%"]
 |====
-2+^.^| Capability | Depends On | Enabled by Extension
+2+^.^| Capability | Implicitly Declares | Enabled by Extension
 | 5340 | *RayTracingNV* +
 Uses the *RayGenerationNV*, *IntersectionNV*, *AnyHitNV*, *ClosestHitNV*,
 *MissNV*, or *CallableNV* Execution Models

--- a/extensions/NV/SPV_NV_ray_tracing_motion_blur.asciidoc
+++ b/extensions/NV/SPV_NV_ray_tracing_motion_blur.asciidoc
@@ -117,7 +117,7 @@ Refer to the Ray Tracing chapter of Vulkan API specification for more details.
 --
 [cols="^.^1,25,^8,15",options="header",width = "100%"]
 |====
-2+^.^| Capability | Depends On | Enabled by Extension
+2+^.^| Capability | Implicitly Declares | Enabled by Extension
 | 5341 | *RayTracingMotionBlurNV* +
 Allows the use of *OpTraceMotionNV* or *OpTraceRayMotionNV*.
 |  | *SPV_NV_ray_tracing_motion_blur*

--- a/extensions/NV/SPV_NV_sample_mask_override_coverage.asciidoc
+++ b/extensions/NV/SPV_NV_sample_mask_override_coverage.asciidoc
@@ -124,7 +124,7 @@ by the original primitive, or that failed the early depth/stencil tests.
 --
 [cols="^.^1,10,^8,15",options="header",width = "80%"]
 |====
-2+^.^| Capability | Depends On | Enabled by Extension
+2+^.^| Capability | Implicitly Declares | Enabled by Extension
 | 5249 | *SampleMaskOverrideCoverageNV* | *SampleRateShading* | *SPV_NV_sample_mask_override_coverage*
 |====
 --

--- a/extensions/NV/SPV_NV_shader_image_footprint.asciidoc
+++ b/extensions/NV/SPV_NV_shader_image_footprint.asciidoc
@@ -74,7 +74,7 @@ Add *OpImageSampleFootprintNV* to the list of opcodes that use 'Image Operands'.
 --
 [cols="^.^1,10,^8,15",options="header",width = "80%"]
 |====
-2+^.^| Capability | Depends On | Enabled by Extension
+2+^.^| Capability | Implicitly Declares | Enabled by Extension
 | 5282 | *ImageFootprintNV* | *Shader*
 | *SPV_NV_shader_image_footprint*
 |====

--- a/extensions/NV/SPV_NV_shader_sm_builtins.asciidoc
+++ b/extensions/NV/SPV_NV_shader_sm_builtins.asciidoc
@@ -113,7 +113,7 @@ Modify Section 3.31, "Capability", adding these rows to the Capability table:
 --
 [cols="^1,10,^6",options="header"]
 |====
-2+^| Capability ^| Depends On
+2+^| Capability ^| Implicitly Declares
 | 5373 | *ShaderSMBuiltinsNV* +
 Enables the *WarpsPerSMNV*, *SMCountNV*, *WarpIDNV*, and *SMIDNV* builtin decorations. | *Shader*
 |====

--- a/extensions/NV/SPV_NV_shader_subgroup_partitioned.asciidoc
+++ b/extensions/NV/SPV_NV_shader_subgroup_partitioned.asciidoc
@@ -194,7 +194,7 @@ Add *GroupNonUniformPartitionedNV* to the capability list.
 --
 [cols="^.^1,15,^8,30",options="header",width = "100%"]
 |====
-2+^.^| Capability | Depends On | Enabled by Extension
+2+^.^| Capability | Implicitly Declares | Enabled by Extension
 | 5301 | *GroupNonUniformPartitionedNV* +
 Uses partitioned subgroup operations.
 | *Shader* | *SPV_NV_shader_subgroup_partitioned*

--- a/extensions/NV/SPV_NV_shading_rate.asciidoc
+++ b/extensions/NV/SPV_NV_shading_rate.asciidoc
@@ -106,7 +106,7 @@ See the API specification for more detail.
 --
 [cols="^.^1,25,^8,15",options="header",width = "80%"]
 |====
-2+^.^| Capability | Depends On | Enabled by Extension
+2+^.^| Capability | Implicitly Declares | Enabled by Extension
 | 5291 | *ShadingRateNV* +
 Uses the *FragmentSizeNV* or *InvocationsPerPixelNV* Builtins. | *Shader*
 | *SPV_NV_shading_rate*

--- a/extensions/NV/SPV_NV_stereo_view_rendering.asciidoc
+++ b/extensions/NV/SPV_NV_stereo_view_rendering.asciidoc
@@ -172,7 +172,7 @@ Execution Model. See Vulkan or OpenGL API specifications for more detail.
 --
 [cols="^.^1,10,^8,15",options="header",width = "80%"]
 |====
-2+^.^| Capability | Depends On | Enabled by Extension
+2+^.^| Capability | Implicitly Declares | Enabled by Extension
 | 5259 | *ShaderStereoViewNV* | *ShaderViewportMaskNV*
 | *SPV_NV_stereo_view_rendering*
 |====

--- a/extensions/NV/SPV_NV_viewport_array2.asciidoc
+++ b/extensions/NV/SPV_NV_viewport_array2.asciidoc
@@ -186,7 +186,7 @@ input to a *Fragment* Execution Model.
 --
 [cols="^.^1,10,^8,15",options="header",width = "80%"]
 |====
-2+^.^| Capability | Depends On | Enabled by Extension
+2+^.^| Capability | Implicitly Declares | Enabled by Extension
 | 5254 | *ShaderViewportIndexLayerNV* | *MultiViewport*
 | *SPV_NV_viewport_array2*
 | 5255 | *ShaderViewportMaskNV* | *ShaderViewportIndexLayerNV*


### PR DESCRIPTION
We clarified this a while ago. It'd be good to reflect it in all specs.


Change-Id: I09efcf58f164c3dc5091bcb20caef887a0c32d2e