### PR TITLE
build HTML specs with the sectanchors attribute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ ASCIIDOC_HTML_OPTIONS = --trace --failure-level ERROR \
   -a icons=font \
   -a data-uri \
   -a nofooter \
+  -a sectanchors \
   -a stylesdir=$(SPIRV_DIR)/resources \
   -a stylesheet=spirv.css \
   -a table-stripes=even \


### PR DESCRIPTION
see also: https://github.com/KhronosGroup/SPIRV-Docs/pull/10

It would be nice to build the extension specs in this repo with the "sectanchors" attribute, also.