### PR TITLE
Fix UTF encoding description in SPV_KHR_constant_data

### DIFF
--- a/extensions/KHR/SPV_KHR_constant_data.asciidoc
+++ b/extensions/KHR/SPV_KHR_constant_data.asciidoc
@@ -178,7 +178,7 @@ Add this row to the Decoration table:
 2+^| Decoration ^| Extra Operands ^| Enabling Capabilities
 | 5145 | *UTFEncodedKHR* + 
 Decorate an array type with scalar _integer type_ elements to indicate that
-it should be interpreted as a UTF encoded string for debugging, transpiling,
+it should be interpreted as a UTF-8 encoded string for debugging, transpiling,
 or assembly/disassembly.
 This has no semantic impact and can be safely removed from a module.
 The _Width_ of each integer element of the decorated type must be 8.


### PR DESCRIPTION
Corrected the description of the UTFEncodedKHR decoration to specify 'UTF-8' instead of 'UTF'.

Fixes https://github.com/KhronosGroup/SPIRV-Registry/issues/449