### PR TITLE
fixes a small typo in SPV_INTEL_device_side_avc_motion_estimation

### DIFF
--- a/extensions/INTEL/SPV_INTEL_device_side_avc_motion_estimation.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_device_side_avc_motion_estimation.asciidoc
@@ -1833,7 +1833,7 @@ _Payload_ must be the [blue]#<<bookmark-OpTypeAvcImePayloadINTEL,__OpTypeAvcImeP
 
 | Capability: + 
 *SubgroupAvcMotionEstimationINTEL* +
-| 7 | 5749 | <id> Result Type | Result <id> | <id> Fwd Ref Offset | <id> Bwd Ref Offset | id> Search Window Config | <id> Payload
+| 7 | 5749 | <id> Result Type | Result <id> | <id> Fwd Ref Offset | <id> Bwd Ref Offset | <id> Search Window Config | <id> Payload
 |=====
 
 [cols="1,1,1,1,1,1",width="100%"]


### PR DESCRIPTION
In one case, the leading `<` was missing from an `<id>`.

See also: https://github.com/KhronosGroup/SPIRV-Headers/pull/537