### PR TITLE
Update logical pointer validation rules for SPV_NV_cluster_acceleration_structure and SPV_NV_linear_swept_spheres.

### DIFF
--- a/extensions/NV/SPV_NV_cluster_acceleration_structure.asciidoc
+++ b/extensions/NV/SPV_NV_cluster_acceleration_structure.asciidoc
@@ -31,8 +31,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2025-09-03
-| Revision           | 3
+| Last Modified Date | 2025-09-02
+| Revision           | 2
 |========================================
 
 Dependencies
@@ -90,7 +90,7 @@ New Instructions
 Instructions added under the *RayTracingClusterAccelerationStructureNV* capability
 
 ----
-OpRayQueryGetClusterIdNV
+OpRayQueryGetIntersectionClusterIdNV
 OpHitObjectGetClusterIdNV
 ----
 
@@ -131,7 +131,7 @@ Allowed in *AnyHitKHR* and *ClosestHitKHR* ray tracing execution models.
 --
 [cols="6*2"]
 |======
-5+|[[OpRayQueryGetClusterIdNV]]*OpRayQueryGetClusterIdNV* +
+5+|[[OpRayQueryGetIntersectionClusterIdNV]]*OpRayQueryGetIntersectionClusterIdNV* +
  +
  Returns the triangle cluster ID corresponding to the current intersection of the ray if the intersection is with a cluster object. Returns -1 otherwise. +
  +
@@ -198,7 +198,7 @@ to include:
 +
 ====
 * <<OpHitObjectGetClusterIdNV,*OpHitObjectGetClusterIdNV*>>
-* <<OpRayQueryGetClusterIdNV,*OpRayQueryGetClusterIdNV*>>
+* <<OpRayQueryGetIntersectionClusterIdNV,*OpRayQueryGetIntersectionClusterIdNV*>>
 ====
 
 Validation Rules
@@ -219,7 +219,7 @@ Builtin *ClusterIDNV* is supported only if SPV_KHR_ray_tracing is supported.
 Interactions with SPV_KHR_ray_query
 -----------------------------------
 
-*OpRayQueryGetClusterIdNV* is supported only if SPV_KHR_ray_query is supported.
+*OpRayQueryGetIntersectionClusterIdNV* is supported only if SPV_KHR_ray_query is supported.
 
 Interactions with SPV_NV_shader_invocation_reorder
 --------------------------------------------------
@@ -241,5 +241,4 @@ Revision History
 |Rev|Date|Author|Changes
 |1 |2025-01-01 |Pyarelal Knowles|*Internal revisions*
 |2 |2025-09-02 |Diego Novillo|*Modify logical pointer validation rules (spir-v#878)*
-|3 |2025-09-03 |Diego Novillo|*Update OpRayQueryGetClusterIdNV name*
 |========================================

--- a/extensions/NV/SPV_NV_cluster_acceleration_structure.asciidoc
+++ b/extensions/NV/SPV_NV_cluster_acceleration_structure.asciidoc
@@ -31,8 +31,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2025-09-02
-| Revision           | 2
+| Last Modified Date | 2025-09-03
+| Revision           | 3
 |========================================
 
 Dependencies
@@ -90,7 +90,7 @@ New Instructions
 Instructions added under the *RayTracingClusterAccelerationStructureNV* capability
 
 ----
-OpRayQueryGetIntersectionClusterIdNV
+OpRayQueryGetClusterIdNV
 OpHitObjectGetClusterIdNV
 ----
 
@@ -131,7 +131,7 @@ Allowed in *AnyHitKHR* and *ClosestHitKHR* ray tracing execution models.
 --
 [cols="6*2"]
 |======
-5+|[[OpRayQueryGetIntersectionClusterIdNV]]*OpRayQueryGetIntersectionClusterIdNV* +
+5+|[[OpRayQueryGetClusterIdNV]]*OpRayQueryGetClusterIdNV* +
  +
  Returns the triangle cluster ID corresponding to the current intersection of the ray if the intersection is with a cluster object. Returns -1 otherwise. +
  +
@@ -198,7 +198,7 @@ to include:
 +
 ====
 * <<OpHitObjectGetClusterIdNV,*OpHitObjectGetClusterIdNV*>>
-* <<OpRayQueryGetIntersectionClusterIdNV,*OpRayQueryGetIntersectionClusterIdNV*>>
+* <<OpRayQueryGetClusterIdNV,*OpRayQueryGetClusterIdNV*>>
 ====
 
 Validation Rules
@@ -219,7 +219,7 @@ Builtin *ClusterIDNV* is supported only if SPV_KHR_ray_tracing is supported.
 Interactions with SPV_KHR_ray_query
 -----------------------------------
 
-*OpRayQueryGetIntersectionClusterIdNV* is supported only if SPV_KHR_ray_query is supported.
+*OpRayQueryGetClusterIdNV* is supported only if SPV_KHR_ray_query is supported.
 
 Interactions with SPV_NV_shader_invocation_reorder
 --------------------------------------------------
@@ -241,4 +241,5 @@ Revision History
 |Rev|Date|Author|Changes
 |1 |2025-01-01 |Pyarelal Knowles|*Internal revisions*
 |2 |2025-09-02 |Diego Novillo|*Modify logical pointer validation rules (spir-v#878)*
+|3 |2025-09-03 |Diego Novillo|*Update OpRayQueryGetClusterIdNV name*
 |========================================

--- a/extensions/NV/SPV_NV_cluster_acceleration_structure.asciidoc
+++ b/extensions/NV/SPV_NV_cluster_acceleration_structure.asciidoc
@@ -19,6 +19,7 @@ Contributors
 - Ashwin Lele, NVIDIA
 - Eric Werness, NVIDIA
 - Vikram Kushwaha, NVIDIA
+- Diego Novillo, NVIDIA
 
 Status
 ------
@@ -30,8 +31,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2025-01-01
-| Revision           | 1
+| Last Modified Date | 2025-09-02
+| Revision           | 2
 |========================================
 
 Dependencies
@@ -185,6 +186,20 @@ Allowed in *AnyHitKHR* and *ClosestHitKHR* ray tracing execution models.
 |======
 --
 
+(Modify Section 2.16.1, Universal Validation Rules) ::
++
+Modify the list following the statement:
++
+====
+It is invalid for a pointer to be an operand to any instruction other than:
+====
++
+to include:
++
+====
+* <<OpHitObjectGetClusterIdNV,*OpHitObjectGetClusterIdNV*>>
+* <<OpRayQueryGetIntersectionClusterIdNV,*OpRayQueryGetIntersectionClusterIdNV*>>
+====
 
 Validation Rules
 ----------------
@@ -225,4 +240,5 @@ Revision History
 |========================================
 |Rev|Date|Author|Changes
 |1 |2025-01-01 |Pyarelal Knowles|*Internal revisions*
+|2 |2025-09-02 |Diego Novillo|*Modify logical pointer validation rules (spir-v#878)*
 |========================================

--- a/extensions/NV/SPV_NV_linear_swept_spheres.asciidoc
+++ b/extensions/NV/SPV_NV_linear_swept_spheres.asciidoc
@@ -18,6 +18,7 @@ Contributors
 - Ashwin Lele, NVIDIA
 - Eric Werness, NVIDIA
 - Vikram Kushwaha, NVIDIA
+- Diego Novillo, NVIDIA
 
 Status
 ------
@@ -29,8 +30,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2025-01-01
-| Revision           | 1
+| Last Modified Date | 2025-09-02
+| Revision           | 2
 |========================================
 
 Dependencies
@@ -547,6 +548,32 @@ See the Ray Primitive Culling section in the Vulkan API specification.
 | '<id>' 'Intersection'
 |======
 
+(Modify Section 2.16.1, Universal Validation Rules) ::
++
+Modify the list following the statement:
++
+====
+It is invalid for a pointer to be an operand to any instruction other than:
+====
++
+to include:
++
+====
+* <<OpHitObjectGetLSSPositionsNV,*OpHitObjectGetLSSPositionsNV*>>
+* <<OpHitObjectGetLSSRadiiNV,*OpHitObjectGetLSSRadiiNV*>>
+* <<OpHitObjectGetSpherePositionNV,*OpHitObjectGetSpherePositionNV*>>
+* <<OpHitObjectGetSphereRadiusNV,*OpHitObjectGetSphereRadiusNV*>>
+* <<OpHitObjectIsLSSHitNV,*OpHitObjectIsLSSHitNV*>>
+* <<OpHitObjectIsSphereHitNV,*OpHitObjectIsSphereHitNV*>>
+* <<OpRayQueryGetIntersectionLSSHitValueNV,*OpRayQueryGetIntersectionLSSHitValueNV*>>
+* <<OpRayQueryGetIntersectionLSSPositionsNV,*OpRayQueryGetIntersectionLSSPositionsNV*>>
+* <<OpRayQueryGetIntersectionLSSRadiiNV,*OpRayQueryGetIntersectionLSSRadiiNV*>>
+* <<OpRayQueryGetIntersectionSpherePositionNV,*OpRayQueryGetIntersectionSpherePositionNV*>>
+* <<OpRayQueryGetIntersectionSphereRadiusNV,*OpRayQueryGetIntersectionSphereRadiusNV*>>
+* <<OpRayQueryIsLSSHitNV,*OpRayQueryIsLSSHitNV*>>
+* <<OpRayQueryIsSphereHitNV,*OpRayQueryIsSphereHitNV*>>
+====
+
 Validation Rules
 ----------------
 
@@ -595,5 +622,6 @@ Revision History
 |========================================
 |Rev|Date|Author|Changes
 |1 |2025-01-01  |Ashwin Lele           | Internal revisions.
+|2 |2025-09-02 |Diego Novillo|*Modify logical pointer validation rules (spir-v#878)*
 |========================================
 


### PR DESCRIPTION

See SPIR-V issue 878.