### PR TITLE
fix SPV_EXT_shader_64bit_indexing capability table

### DIFF
--- a/extensions/EXT/SPV_EXT_shader_64bit_indexing.asciidoc
+++ b/extensions/EXT/SPV_EXT_shader_64bit_indexing.asciidoc
@@ -128,7 +128,7 @@ Modify Section 3.31, "Capability", adding these rows to the Capability table:
 --
 [options="header"]
 |====
-2+^| Capability ^| Enabling Capabilities
+2+^| Capability ^| Implicitly Declares
 | 5426 | *Shader64BitIndexingEXT* +
 Enables the *Shader64BitIndexingEXT* execution mode.
 |


### PR DESCRIPTION
Capabilities "implicitly declare" other capabilities rather than being "enabled by" other capabilities.