### PR TITLE
Add SPV_INTEL_variable_length_array

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Note: we no longer push the HTML along side the extension.
 * [SPV_INTEL_ternary_bitwise_function      ]( https://github.khronos.org/SPIRV-Registry/extensions/INTEL/SPV_INTEL_ternary_bitwise_function.html)
 * [SPV_INTEL_unstructured_loop_controls    ]( https://github.khronos.org/SPIRV-Registry/extensions/INTEL/SPV_INTEL_unstructured_loop_controls.html)
 * [SPV_INTEL_usm_storage_classes           ]( https://github.khronos.org/SPIRV-Registry/extensions/ALTERA/SPV_INTEL_usm_storage_classes.html)
+* [SPV_INTEL_variable_length_array         ]( https://github.khronos.org/SPIRV-Registry/extensions/INTEL/SPV_INTEL_variable_length_array.html)
 * [SPV_NV_bindless_texture                 ]( https://github.khronos.org/SPIRV-Registry/extensions/NV/SPV_NV_bindless_texture.html)
 * [SPV_NV_cluster_acceleration_structure   ]( https://github.khronos.org/SPIRV-Registry/extensions/NV/SPV_NV_cluster_acceleration_structure.html)
 * [SPV_NV_compute_shader_derivatives       ]( https://github.khronos.org/SPIRV-Registry/extensions/NV/SPV_NV_compute_shader_derivatives.html)

--- a/extensions/INTEL/SPV_INTEL_variable_length_array.asciidoc
+++ b/extensions/INTEL/SPV_INTEL_variable_length_array.asciidoc
@@ -1,0 +1,264 @@
+SPV_INTEL_variable_length_array
+===============================
+
+:capability_token                 : pass:normal[5817]
+:capability_untyped_token         : pass:normal[6243]
+:OpVariableLengthArrayINTEL_token : pass:normal[5818]
+:OpSaveMemoryINTEL_token          : pass:normal[5819]
+:OpRestoreMemoryINTEL_token       : pass:normal[5820]
+:OpUntypedVariableLengthArrayINTEL_token : pass:normal[6244]
+
+:untyped_ptr_khr_url: https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/KHR/SPV_KHR_untyped_pointers.asciidoc
+
+== Name Strings
+
+SPV_INTEL_variable_length_array
+
+== Contact
+
+To report problems with this extension, please open a new issue at:
+
+https://github.com/intel/llvm/issues
+
+== Contributors
+
+- Alexey Sotkin, Intel +
+- Ben Ashbaugh, Intel +
+- Vyacheslav Zakharin, Intel +
+- Michael Kinsner, Intel +
+- Dmitry Sidorov, Intel +
+- Viktoria Maksimova, Intel +
+- Victor Lomuller, Codeplay +
+
+== Notice
+
+Copyright (c) 2025 Intel Corporation.  All rights reserved.
+
+== Status
+
+* Complete
+
+== Version
+
+[width="40%",cols="25,25"]
+|========================================
+| Last Modified Date | 2025-03-14
+| Revision           | 3
+|========================================
+
+== Dependencies
+
+This extension is written against the SPIR-V Specification,
+Version 1.6 Revision 5.
+
+This extension interacts with {untyped_ptr_khr_url}[*SPV_KHR_untyped_pointers*] extension.
+
+This extension requires SPIR-V 1.0.
+
+== Overview
+
+This extension allows to allocate local arrays whose number of elements is
+unknown at compile time. This is useful for implementing high-level language
+features like C99 variable length arrays.
+
+== Extension Name
+
+To use this extension within a SPIR-V module, the appropriate *OpExtension* must
+be present in the module:
+
+----
+OpExtension "SPV_INTEL_variable_length_array"
+----
+
+== Modifications to the SPIR-V Specification, Version 1.6
+
+=== Capabilities
+
+Modify Section 3.31, Capability, adding rows to the Capability table:
+
+--
+[options="header"]
+|====
+2+^| Capability ^| Implicitly Declares 
+| {capability_token} | *VariableLengthArrayINTEL* +
+Uses *OpVariableLengthArrayINTEL*, *OpSaveMemoryINTEL* and *OpRestoreMemoryINTEL* instructions. +
+|
+| {capability_untyped_token} | *UntypedVariableLengthArrayINTEL* +
+Uses *UntypedOpVariableLengthArrayINTEL* instruction. +
+| *VariableLengthArrayINTEL*, *UntypedPointersKHR*
+|====
+--
+
+=== Instructions
+
+Modify Section 3.56.8. Memory Instructions, adding to the end of the list of
+instructions:
+
+[cols="1,1,3*3",width="100%"]
+|=====
+4+|[[OpVariableLengthArrayINTEL]]*OpVariableLengthArrayINTEL* +
+ +
+Allocate a runtime-sized array in memory, resulting in a pointer to it, which
+can be used with *OpLoad* and *OpStore*. The memory is allocated in Function
+storage class and is uninitialized. Loading from uninitialized memory will
+return indeterminate values. Size of memory to be allocated is computed as the
+size of 'Type' operand of the 'Result Type' multiplied by the 'Length'. +
+
+'Result Type' must be *OpTypePointer* with *Function* storage class.
+Its 'Type' operand is the type of array elements. The type of array elements
+must be a _Concrete Type_. +
+
+'Length' is the number of elements in the array. It must have a scalar integer
+type. 'Length' is treated as unsigned. If value of 'Length' is 0, no memory will be
+allocated and accessing such array is undefined behavior. +
+ +
+The current invocation’s memory is deallocated when it executes any function
+termination instruction of the dynamic instance of the function it was
+allocated by. +
+ +
+If there is insufficient memory space for the allocation the behavior
+is undefined. +
+
+1+|Capability: +
+*VariableLengthArrayINTEL*
+| 4 | {OpVariableLengthArrayINTEL_token}
+| '<id>' 'Result Type'
+| '<id>' 'Result'
+| '<id>' 'Length'
+|=====
+
+[cols="1,1,4*3",width="100%"]
+|=====
+5+|[[OpUntypedVariableLengthArrayINTEL]]*OpUntypedVariableLengthArrayINTEL* +
+ +
+Allocate a runtime-sized array in memory, resulting in a pointer to it, which
+can be used with *OpLoad* and *OpStore*. The memory is allocated in Function
+storage class and is uninitialized. Loading from uninitialized memory will
+return indeterminate values. Size of memory to be allocated is computed as the
+size of 'ElementType' operand multiplied by the 'Length'. +
+
+'Result Type' must be *OpTypeUntypedPointerKHR* with *Function* storage class. +
+
+'ElementType' must be a _Concrete Type_. It's the type of array elements. +
+
+'Length' is the number of elements in the array. It must have a scalar integer
+type. 'Length' is treated as unsigned. If value of 'Length' is 0, no memory will be
+allocated and accessing such array is undefined behavior. +
+ +
+The current invocation’s memory is deallocated when it executes any function
+termination instruction of the dynamic instance of the function it was
+allocated by. +
+ +
+If there is insufficient memory space for the allocation the behavior
+is undefined. +
+
+1+|Capability: +
+*UntypedVariableLengthArrayINTEL*
+| 5 | {OpUntypedVariableLengthArrayINTEL_token}
+| '<id>' 'Result Type'
+| '<id>' 'Result'
+| '<id>' 'Element Type'
+| '<id>' 'Length'
+|=====
+
+[cols="1,1,2*3",width="100%"]
+|=====
+3+|[[OpSaveMemoryINTEL]]*OpSaveMemoryINTEL* +
+ +
+Save the current state of the *Function* storage class memory. Returns a
+pointer that should be passed to *OpRestoreMemoryINTEL*. When *OpRestoreMemoryINTEL*
+is called it restores the saved state of the *Function* storage class memory by
+deallocating memory allocated by every *OpVariableLengthArrayINTEL* or *OpUntypedVariableLengthArrayINTEL*
+instructions executed after this *OpSaveMemoryINTEL*. +
+
+'Result Type' must be a _pointer type_ with *Function* storage class. +
+1+|Capability: +
+*VariableLengthArrayINTEL*
+| 3 | {OpSaveMemoryINTEL_token}
+| '<id>' 'Result Type'
+| '<id>' 'Result'
+|=====
+
+[cols="1a,1,1*3",width="100%"]
+|=====
+2+|[[OpRestoreMemoryINTEL]]*OpRestoreMemoryINTEL* +
+ +
+Restore the *Function* storage class memory to the state it was in when the
+*OpSaveMemoryINTEL* was executed. +
+
+'Ptr' is a pointer value returned by *OpSaveMemoryINTEL*.
+It must be a _pointer type_ with *Function* storage class. +
+ +
+The behavior is undefined if 2 or more dynamic instances of this instruction use the result of the same dynamic instance as 'Ptr' operand. +
+ +
+If in the control flow graph there are multiple *OpRestoreMemoryINTEL* instructions postdominating multiple
+*OpSaveMemoryINTEL* instructions, then *OpRestoreMemoryINTEL* instructions should be executed in the reversed order
+of *OpSaveMemoryINTEL* instructions, otherwise the behavior is undefined. E.g. the following example is UB:
+
+[source]
+....
+%state1 = OpSaveMemoryINTEL
+%vla1 = OpVariableLengthArrayINTEL
+%state2 = OpSaveMemoryINTEL
+%vla2 = OpVariableLengthArrayINTEL
+/* ... */
+OpRestoreMemoryINTEL %state1
+OpRestoreMemoryINTEL %state2 <--- causes double deallocation
+....
+
+
+1+|Capability: +
+*VariableLengthArrayINTEL*
+| 2 | {OpRestoreMemoryINTEL_token} | '<id>' 'Ptr'
+|=====
+
+== Validation Rules
+
+ - In control flow graph every *OpVariableLengthArrayINTEL* and *OpUntypedVariableLengthArrayINTEL*
+must be dominated by at least one *OpSaveMemoryINTEL*.
+
+== Issues
+
+. Can *OpVariableLengthArrayINTEL* be used without *OpSaveMemoryINTEL* and *OpRestoreMemoryINTEL*?
++
+--
+*RESOLVED*: It will result in undefined behavior.
+--
+
+. Should we mention that the memory should be automatically deallocated when
+the control flow reaches the end of the (Function?) scope?
++
+--
+*RESOLVED*: reuse *OpVariable* definition.
+--
+
+. Should we restrict usage of the instructions declared in this extension to
+uniform(convergent) control flow only?
++
+--
+*RESOLVED*: no, as each invocation owns its own *Function* memory.
+--
+
+. Should zero-length VLA allocation return nullptr?
++
+--
+*RESOLVED*: No. Yet accessing such allocation is undefined behavior.
+--
+
+. Should we clarify order of *OpRestoreMemoryINTEL* instructions when they are
+postdominating several *OpSaveMemoryINTEL* instructions?
++
+--
+*RESOLVED*: If the order of deallocations is not reversed to the order of *OpSaveMemoryINTEL* instructions, then the behavior is undefined.
+--
+
+== Revision History
+
+[cols="5,15,15,70"]
+[options="header"]
+|========================================
+|Rev|Date|Author|Changes
+|1|2020-08-31|Alexey Sotkin|*Initial revision*
+|2|2025-01-28|Dmitry Sidorov|*Add untyped capability*
+|3|2025-03-14|Dmitry Sidorov|*Add notes about UB in case of multiple deallocations*
+|========================================


### PR DESCRIPTION
This extension allows to allocate local arrays whose number of elements is unknown at compile time. This is useful for implementing high-level language features like C99 variable length arrays.