### PR TITLE
SPV_KHR_ray_query: fix ray query wording issues

### DIFF
--- a/extensions/KHR/SPV_KHR_ray_query.asciidoc
+++ b/extensions/KHR/SPV_KHR_ray_query.asciidoc
@@ -187,7 +187,7 @@ Identifies which intersection should be returned from a ray query.
 Identifies the current candidate intersection being considered, valid when 'OpRayQueryProceedKHR' returns true.
 | *RayQueryKHR*
 | 1 | *RayQueryCommittedIntersectionKHR* +
-Identifies the last intersection committed that is being considered, valid when 'OpRayQueryGetCommittedIntersectionTypeKHR' does not return *RayQueryCommittedIntersectionNoneKHR*.
+Identifies the closest recorded hit so far, valid when 'OpRayQueryGetIntersectionTypeKHR' with 'Intersection' set to *RayQueryCommittedIntersectionKHR* does not return *RayQueryCommittedIntersectionNoneKHR*.
 | *RayQueryKHR*
 |====
 

--- a/extensions/KHR/SPV_KHR_ray_query.asciidoc
+++ b/extensions/KHR/SPV_KHR_ray_query.asciidoc
@@ -39,8 +39,8 @@ Version
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2025-08-20
-| Revision           | 15
+| Last Modified Date | 2026-06-03
+| Revision           | 16
 |========================================
 
 Dependencies
@@ -573,7 +573,7 @@ include::ray_common/opconvertutoaccelerationstructure_table.txt[]
  +
  Gets the shader binding table record offset for the current intersection considered in a ray query. +
  +
- 'Result' is the returned instance id. +
+ 'Result' is the returned shader binding table record offset. +
  +
  'Result Type' must be a 32-bit 'integer type' scalar. +
  +
@@ -960,5 +960,6 @@ Revision History
 |13|2022-05-27 |Daniel Koch           | disallow more combinations of ray flags (vk-gl-cts#3647)
 |14|2023-01-13 |Daniel Koch           | Follow SPIR-V conventions for undefined behavior.
 |15|2025-08-20 |Alan Baker            | Modify logical pointer validation rules (spir-v#878)
+|16|2026-06-03 |Daniel Koch           | Fix ray query wording typos (spir-v#935, spir-v#936)
 |========================================
 


### PR DESCRIPTION
## Summary

- Clarify the `RayQueryCommittedIntersectionKHR` table entry to reference `OpRayQueryGetIntersectionTypeKHR` with `Intersection` set to `RayQueryCommittedIntersectionKHR`.
- Fix the `OpRayQueryGetIntersectionInstanceShaderBindingTableRecordOffsetKHR` result description so it describes the shader binding table record offset instead of the instance ID.
- Bump `SPV_KHR_ray_query` once for the paired wording fixes.

## Issues

Fixes spir-v#935.
Fixes spir-v#936.

## Validation

- `git diff --check origin/main..HEAD`
