### PR TITLE
Update validation rules for several extensions

### DIFF
--- a/extensions/EXT/SPV_EXT_mesh_shader.asciidoc
+++ b/extensions/EXT/SPV_EXT_mesh_shader.asciidoc
@@ -24,6 +24,7 @@ Contributors
 - Slawomir Grajewski, Intel
 - Timur Kristóf, Valve
 - Pankaj Mistry, NVIDIA
+- Alan Baker, Google
 
 Status
 ------
@@ -37,8 +38,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2022-09-16
-| Revision           | 7
+| Last Modified Date | 2025-08-20
+| Revision           | 8
 |========================================
 
 Dependencies
@@ -158,6 +159,19 @@ Modifications to the SPIR-V Specification
 Add *OpEmitMeshTasksEXT* to the list of Termination Instructions.
 
 (Modify Section 2.16.1, Universal Validation Rules) ::
++
+Modify the list following the statement:
++
+====
+It is invalid for a pointer to be an operand to any instruction other than:
+====
++
+to include:
++
+====
+* <<OpEmitMeshTasksEXT,*OpEmitMeshTasksEXT*>>
+====
++
 * *OpSetMeshOutputsEXT* must be called before any variable from *Output* storage class
   is written to.  Behavior is undefined if any invocation executes this instruction
   more than once or under non-uniform control flow. The arguments for the instruction
@@ -591,4 +605,5 @@ Revision History
 |5  |2022-08-31 |Pankaj Mistry|Added validation rules for OpSetMeshOutputsEXT and OpEmitMeshTasksEXT
 |6  |2022-09-06 |Pankaj Mistry|Added OpEmitMeshTasksEXT as a termination instruction and added atomic access validation rule for TaskPayloadWorkgroupEXT
 |7  |2022-09-16 |Ricardo Garcia|Forbid more than one TaskPayloadWorkgroupEXT variable in each TaskEXT entry point
+|8  |2025-08-20 |Alan Baker    | Modify logical pointer validation rules (spir-v#878)
 |========================================

--- a/extensions/EXT/SPV_EXT_mesh_shader.asciidoc
+++ b/extensions/EXT/SPV_EXT_mesh_shader.asciidoc
@@ -172,6 +172,7 @@ to include:
 * <<OpEmitMeshTasksEXT,*OpEmitMeshTasksEXT*>>
 ====
 +
+Add the following to the end of the section:
 * *OpSetMeshOutputsEXT* must be called before any variable from *Output* storage class
   is written to.  Behavior is undefined if any invocation executes this instruction
   more than once or under non-uniform control flow. The arguments for the instruction

--- a/extensions/KHR/SPV_KHR_ray_query.asciidoc
+++ b/extensions/KHR/SPV_KHR_ray_query.asciidoc
@@ -39,8 +39,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2023-01-13
-| Revision           | 14
+| Last Modified Date | 2025-08-20
+| Revision           | 15
 |========================================
 
 Dependencies
@@ -131,7 +131,41 @@ Modifications to the SPIR-V Specification
 --
 
 (Modify Section 2.16.1, Universal Validation Rules) ::
-
++
+Modify the list following the statement:
++
+====
+It is invalid for a pointer to be an operand to any instruction other than:
+====
++
+to include:
++
+====
+* <<OpRayQueryConfirmIntersectionKHR,*OpRayQueryConfirmIntersectionKHR*>>
+* <<OpRayQueryInitializeKHR,*OpRayQueryInitializeKHR*>>
+* <<OpRayQueryTerminateKHR,*OpRayQueryTerminateKHR*>>
+* <<OpRayQueryGenerateIntersectionKHR,*OpRayQueryGenerateIntersectionKHR*>>
+* <<OpRayQueryProceedKHR,*OpRayQueryProceedKHR*>>
+* <<OpRayQueryGetIntersectionTypeKHR,*OpRayQueryGetIntersectionTypeKHR*>>
+* <<OpRayQueryGetRayTMinKHR,*OpRayQueryGetRayTMinKHR*>>
+* <<OpRayQueryGetRayFlagsKHR,*OpRayQueryGetRayFlagsKHR*>>
+* <<OpRayQueryGetIntersectionTKHR,*OpRayQueryGetIntersectionTKHR*>>
+* <<OpRayQueryGetIntersectionInstanceCustomIndexKHR,*OpRayQueryGetIntersectionInstanceCustomIndexKHR*>>
+* <<OpRayQueryGetIntersectionInstanceIdKHR,*OpRayQueryGetIntersectionInstanceIdKHR*>>
+* <<OpRayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetKHR,*OpRayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetKHR*>>
+* <<OpRayQueryGetIntersectionGeometryIndexKHR,*OpRayQueryGetIntersectionGeometryIndexKHR*>>
+* <<OpRayQueryGetIntersectionPrimitiveIndexKHR,*OpRayQueryGetIntersectionPrimitiveIndexKHR*>>
+* <<OpRayQueryGetIntersectionBarycentricsKHR,*OpRayQueryGetIntersectionBarycentricsKHR*>>
+* <<OpRayQueryGetIntersectionFrontFaceKHR,*OpRayQueryGetIntersectionFrontFaceKHR*>>
+* <<OpRayQueryGetIntersectionCandidateAABBOpaqueKHR,*OpRayQueryGetIntersectionCandidateAABBOpaqueKHR*>>
+* <<OpRayQueryGetIntersectionObjectRayDirectionKHR,*OpRayQueryGetIntersectionObjectRayDirectionKHR*>>
+* <<OpRayQueryGetIntersectionObjectRayOriginKHR,*OpRayQueryGetIntersectionObjectRayOriginKHR*>>
+* <<OpRayQueryGetWorldRayDirectionKHR,*OpRayQueryGetWorldRayDirectionKHR*>>
+* <<OpRayQueryGetWorldRayOriginKHR,*OpRayQueryGetWorldRayOriginKHR*>>
+* <<OpRayQueryGetIntersectionObjectToWorldKHR,*OpRayQueryGetIntersectionObjectToWorldKHR*>>
+* <<OpRayQueryGetIntersectionWorldToObjectKHR,*OpRayQueryGetIntersectionWorldToObjectKHR*>>
+====
++
 include::ray_common/acceleration_structure_universal_val.txt[]
 
 
@@ -925,5 +959,6 @@ Revision History
 |12|2021-09-08 |Daniel Koch           | replace references to nonexistent OpRayQueryCommittedTypeKHR (GH#128)
 |13|2022-05-27 |Daniel Koch           | disallow more combinations of ray flags (vk-gl-cts#3647)
 |14|2023-01-13 |Daniel Koch           | Follow SPIR-V conventions for undefined behavior.
+|15|2025-08-20 |Alan Baker            | Modify logical pointer validation rules (spir-v#878)
 |========================================
 

--- a/extensions/KHR/SPV_KHR_ray_tracing.asciidoc
+++ b/extensions/KHR/SPV_KHR_ray_tracing.asciidoc
@@ -38,8 +38,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2022-08-17
-| Revision           | 24
+| Last Modified Date | 2025-08-20
+| Revision           | 25
 |========================================
 
 Dependencies
@@ -168,7 +168,20 @@ add *OpTypeAccelerationStructureKHR* to list of opaque types
 Add *OpIgnoreIntersectionKHR* and *OpTerminateRayKHR* to the list of _Termination Instructions_.
 
 (Modify Section 2.16.1, Universal Validation Rules) ::
-
++
+Modify the list following the statement:
++
+====
+It is invalid for a pointer to be an operand to any instruction other than:
+====
++
+to include:
++
+====
+* <<OpTraceRayKHR,*OpTraceRayKHR*>>
+* <<OpExecuteCallableKHR,*OpExecuteCallableKHR*>>
+====
++
 Modify the list following the statement:
 +
 ====
@@ -749,5 +762,6 @@ Revision History
 |22|2021-05-13 |Eric Werness          | Fix ray payload allowed execution models to exclude any hit.
 |23|2022-05-27 |Daniel Koch           | disallow more combinations of ray flags (vk-gl-cts#3647)
 |24|2022-08-17 |Daniel Koch           | OpExecuteCallableKHR `SBT Index` must be 32-bit unsigned integer (#156)
+|24|2025-08-20 |Alan Baker            | Modify logical pointer validation rules (spir-v#878)
 |========================================
 

--- a/extensions/KHR/SPV_KHR_ray_tracing_position_fetch.asciidoc
+++ b/extensions/KHR/SPV_KHR_ray_tracing_position_fetch.asciidoc
@@ -30,8 +30,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2023-04-21
-| Revision           | 4
+| Last Modified Date | 2025-08-20
+| Revision           | 5
 |========================================
 
 Dependencies
@@ -94,6 +94,20 @@ OpRayQueryGetIntersectionTriangleVertexPositionsKHR
 
 Modifications to the SPIR-V Specification
 -----------------------------------------
+
+(Modify Section 2.16.1, Universal Validation Rules) ::
++
+Modify the list following the statement:
++
+====
+It is invalid for a pointer to be an operand to any instruction other than:
+====
++
+to include:
++
+====
+* <<OpRayQueryGetIntersectionTriangleVertexPositionsKHR,*OpRayQueryGetIntersectionTriangleVertexPositionsKHR*>>
+====
 
 (Modify Section 3.21, BuiltIn, adding rows to the BuiltIn table) ::
 +
@@ -210,5 +224,6 @@ Revision History
 |2 |2022-12-14 |Daniel Koch   | Use two capabilities and other spec cleanup.
 |3 |2023-01-06 |Daniel Koch   | Follow SPIR-V conventions for undefined behavior.
 |4 |2023-04-21 |Daniel Koch   | Add ratification status
+|5 |2025-08-20 |Alan Baker    | Modify logical pointer validation rules (spir-v#878)
 |========================================
 


### PR DESCRIPTION
See SPIR-V issue 878

These extensions were all missing logical pointer validation rule updates