### PR TITLE
SPV_ARM_tensors: allow NonReadable/NonWritable decorations

### DIFF
--- a/extensions/ARM/SPV_ARM_tensors.asciidoc
+++ b/extensions/ARM/SPV_ARM_tensors.asciidoc
@@ -93,7 +93,7 @@ Modify Section 3.20, "Decoration", adding
 
 "A tensor variable in the *UniformConstant* storage class (see **OpTypeTensorARM**)"
 
-to the list of types for which a memory object declaration may be decorated with
+to the list of cases in which a memory object declaration may be decorated with
 *NonWritable* or *NonReadable*.
 
 Capability


### PR DESCRIPTION
on tensor variables in the UniformConstant storage class.


Change-Id: I5146a29bf83266ba99ff68e2b6fe9494600fd48d