### PR TITLE
Readability fix for SPV_EXT_ocp_microscaling_types

### DIFF
--- a/extensions/EXT/SPV_EXT_ocp_microscaling_types.asciidoc
+++ b/extensions/EXT/SPV_EXT_ocp_microscaling_types.asciidoc
@@ -91,6 +91,8 @@ Add the following bullets to section 2.16.11, "Universal Validation Rules":
 ** *Float4E2M1EXT*
 ** *Float8UnsignedE8M0EXT*
 ** *MXInt8EXT*
+
++
 must only be used with the following instructions:
 ** Constant Creation Instructions
 ** Memory Instructions


### PR DESCRIPTION
Styling fix to improve readability after rendering - attaching text block to the parent list item.